### PR TITLE
[codex] Fix MQTT WebSocket frame streaming

### DIFF
--- a/server/websocket/server.go
+++ b/server/websocket/server.go
@@ -230,10 +230,13 @@ type wsConnection struct {
 	ws           *websocket.Conn
 	remoteAddr   string
 	reader       io.Reader
+	frameReader  *wsFrameReader
 	version      int
 	mu           sync.RWMutex
+	readMu       sync.RWMutex
 	writeMu      sync.Mutex
 	closed       bool
+	readDeadline time.Time
 	lastActivity time.Time
 	onDisconnect func(graceful bool)
 	pingStop     chan struct{}
@@ -252,29 +255,24 @@ func newWSConnection(ws *websocket.Conn, remoteAddr string, protocolVersion int)
 func (c *wsConnection) ReadPacket() (packets.ControlPacket, error) {
 	c.Touch()
 
-	messageType, data, err := c.ws.ReadMessage()
-	if err != nil {
-		return nil, err
+	if c.frameReader == nil {
+		c.frameReader = &wsFrameReader{conn: c}
 	}
-
-	if messageType != websocket.BinaryMessage {
-		return nil, ErrExpectedBinaryMessage
+	if c.reader == nil {
+		c.reader = c.frameReader
 	}
-
-	reader := bytes.NewReader(data)
 
 	if c.version == 0 {
-		ver, restored, err := packets.DetectProtocolVersion(reader)
+		ver, restored, err := packets.DetectProtocolVersion(c.reader)
 		if err != nil {
 			return nil, err
 		}
 		c.version = ver
 		c.reader = restored
-	} else {
-		c.reader = reader
 	}
 
 	var pkt packets.ControlPacket
+	var err error
 	switch c.version {
 	case 5:
 		pkt, _, _, err = v5.ReadPacket(c.reader)
@@ -288,6 +286,120 @@ func (c *wsConnection) ReadPacket() (packets.ControlPacket, error) {
 		return nil, err
 	}
 	return pkt, nil
+}
+
+type wsFrameReader struct {
+	conn    *wsConnection
+	current *bytes.Reader
+	reads   chan wsReadResult
+	once    sync.Once
+	errMu   sync.RWMutex
+	err     error
+}
+
+type wsReadResult struct {
+	messageType int
+	data        []byte
+	err         error
+}
+
+func (r *wsFrameReader) Read(p []byte) (int, error) {
+	r.once.Do(r.start)
+
+	for {
+		if r.current != nil && r.current.Len() > 0 {
+			return r.current.Read(p)
+		}
+
+		result, err := r.nextMessage()
+		if err != nil {
+			return 0, err
+		}
+		if result.messageType != websocket.BinaryMessage {
+			return 0, ErrExpectedBinaryMessage
+		}
+		if len(result.data) == 0 {
+			continue
+		}
+
+		r.conn.Touch()
+		r.current = bytes.NewReader(result.data)
+	}
+}
+
+func (r *wsFrameReader) start() {
+	r.reads = make(chan wsReadResult, 1)
+	go func() {
+		defer close(r.reads)
+		for {
+			messageType, data, err := r.conn.ws.ReadMessage()
+			result := wsReadResult{messageType: messageType, data: data, err: err}
+			if err != nil {
+				r.setErr(err)
+				r.reads <- result
+				return
+			}
+			r.reads <- result
+		}
+	}()
+}
+
+func (r *wsFrameReader) nextMessage() (wsReadResult, error) {
+	deadline := r.conn.getReadDeadline()
+	if deadline.IsZero() {
+		result, ok := <-r.reads
+		if !ok {
+			return wsReadResult{}, r.getErr()
+		}
+		return result, result.err
+	}
+
+	timeout := time.Until(deadline)
+	if timeout <= 0 {
+		return wsReadResult{}, wsReadTimeoutError{}
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case result, ok := <-r.reads:
+		if !ok {
+			return wsReadResult{}, r.getErr()
+		}
+		return result, result.err
+	case <-timer.C:
+		return wsReadResult{}, wsReadTimeoutError{}
+	}
+}
+
+func (r *wsFrameReader) setErr(err error) {
+	r.errMu.Lock()
+	defer r.errMu.Unlock()
+	r.err = err
+}
+
+func (r *wsFrameReader) getErr() error {
+	r.errMu.RLock()
+	defer r.errMu.RUnlock()
+	if r.err != nil {
+		return r.err
+	}
+	return io.EOF
+}
+
+type wsReadTimeoutError struct{}
+
+func (wsReadTimeoutError) Error() string {
+	return "websocket read timeout"
+}
+
+func (wsReadTimeoutError) Timeout() bool {
+	return true
+}
+
+func (wsReadTimeoutError) Temporary() bool {
+	return true
 }
 
 func (c *wsConnection) WritePacket(pkt packets.ControlPacket) error {
@@ -369,7 +481,10 @@ func (c *wsConnection) RemoteAddr() net.Addr {
 }
 
 func (c *wsConnection) SetReadDeadline(t time.Time) error {
-	return c.ws.SetReadDeadline(t)
+	c.readMu.Lock()
+	defer c.readMu.Unlock()
+	c.readDeadline = t
+	return nil
 }
 
 func (c *wsConnection) SetWriteDeadline(t time.Time) error {
@@ -377,10 +492,14 @@ func (c *wsConnection) SetWriteDeadline(t time.Time) error {
 }
 
 func (c *wsConnection) SetDeadline(t time.Time) error {
-	if err := c.ws.SetReadDeadline(t); err != nil {
-		return err
-	}
+	c.SetReadDeadline(t) //nolint:errcheck // local state update cannot fail
 	return c.ws.SetWriteDeadline(t)
+}
+
+func (c *wsConnection) getReadDeadline() time.Time {
+	c.readMu.RLock()
+	defer c.readMu.RUnlock()
+	return c.readDeadline
 }
 
 func (c *wsConnection) SetKeepAlive(d time.Duration) error {

--- a/server/websocket/server.go
+++ b/server/websocket/server.go
@@ -354,11 +354,15 @@ func (r *wsFrameReader) start() {
 				r.setErr(err)
 			}
 
+			// Clear the in-flight flag before delivering the result. A consumer
+			// that receives this result must observe reading==false on its next
+			// requestRead, otherwise it would reuse a read that is already done
+			// and block waiting for a request that is never sent.
+			r.finishRead()
+
 			select {
 			case r.reads <- result:
-				r.finishRead()
 			case <-r.conn.done():
-				r.finishRead()
 				return
 			}
 

--- a/server/websocket/server.go
+++ b/server/websocket/server.go
@@ -233,9 +233,11 @@ type wsConnection struct {
 	frameReader  *wsFrameReader
 	version      int
 	mu           sync.RWMutex
+	closeOnce    sync.Once
 	readMu       sync.RWMutex
 	writeMu      sync.Mutex
 	closed       bool
+	closeCh      chan struct{}
 	readDeadline time.Time
 	lastActivity time.Time
 	onDisconnect func(graceful bool)
@@ -249,6 +251,7 @@ func newWSConnection(ws *websocket.Conn, remoteAddr string, protocolVersion int)
 		remoteAddr: remoteAddr,
 		version:    protocolVersion,
 		closed:     false,
+		closeCh:    make(chan struct{}),
 	}
 }
 
@@ -289,12 +292,16 @@ func (c *wsConnection) ReadPacket() (packets.ControlPacket, error) {
 }
 
 type wsFrameReader struct {
-	conn    *wsConnection
-	current *bytes.Reader
-	reads   chan wsReadResult
-	once    sync.Once
-	errMu   sync.RWMutex
-	err     error
+	conn     *wsConnection
+	current  *bytes.Reader
+	reads    chan wsReadResult
+	requests chan struct{}
+	done     chan struct{}
+	once     sync.Once
+	stateMu  sync.Mutex
+	reading  bool
+	errMu    sync.RWMutex
+	err      error
 }
 
 type wsReadResult struct {
@@ -329,29 +336,66 @@ func (r *wsFrameReader) Read(p []byte) (int, error) {
 
 func (r *wsFrameReader) start() {
 	r.reads = make(chan wsReadResult, 1)
+	r.requests = make(chan struct{}, 1)
+	r.done = make(chan struct{})
 	go func() {
+		defer close(r.done)
 		defer close(r.reads)
 		for {
+			select {
+			case <-r.conn.done():
+				return
+			case <-r.requests:
+			}
+
 			messageType, data, err := r.conn.ws.ReadMessage()
 			result := wsReadResult{messageType: messageType, data: data, err: err}
 			if err != nil {
 				r.setErr(err)
-				r.reads <- result
+			}
+
+			select {
+			case r.reads <- result:
+				r.finishRead()
+			case <-r.conn.done():
+				r.finishRead()
 				return
 			}
-			r.reads <- result
+
+			if err != nil {
+				return
+			}
 		}
 	}()
 }
 
 func (r *wsFrameReader) nextMessage() (wsReadResult, error) {
-	deadline := r.conn.getReadDeadline()
-	if deadline.IsZero() {
-		result, ok := <-r.reads
+	select {
+	case result, ok := <-r.reads:
 		if !ok {
+			r.finishRead()
 			return wsReadResult{}, r.getErr()
 		}
 		return result, result.err
+	default:
+	}
+
+	if err := r.requestRead(); err != nil {
+		return wsReadResult{}, err
+	}
+
+	deadline := r.conn.getReadDeadline()
+	if deadline.IsZero() {
+		select {
+		case result, ok := <-r.reads:
+			if !ok {
+				r.finishRead()
+				return wsReadResult{}, r.getErr()
+			}
+			return result, result.err
+		case <-r.conn.done():
+			return wsReadResult{}, r.getErr()
+		}
 	}
 
 	timeout := time.Until(deadline)
@@ -365,12 +409,39 @@ func (r *wsFrameReader) nextMessage() (wsReadResult, error) {
 	select {
 	case result, ok := <-r.reads:
 		if !ok {
+			r.finishRead()
 			return wsReadResult{}, r.getErr()
 		}
 		return result, result.err
 	case <-timer.C:
 		return wsReadResult{}, wsReadTimeoutError{}
+	case <-r.conn.done():
+		return wsReadResult{}, r.getErr()
 	}
+}
+
+func (r *wsFrameReader) requestRead() error {
+	r.stateMu.Lock()
+	if r.reading {
+		r.stateMu.Unlock()
+		return nil
+	}
+	r.reading = true
+	r.stateMu.Unlock()
+
+	select {
+	case r.requests <- struct{}{}:
+		return nil
+	case <-r.conn.done():
+		r.finishRead()
+		return r.getErr()
+	}
+}
+
+func (r *wsFrameReader) finishRead() {
+	r.stateMu.Lock()
+	defer r.stateMu.Unlock()
+	r.reading = false
 }
 
 func (r *wsFrameReader) setErr(err error) {
@@ -384,6 +455,11 @@ func (r *wsFrameReader) getErr() error {
 	defer r.errMu.RUnlock()
 	if r.err != nil {
 		return r.err
+	}
+	select {
+	case <-r.conn.done():
+		return net.ErrClosed
+	default:
 	}
 	return io.EOF
 }
@@ -460,6 +536,11 @@ func (c *wsConnection) Close() error {
 	}
 
 	c.closed = true
+	c.closeOnce.Do(func() {
+		if c.closeCh != nil {
+			close(c.closeCh)
+		}
+	})
 	c.pingOnce.Do(func() {
 		if c.pingStop != nil {
 			close(c.pingStop)
@@ -470,6 +551,13 @@ func (c *wsConnection) Close() error {
 	}
 
 	return c.ws.Close()
+}
+
+func (c *wsConnection) done() <-chan struct{} {
+	if c.closeCh == nil {
+		return nil
+	}
+	return c.closeCh
 }
 
 func (c *wsConnection) LocalAddr() net.Addr {
@@ -511,7 +599,7 @@ func (c *wsConnection) SetKeepAlive(d time.Duration) error {
 
 	c.ws.SetPongHandler(func(string) error {
 		c.Touch()
-		return c.ws.SetReadDeadline(time.Now().Add(d + d/2))
+		return c.SetReadDeadline(time.Now().Add(d + d/2))
 	})
 
 	pingInterval := d / 2

--- a/server/websocket/server_test.go
+++ b/server/websocket/server_test.go
@@ -5,6 +5,7 @@ package websocket
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -215,6 +216,48 @@ func TestReadPacketAcrossWebSocketMessages(t *testing.T) {
 	}
 	if string(connect.Password) != string(want.Password) {
 		t.Fatalf("Password = %q, want %q", connect.Password, want.Password)
+	}
+}
+
+func TestReadPacketSequentialMessages(t *testing.T) {
+	serverWS, clientWS := wsConnPair(t)
+	defer clientWS.Close()
+
+	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolAuto)
+	defer conn.Close()
+
+	const count = 50
+	go func() {
+		for i := range count {
+			pkt := &v3.Connect{
+				FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
+				ProtocolName:    "MQTT",
+				ProtocolVersion: 4,
+				CleanSession:    true,
+				KeepAlive:       30,
+				ClientID:        fmt.Sprintf("client%d", i),
+			}
+			if err := clientWS.WriteMessage(websocket.BinaryMessage, pkt.Encode()); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Each packet arrives in its own WebSocket message, so every ReadPacket
+	// drains r.current and issues a fresh requestRead. This exercises the
+	// finishRead/requestRead handoff that must not deadlock.
+	for i := range count {
+		got, err := conn.ReadPacket()
+		if err != nil {
+			t.Fatalf("ReadPacket %d: %v", i, err)
+		}
+		connect, ok := got.(*v3.Connect)
+		if !ok {
+			t.Fatalf("packet %d: expected *v3.Connect, got %T", i, got)
+		}
+		if want := fmt.Sprintf("client%d", i); connect.ClientID != want {
+			t.Fatalf("packet %d: ClientID = %q, want %q", i, connect.ClientID, want)
+		}
 	}
 }
 

--- a/server/websocket/server_test.go
+++ b/server/websocket/server_test.go
@@ -267,6 +267,108 @@ func TestReadPacketTimeoutDoesNotPoisonWebSocket(t *testing.T) {
 	}
 }
 
+func TestSetKeepAliveAfterReadPacketProcessesPong(t *testing.T) {
+	serverWS, clientWS := wsConnPair(t)
+	defer clientWS.Close()
+
+	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolAuto).(*wsConnection)
+	defer conn.Close()
+
+	connect := &v3.Connect{
+		FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
+		ProtocolName:    "MQTT",
+		ProtocolVersion: 4,
+		CleanSession:    true,
+		KeepAlive:       30,
+		ClientID:        "client1",
+	}
+
+	go func() {
+		_ = clientWS.WriteMessage(websocket.BinaryMessage, connect.Encode())
+	}()
+
+	if _, err := conn.ReadPacket(); err != nil {
+		t.Fatalf("ReadPacket: %v", err)
+	}
+	if err := conn.SetKeepAlive(30 * time.Second); err != nil {
+		t.Fatalf("SetKeepAlive: %v", err)
+	}
+
+	before := lastActivity(conn)
+	time.Sleep(10 * time.Millisecond)
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := conn.ReadPacket()
+		errCh <- err
+	}()
+
+	if err := clientWS.WriteControl(websocket.PongMessage, nil, time.Now().Add(time.Second)); err != nil {
+		t.Fatalf("client pong: %v", err)
+	}
+
+	waitFor(t, time.Second, func() bool {
+		return lastActivity(conn).After(before)
+	}, "expected pong handler to update last activity")
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	select {
+	case <-errCh:
+	case <-time.After(time.Second):
+		t.Fatal("ReadPacket did not exit after Close")
+	}
+}
+
+func TestReadPumpStopsAfterCloseWithBufferedRead(t *testing.T) {
+	serverWS, clientWS := wsConnPair(t)
+	defer clientWS.Close()
+
+	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolAuto).(*wsConnection)
+	reader := &wsFrameReader{conn: conn}
+	reader.once.Do(reader.start)
+
+	if err := reader.requestRead(); err != nil {
+		t.Fatalf("requestRead: %v", err)
+	}
+	if err := clientWS.WriteMessage(websocket.BinaryMessage, []byte{0}); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+
+	waitFor(t, time.Second, func() bool {
+		return len(reader.reads) == 1
+	}, "expected buffered read result")
+
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	select {
+	case <-reader.done:
+	case <-time.After(time.Second):
+		t.Fatal("read pump did not exit after Close")
+	}
+}
+
+func lastActivity(conn *wsConnection) time.Time {
+	conn.mu.RLock()
+	defer conn.mu.RUnlock()
+	return conn.lastActivity
+}
+
+func waitFor(t *testing.T, timeout time.Duration, fn func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}
+
 // wsConnPair creates a connected pair of WebSocket connections using an in-process
 // httptest server. The server-side conn is returned first.
 func wsConnPair(t *testing.T) (server *websocket.Conn, client *websocket.Conn) {

--- a/server/websocket/server_test.go
+++ b/server/websocket/server_test.go
@@ -4,6 +4,7 @@
 package websocket
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -11,6 +12,8 @@ import (
 	"time"
 
 	core "github.com/absmach/fluxmq/mqtt"
+	"github.com/absmach/fluxmq/mqtt/packets"
+	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
 	"github.com/gorilla/websocket"
 )
 
@@ -159,6 +162,108 @@ func TestSetKeepAliveZero(t *testing.T) {
 	}
 	if conn.pingStop != nil {
 		t.Fatal("expected pingStop to be nil for zero keep-alive")
+	}
+}
+
+func TestReadPacketAcrossWebSocketMessages(t *testing.T) {
+	serverWS, clientWS := wsConnPair(t)
+	defer clientWS.Close()
+
+	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolAuto)
+	defer conn.Close()
+
+	want := &v3.Connect{
+		FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
+		ProtocolName:    "MQTT",
+		ProtocolVersion: 4,
+		CleanSession:    true,
+		KeepAlive:       30,
+		ClientID:        "client1",
+		UsernameFlag:    true,
+		Username:        "user",
+		PasswordFlag:    true,
+		Password:        []byte("pass"),
+	}
+	encoded := want.Encode()
+
+	errCh := make(chan error, 1)
+	go func() {
+		if err := clientWS.WriteMessage(websocket.BinaryMessage, encoded[:1]); err != nil {
+			errCh <- err
+			return
+		}
+		errCh <- clientWS.WriteMessage(websocket.BinaryMessage, encoded[1:])
+	}()
+
+	got, err := conn.ReadPacket()
+	if err != nil {
+		t.Fatalf("ReadPacket: %v", err)
+	}
+	if err := <-errCh; err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+
+	connect, ok := got.(*v3.Connect)
+	if !ok {
+		t.Fatalf("expected *v3.Connect, got %T", got)
+	}
+	if connect.ClientID != want.ClientID {
+		t.Fatalf("ClientID = %q, want %q", connect.ClientID, want.ClientID)
+	}
+	if connect.Username != want.Username {
+		t.Fatalf("Username = %q, want %q", connect.Username, want.Username)
+	}
+	if string(connect.Password) != string(want.Password) {
+		t.Fatalf("Password = %q, want %q", connect.Password, want.Password)
+	}
+}
+
+func TestReadPacketTimeoutDoesNotPoisonWebSocket(t *testing.T) {
+	serverWS, clientWS := wsConnPair(t)
+	defer clientWS.Close()
+
+	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolAuto)
+	defer conn.Close()
+
+	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Millisecond)); err != nil {
+		t.Fatalf("SetReadDeadline: %v", err)
+	}
+	_, err := conn.ReadPacket()
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	var netErr interface{ Timeout() bool }
+	if !errors.As(err, &netErr) || !netErr.Timeout() {
+		t.Fatalf("expected timeout error, got %v", err)
+	}
+
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
+		t.Fatalf("clear SetReadDeadline: %v", err)
+	}
+
+	want := &v3.Connect{
+		FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
+		ProtocolName:    "MQTT",
+		ProtocolVersion: 4,
+		CleanSession:    true,
+		KeepAlive:       30,
+		ClientID:        "client1",
+	}
+
+	go func() {
+		_ = clientWS.WriteMessage(websocket.BinaryMessage, want.Encode())
+	}()
+
+	got, err := conn.ReadPacket()
+	if err != nil {
+		t.Fatalf("ReadPacket after timeout: %v", err)
+	}
+	connect, ok := got.(*v3.Connect)
+	if !ok {
+		t.Fatalf("expected *v3.Connect, got %T", got)
+	}
+	if connect.ClientID != want.ClientID {
+		t.Fatalf("ClientID = %q, want %q", connect.ClientID, want.ClientID)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Stream MQTT packet parsing across successive WebSocket binary messages instead of assuming one WebSocket message contains a complete MQTT packet.
- Preserve broker read-timeout behavior with an internal WebSocket read deadline wrapper, avoiding repeated reads on a Gorilla WebSocket connection after a timeout.
- Add regression tests for split CONNECT packets and timeout recovery.

## Root Cause

MQTTX/MQTT.js can send an MQTT CONNECT packet split across multiple WebSocket binary messages. The WebSocket adapter read exactly one WebSocket message per MQTT packet, so FluxMQ could see only a partial packet, fail protocol detection, and close before CONNACK. Broker retry timers also set short read deadlines on the Gorilla connection, which can poison the connection and panic on repeated reads after timeout.

## Validation

- `go test ./server/websocket ./mqtt/...`

This same fix was also tested against a deployed Magistrala/FluxMQ stack with MQTTX WSS publishes for MQTT 3.1.1 and MQTT 5.