### PR TITLE
MG-178  - Add repo dispatch to trigger stage deployment

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Continuous Delivery
-
 on:
   push:
     branches:
@@ -10,8 +9,10 @@ on:
 
 jobs:
   build-and-push:
-    name: Build and Push
+    name: Build and Push Magistrala Image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -42,25 +43,28 @@ jobs:
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to DockerHub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Dockers
+      - name: Build and push Docker image to GHCR
         run: |
+          # This command should build and push ghcr.io/absmach/magistrala:latest
           make latest -j $(nproc)
 
-      - name: Notify Helm chart repo (amdm)
-        uses: peter-evans/repository-dispatch@v2
+      - name: Notify amdm Helm Chart Repository of Magistrala Image Update
+        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
           repository: absmach/amdm
-          event-type: deploy-latest-image
+          event-type: magistrala-image-updated
           client-payload: |
             {
-              "repo": "ghcr.io/absmach/magistrala",
-              "tag": "latest"
+              "image_repository": "ghcr.io/absmach/magistrala",
+              "image_tag": "latest",
+              "source_commit_sha": "${{ github.sha }}"
             }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,3 +52,15 @@ jobs:
       - name: Build and push Dockers
         run: |
           make latest -j $(nproc)
+
+      - name: Notify Helm chart repo (amdm)
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.REPO_DISPATCH_TOKEN }}
+          repository: absmach/amdm
+          event-type: deploy-latest-image
+          client-payload: |
+            {
+              "repo": "ghcr.io/absmach/magistrala",
+              "tag": "latest"
+            }

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-and-push:
-    name: Build and Push Magistrala Image
+    name: Build and Push
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -43,16 +43,15 @@ jobs:
       - name: Set up Docker Build
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GitHub Container Registry
+      - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image to GHCR
+      - name: Build and push Dockers
         run: |
-          # This command should build and push ghcr.io/absmach/magistrala:latest
           make latest -j $(nproc)
 
       - name: Notify amdm Helm Chart Repository of Magistrala Image Update


### PR DESCRIPTION
# What type of PR is this?

This is a feature 

## What does this do?

Updates the GitHub Actions workflow to include a `repository_dispatch` step. After building and pushing Docker images, the workflow now sends a dispatch event to the `absmach/amdm` repository with payload metadata. The new step enables automatic Helm chart updates in the `amdm` repo based on the latest image tag (`latest`) from Magistrala.

## Which issue(s) does this PR fix/relate to?

- Resolves  #178

## Have you included tests for your changes?

No

## Did you document any new/modified feature?

No
### Notes
