### PR TITLE
NOISSUE - Pin pnpm version

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -9,6 +9,7 @@
 		"lint": "biome check",
 		"lint:fix": "biome check --fix"
 	},
+	"packageManager": "pnpm@10.33.0",
 	"pnpm": {
 		"onlyBuiltDependencies": [
 			"sharp",


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?
This is a bug fix
<!--
This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?



## Which issue(s) does this PR fix/relate to?
<!--
- Related Issue #
- Resolves #
-->

## Have you included tests for your changes?


## Did you document any new/modified features?


### Notes
No `packageManager` field meant corepack downloaded pnpm v11 in CI. pnpm v11
dropped support for the `pnpm` field in `package.json`, so `onlyBuiltDependencies`
was silently ignored, blocking native build scripts for `sharp` and `unrs-resolver`
and failing the Docker build.
