### PR TITLE
[codex] Fix stale queue consumers blocking stream delivery

### DIFF
--- a/amqp/broker/broker.go
+++ b/amqp/broker/broker.go
@@ -132,6 +132,14 @@ func (b *Broker) unregisterConnection(connID string) {
 	b.connections.Delete(connID)
 }
 
+// IsClientConnected reports whether the AMQP 0.9.1 client has a live
+// connection in this broker instance.
+func (b *Broker) IsClientConnected(clientID string) bool {
+	connID := strings.TrimPrefix(clientID, corebroker.AMQP091ClientPrefix)
+	_, ok := b.connections.Load(connID)
+	return ok
+}
+
 // ConnectionIDs returns active AMQP 0.9.1 connection IDs sorted ascending.
 func (b *Broker) ConnectionIDs() []string {
 	ids := make([]string, 0)
@@ -231,7 +239,7 @@ func (b *Broker) DeliverToClient(ctx context.Context, clientID string, msg any) 
 
 	val, ok := b.connections.Load(connID)
 	if !ok {
-		return fmt.Errorf("AMQP 0.9.1 client not found: %s", connID)
+		return fmt.Errorf("%w: AMQP 0.9.1 client not found: %s", corebroker.ErrClientNotConnected, connID)
 	}
 
 	c := val.(*Connection)
@@ -252,7 +260,7 @@ func (b *Broker) DeliverToClusterMessage(ctx context.Context, clientID string, m
 
 	val, ok := b.connections.Load(connID)
 	if !ok {
-		return fmt.Errorf("AMQP 0.9.1 client not found: %s", connID)
+		return fmt.Errorf("%w: AMQP 0.9.1 client not found: %s", corebroker.ErrClientNotConnected, connID)
 	}
 
 	c := val.(*Connection)

--- a/amqp1/broker/broker.go
+++ b/amqp1/broker/broker.go
@@ -92,6 +92,14 @@ func (b *Broker) unregisterConnection(containerID string) {
 	b.connections.Delete(containerID)
 }
 
+// IsClientConnected reports whether the AMQP 1.0 client has a live
+// connection in this broker instance.
+func (b *Broker) IsClientConnected(clientID string) bool {
+	containerID := strings.TrimPrefix(clientID, corebroker.AMQP1ClientPrefix)
+	_, ok := b.connections.Load(containerID)
+	return ok
+}
+
 // Publish routes a message to all subscribers via the shared router.
 // AMQP 1.0 subscribers are delivered locally; others via the cross-deliver callback.
 // The ctx is forwarded to cross-protocol delivery so that connection or broker
@@ -181,7 +189,7 @@ func (b *Broker) DeliverToClient(ctx context.Context, clientID string, msg any) 
 
 	val, ok := b.connections.Load(containerID)
 	if !ok {
-		return fmt.Errorf("AMQP client not found: %s", containerID)
+		return fmt.Errorf("%w: AMQP client not found: %s", corebroker.ErrClientNotConnected, containerID)
 	}
 
 	c := val.(*Connection)
@@ -232,7 +240,7 @@ func (b *Broker) DeliverToClusterMessage(ctx context.Context, clientID string, m
 	containerID := strings.TrimPrefix(clientID, corebroker.AMQP1ClientPrefix)
 	val, ok := b.connections.Load(containerID)
 	if !ok {
-		return fmt.Errorf("AMQP client not found: %s", containerID)
+		return fmt.Errorf("%w: AMQP client not found: %s", corebroker.ErrClientNotConnected, containerID)
 	}
 	c := val.(*Connection)
 	c.deliverMessage(msg.Topic, msg.Payload, msg.Properties, msg.QoS) //nolint:contextcheck // fire-and-forget delivery, metrics use background context

--- a/broker/errors.go
+++ b/broker/errors.go
@@ -3,27 +3,16 @@
 
 package broker
 
-import (
-	"errors"
-	"strings"
-)
+import "errors"
 
 // ErrClientNotConnected is returned by protocol adapters when a queue delivery
 // targets a client that no longer has a live connection.
 var ErrClientNotConnected = errors.New("client not connected")
 
-// IsClientNotConnected reports whether err means a queue delivery target is
-// gone. The string fallback preserves this signal across RPC boundaries where
-// error wrapping is flattened into response text.
-func IsClientNotConnected(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, ErrClientNotConnected) {
-		return true
-	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, ErrClientNotConnected.Error()) ||
-		strings.Contains(msg, "client not found") ||
-		strings.Contains(msg, "session not found")
+// IsErrClientNotConnected reports whether err means a queue delivery target is
+// gone. Across the cluster RPC the signal is carried structurally (the
+// client_not_connected proto field, re-wrapped into ErrClientNotConnected by
+// the sender), so errors.Is matches it end to end.
+func IsErrClientNotConnected(err error) bool {
+	return errors.Is(err, ErrClientNotConnected)
 }

--- a/broker/errors.go
+++ b/broker/errors.go
@@ -1,0 +1,29 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"errors"
+	"strings"
+)
+
+// ErrClientNotConnected is returned by protocol adapters when a queue delivery
+// targets a client that no longer has a live connection.
+var ErrClientNotConnected = errors.New("client not connected")
+
+// IsClientNotConnected reports whether err means a queue delivery target is
+// gone. The string fallback preserves this signal across RPC boundaries where
+// error wrapping is flattened into response text.
+func IsClientNotConnected(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrClientNotConnected) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, ErrClientNotConnected.Error()) ||
+		strings.Contains(msg, "client not found") ||
+		strings.Contains(msg, "session not found")
+}

--- a/cluster/transport.go
+++ b/cluster/transport.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -991,6 +992,7 @@ func (t *Transport) SendRouteQueueBatch(ctx context.Context, nodeID string, deli
 	}
 
 	remaining := deliveries
+	var failures []queueBatchFailure
 	for attempt := range maxPartialRetries {
 		failed, err := t.sendRouteQueueBatchOnce(ctx, nodeID, remaining)
 		if err != nil {
@@ -999,11 +1001,12 @@ func (t *Transport) SendRouteQueueBatch(ctx context.Context, nodeID string, deli
 		if len(failed) == 0 {
 			return nil
 		}
-		remaining = failed
+		failures = failed
+		remaining = queueBatchFailureDeliveries(failed)
 		if attempt < maxPartialRetries-1 {
 			t.logger.Warn("route queue batch partial failure, retrying failed subset",
 				slog.String("node_id", nodeID),
-				slog.Int("failed", len(failed)),
+				slog.Int("failed", len(remaining)),
 				slog.Int("attempt", attempt+1))
 		}
 	}
@@ -1011,13 +1014,19 @@ func (t *Transport) SendRouteQueueBatch(ctx context.Context, nodeID string, deli
 	t.logger.Warn("route queue batch partial failure after retries",
 		slog.String("node_id", nodeID),
 		slog.Int("remaining_failures", len(remaining)))
-	return fmt.Errorf("route queue batch failed after %d retries: %d deliveries still failing", maxPartialRetries, len(remaining))
+	return fmt.Errorf("route queue batch failed after %d retries: %d deliveries still failing: %s",
+		maxPartialRetries, len(remaining), summarizeQueueBatchFailures(failures))
+}
+
+type queueBatchFailure struct {
+	delivery QueueDelivery
+	err      string
 }
 
 func (t *Transport) sendRouteQueueBatchOnce(
 	ctx context.Context, nodeID string, deliveries []QueueDelivery,
-) ([]QueueDelivery, error) {
-	var failedDeliveries []QueueDelivery
+) ([]queueBatchFailure, error) {
+	var failures []queueBatchFailure
 
 	err := retryWithBreaker(ctx, t.breakers, nodeID, func() error {
 		client, err := t.GetPeerClient(nodeID)
@@ -1046,7 +1055,6 @@ func (t *Transport) sendRouteQueueBatchOnce(
 			return fmt.Errorf("connect call failed: %w", err)
 		}
 
-		failedDeliveries = nil
 		if resp.Msg.Success {
 			if len(resp.Msg.Failures) > 0 {
 				return fmt.Errorf("route queue batch response marked success with %d failures", len(resp.Msg.Failures))
@@ -1071,15 +1079,43 @@ func (t *Transport) sendRouteQueueBatchOnce(
 				continue
 			}
 			seen[deliveryIdx] = struct{}{}
-			failedDeliveries = append(failedDeliveries, deliveries[deliveryIdx])
+			failures = append(failures, queueBatchFailure{
+				delivery: deliveries[deliveryIdx],
+				err:      f.Error,
+			})
 		}
-		if len(failedDeliveries) == 0 {
+		if len(failures) == 0 {
 			return fmt.Errorf("route queue batch reported failures but none matched the request batch")
 		}
 		return nil
 	})
 
-	return failedDeliveries, err
+	return failures, err
+}
+
+func queueBatchFailureDeliveries(failures []queueBatchFailure) []QueueDelivery {
+	deliveries := make([]QueueDelivery, 0, len(failures))
+	for _, failure := range failures {
+		deliveries = append(deliveries, failure.delivery)
+	}
+	return deliveries
+}
+
+func summarizeQueueBatchFailures(failures []queueBatchFailure) string {
+	if len(failures) == 0 {
+		return "unknown error"
+	}
+
+	parts := make([]string, 0, len(failures))
+	for _, failure := range failures {
+		reason := strings.TrimSpace(failure.err)
+		if reason == "" {
+			reason = "unknown error"
+		}
+		parts = append(parts, fmt.Sprintf("client %s queue %s: %s",
+			failure.delivery.ClientID, failure.delivery.QueueName, reason))
+	}
+	return strings.Join(parts, "; ")
 }
 
 // SendForwardGroupOp forwards a consumer group operation to a peer node with retry and circuit breaker.

--- a/cluster/transport.go
+++ b/cluster/transport.go
@@ -1055,6 +1055,7 @@ func (t *Transport) sendRouteQueueBatchOnce(
 			return fmt.Errorf("connect call failed: %w", err)
 		}
 
+		failures = nil
 		if resp.Msg.Success {
 			if len(resp.Msg.Failures) > 0 {
 				return fmt.Errorf("route queue batch response marked success with %d failures", len(resp.Msg.Failures))

--- a/cluster/transport.go
+++ b/cluster/transport.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	corebroker "github.com/absmach/fluxmq/broker"
 	clusterv1 "github.com/absmach/fluxmq/pkg/proto/cluster/v1"
 	"github.com/absmach/fluxmq/pkg/proto/cluster/v1/clusterv1connect"
 	queueTypes "github.com/absmach/fluxmq/queue/types"
@@ -523,8 +524,9 @@ func (t *Transport) RouteQueueMessage(ctx context.Context, req *RouteQueueMessag
 	err := handler.DeliverQueueMessage(ctx, req.Msg.ClientId, msg)
 	if err != nil {
 		return connect.NewResponse(&clusterv1.RouteQueueMessageResponse{
-			Success: false,
-			Error:   err.Error(),
+			Success:            false,
+			Error:              err.Error(),
+			ClientNotConnected: corebroker.IsErrClientNotConnected(err),
 		}), nil
 	}
 
@@ -563,10 +565,11 @@ func (t *Transport) RouteQueueBatch(ctx context.Context, req *RouteQueueBatchReq
 		msg := decodeRouteQueueMessage(wire)
 		if err := handler.DeliverQueueMessage(ctx, wire.ClientId, msg); err != nil {
 			failures = append(failures, &clusterv1.RouteQueueBatchError{
-				Index:     uint32(idx),
-				ClientId:  wire.ClientId,
-				QueueName: wire.QueueName,
-				Error:     err.Error(),
+				Index:              uint32(idx),
+				ClientId:           wire.ClientId,
+				QueueName:          wire.QueueName,
+				Error:              err.Error(),
+				ClientNotConnected: corebroker.IsErrClientNotConnected(err),
 			})
 			continue
 		}
@@ -889,6 +892,9 @@ func (t *Transport) SendRouteQueueMessage(ctx context.Context, nodeID, clientID,
 		}
 
 		if !resp.Msg.Success {
+			if resp.Msg.ClientNotConnected {
+				return fmt.Errorf("%w: route queue message failed: %s", corebroker.ErrClientNotConnected, resp.Msg.Error)
+			}
 			return fmt.Errorf("route queue message failed: %s", resp.Msg.Error)
 		}
 
@@ -1014,13 +1020,33 @@ func (t *Transport) SendRouteQueueBatch(ctx context.Context, nodeID string, deli
 	t.logger.Warn("route queue batch partial failure after retries",
 		slog.String("node_id", nodeID),
 		slog.Int("remaining_failures", len(remaining)))
-	return fmt.Errorf("route queue batch failed after %d retries: %d deliveries still failing: %s",
+	batchErr := fmt.Errorf("route queue batch failed after %d retries: %d deliveries still failing: %s",
 		maxPartialRetries, len(remaining), summarizeQueueBatchFailures(failures))
+	// When every remaining failure is a not-connected target, wrap the sentinel
+	// so the caller can evict via errors.Is without parsing the message. Batches
+	// are built per single consumer, so "all" maps to one client.
+	if noClientConnected(failures) {
+		return fmt.Errorf("%w: %s", corebroker.ErrClientNotConnected, batchErr)
+	}
+	return batchErr
+}
+
+func noClientConnected(failures []queueBatchFailure) bool {
+	if len(failures) == 0 {
+		return false
+	}
+	for _, failure := range failures {
+		if !failure.clientNotConnected {
+			return false
+		}
+	}
+	return true
 }
 
 type queueBatchFailure struct {
-	delivery QueueDelivery
-	err      string
+	delivery           QueueDelivery
+	err                string
+	clientNotConnected bool
 }
 
 func (t *Transport) sendRouteQueueBatchOnce(
@@ -1081,8 +1107,9 @@ func (t *Transport) sendRouteQueueBatchOnce(
 			}
 			seen[deliveryIdx] = struct{}{}
 			failures = append(failures, queueBatchFailure{
-				delivery: deliveries[deliveryIdx],
-				err:      f.Error,
+				delivery:           deliveries[deliveryIdx],
+				err:                f.Error,
+				clientNotConnected: f.ClientNotConnected,
 			})
 		}
 		if len(failures) == 0 {

--- a/cluster/transport_batch_send_test.go
+++ b/cluster/transport_batch_send_test.go
@@ -5,6 +5,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -13,6 +14,7 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
+	corebroker "github.com/absmach/fluxmq/broker"
 	clusterv1 "github.com/absmach/fluxmq/pkg/proto/cluster/v1"
 	"github.com/absmach/fluxmq/pkg/proto/cluster/v1/clusterv1connect"
 )
@@ -548,6 +550,60 @@ func TestSendRouteQueueBatch_ExhaustsPartialRetriesReturnsError(t *testing.T) {
 	}
 	if c := callCount.Load(); int(c) != maxPartialRetries {
 		t.Fatalf("expected %d partial retry calls, got %d", maxPartialRetries, c)
+	}
+}
+
+func TestSendRouteQueueBatch_WrapsSentinelWhenAllFailuresNotConnected(t *testing.T) {
+	mock := &mockBrokerClient{
+		routeQueueBatchFn: func(_ context.Context, _ *connect.Request[clusterv1.RouteQueueBatchRequest]) (*connect.Response[clusterv1.RouteQueueBatchResponse], error) {
+			return connect.NewResponse(&clusterv1.RouteQueueBatchResponse{
+				Success: false,
+				Error:   testAlwaysFails,
+				Failures: []*clusterv1.RouteQueueBatchError{
+					{Index: 0, ClientId: "c1", QueueName: "q1", Error: "session not found", ClientNotConnected: true},
+				},
+			}), nil
+		},
+	}
+	tr := newTestTransport("peer1", mock)
+
+	deliveries := []QueueDelivery{
+		{ClientID: "c1", QueueName: "q1", Message: &QueueMessage{MessageID: "m1", Payload: []byte("1")}},
+	}
+	err := tr.SendRouteQueueBatch(context.Background(), "peer1", deliveries)
+	if err == nil {
+		t.Fatal("expected error after exhausted partial retries")
+	}
+	if !errors.Is(err, corebroker.ErrClientNotConnected) {
+		t.Fatalf("expected wrapped ErrClientNotConnected, got %v", err)
+	}
+}
+
+func TestSendRouteQueueBatch_DoesNotWrapSentinelOnMixedFailures(t *testing.T) {
+	mock := &mockBrokerClient{
+		routeQueueBatchFn: func(_ context.Context, _ *connect.Request[clusterv1.RouteQueueBatchRequest]) (*connect.Response[clusterv1.RouteQueueBatchResponse], error) {
+			return connect.NewResponse(&clusterv1.RouteQueueBatchResponse{
+				Success: false,
+				Error:   testAlwaysFails,
+				Failures: []*clusterv1.RouteQueueBatchError{
+					{Index: 0, ClientId: "c1", QueueName: "q1", Error: "client not connected", ClientNotConnected: true},
+					{Index: 1, ClientId: "c2", QueueName: "q2", Error: "queue busy", ClientNotConnected: false},
+				},
+			}), nil
+		},
+	}
+	tr := newTestTransport("peer1", mock)
+
+	deliveries := []QueueDelivery{
+		{ClientID: "c1", QueueName: "q1", Message: &QueueMessage{MessageID: "m1", Payload: []byte("1")}},
+		{ClientID: "c2", QueueName: "q2", Message: &QueueMessage{MessageID: "m2", Payload: []byte("2")}},
+	}
+	err := tr.SendRouteQueueBatch(context.Background(), "peer1", deliveries)
+	if err == nil {
+		t.Fatal("expected error after exhausted partial retries")
+	}
+	if errors.Is(err, corebroker.ErrClientNotConnected) {
+		t.Fatalf("mixed failures must not wrap the not-connected sentinel, got %v", err)
 	}
 }
 

--- a/cluster/transport_batch_send_test.go
+++ b/cluster/transport_batch_send_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -483,8 +484,12 @@ func TestSendRouteQueueBatch_ExhaustsPartialRetriesReturnsError(t *testing.T) {
 	deliveries := []QueueDelivery{
 		{ClientID: "c1", QueueName: "q1", Message: &QueueMessage{MessageID: "m1", Payload: []byte("1")}},
 	}
-	if err := tr.SendRouteQueueBatch(context.Background(), "peer1", deliveries); err == nil {
+	err := tr.SendRouteQueueBatch(context.Background(), "peer1", deliveries)
+	if err == nil {
 		t.Fatal("expected error after exhausted partial retries")
+	}
+	if !strings.Contains(err.Error(), "persistent") {
+		t.Fatalf("expected final error to preserve failure reason, got %v", err)
 	}
 	if c := callCount.Load(); int(c) != maxPartialRetries {
 		t.Fatalf("expected %d partial retry calls, got %d", maxPartialRetries, c)

--- a/cluster/transport_batch_send_test.go
+++ b/cluster/transport_batch_send_test.go
@@ -449,6 +449,61 @@ func TestSendRouteQueueBatch_PartialFailureRetriesSubset(t *testing.T) {
 	}
 }
 
+func TestSendRouteQueueBatch_ClearsFailuresBetweenTransportRetries(t *testing.T) {
+	var callCount atomic.Int32
+
+	const (
+		peerID       = "peer-route-retry"
+		failedClient = "retry-route-client"
+		queueName    = "retry-route-queue"
+	)
+
+	mock := &mockBrokerClient{
+		routeQueueBatchFn: func(_ context.Context, req *connect.Request[clusterv1.RouteQueueBatchRequest]) (*connect.Response[clusterv1.RouteQueueBatchResponse], error) {
+			call := callCount.Add(1)
+			switch call {
+			case 1:
+				if len(req.Msg.Messages) != 2 {
+					t.Errorf("call 1: expected 2 messages, got %d", len(req.Msg.Messages))
+				}
+				return connect.NewResponse(&clusterv1.RouteQueueBatchResponse{
+					Success: false,
+					Error:   "partial malformed response",
+					Failures: []*clusterv1.RouteQueueBatchError{
+						{Index: 0, ClientId: failedClient, QueueName: queueName, Error: "busy"},
+						{Index: 99, ClientId: "invalid-route-client", QueueName: queueName, Error: "bad index"},
+					},
+				}), nil
+			case 2:
+				if len(req.Msg.Messages) != 2 {
+					t.Errorf("call 2: expected full batch retry, got %d messages", len(req.Msg.Messages))
+				}
+				return connect.NewResponse(&clusterv1.RouteQueueBatchResponse{
+					Success:   true,
+					Delivered: uint32(len(req.Msg.Messages)),
+				}), nil
+			default:
+				t.Errorf("unexpected route queue batch call %d", call)
+				return connect.NewResponse(&clusterv1.RouteQueueBatchResponse{
+					Success: true,
+				}), nil
+			}
+		},
+	}
+	tr := newTestTransport(peerID, mock)
+
+	deliveries := []QueueDelivery{
+		{ClientID: failedClient, QueueName: queueName, Message: &QueueMessage{MessageID: "retry-route-message", Payload: []byte("retry-route-payload")}},
+		{ClientID: "delivered-route-client", QueueName: queueName, Message: &QueueMessage{MessageID: "delivered-route-message", Payload: []byte("delivered-route-payload")}},
+	}
+	if err := tr.SendRouteQueueBatch(context.Background(), peerID, deliveries); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if c := callCount.Load(); c != 2 {
+		t.Fatalf("expected malformed response retry to stop after success, got %d calls", c)
+	}
+}
+
 func TestSendRouteQueueBatch_TransportError(t *testing.T) {
 	mock := &mockBrokerClient{
 		routeQueueBatchFn: func(context.Context, *connect.Request[clusterv1.RouteQueueBatchRequest]) (*connect.Response[clusterv1.RouteQueueBatchResponse], error) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,6 +68,32 @@ func protocolVersionForMode(mode string) int {
 	}
 }
 
+type brokerDeliveryTarget struct {
+	mqtt    *broker.Broker
+	amqp    *amqp1broker.Broker
+	amqp091 *amqpbroker.Broker
+}
+
+func (t *brokerDeliveryTarget) Deliver(ctx context.Context, clientID string, msg *storage.Message) error {
+	if amqp1broker.IsAMQPClient(clientID) {
+		return t.amqp.DeliverToClient(ctx, clientID, msg)
+	}
+	if amqpbroker.IsAMQP091Client(clientID) {
+		return t.amqp091.DeliverToClient(ctx, clientID, msg)
+	}
+	return t.mqtt.DeliverToSessionByID(ctx, clientID, msg)
+}
+
+func (t *brokerDeliveryTarget) IsClientConnected(clientID string) bool {
+	if amqp1broker.IsAMQPClient(clientID) {
+		return t.amqp != nil && t.amqp.IsClientConnected(clientID)
+	}
+	if amqpbroker.IsAMQP091Client(clientID) {
+		return t.amqp091 != nil && t.amqp091.IsClientConnected(clientID)
+	}
+	return t.mqtt != nil && t.mqtt.IsClientConnected(clientID)
+}
+
 func main() {
 	configFile := flag.String("config", "", "Path to configuration file")
 	flag.Parse()
@@ -508,16 +534,12 @@ func main() {
 			amqp091Broker.CancelConsumers(queueName, groupID, consumerIDs)
 		}
 
-		// Delivery dispatcher: routes to AMQP or MQTT broker based on client ID prefix
-		deliveryTarget := queue.DeliveryTargetFunc(func(ctx context.Context, clientID string, msg *storage.Message) error {
-			if amqp1broker.IsAMQPClient(clientID) {
-				return amqpBroker.DeliverToClient(ctx, clientID, msg)
-			}
-			if amqpbroker.IsAMQP091Client(clientID) {
-				return amqp091Broker.DeliverToClient(ctx, clientID, msg)
-			}
-			return b.DeliverToSessionByID(ctx, clientID, msg)
-		})
+		// Delivery dispatcher: routes to AMQP or MQTT broker based on client ID prefix.
+		deliveryTarget := &brokerDeliveryTarget{
+			mqtt:    b,
+			amqp:    amqpBroker,
+			amqp091: amqp091Broker,
+		}
 
 		// Create log-based queue manager with wildcard support
 		qm = queue.NewManager(

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -84,14 +84,14 @@ func (t *brokerDeliveryTarget) Deliver(ctx context.Context, clientID string, msg
 	return t.mqtt.DeliverToSessionByID(ctx, clientID, msg)
 }
 
-func (t *brokerDeliveryTarget) IsClientConnected(clientID string) bool {
+func (t *brokerDeliveryTarget) HasDeliveryTarget(clientID string) bool {
 	if amqp1broker.IsAMQPClient(clientID) {
 		return t.amqp != nil && t.amqp.IsClientConnected(clientID)
 	}
 	if amqpbroker.IsAMQP091Client(clientID) {
 		return t.amqp091 != nil && t.amqp091.IsClientConnected(clientID)
 	}
-	return t.mqtt != nil && t.mqtt.IsClientConnected(clientID)
+	return t.mqtt != nil && t.mqtt.Get(clientID) != nil
 }
 
 func main() {

--- a/deployments/docker/Dockerfile
+++ b/deployments/docker/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 # Multi-arch build: BUILDPLATFORM is the builder's native arch,
 # TARGETOS/TARGETARCH are the requested target. buildx supplies both.
-FROM --platform=$BUILDPLATFORM golang:1.26.3-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/absmach/fluxmq
 
 go 1.26.3
 
+toolchain go1.26.4
+
 require (
 	connectrpc.com/connect v1.20.0
 	github.com/Azure/go-amqp v1.6.0

--- a/mqtt/broker/broker.go
+++ b/mqtt/broker/broker.go
@@ -215,6 +215,12 @@ func (b *Broker) Get(clientID string) *session.Session {
 	return b.sessionsMap.Get(clientID)
 }
 
+// IsClientConnected reports whether the MQTT client has a live session.
+func (b *Broker) IsClientConnected(clientID string) bool {
+	s := b.Get(clientID)
+	return s != nil && s.IsConnected()
+}
+
 // Stats returns the broker statistics.
 func (b *Broker) Stats() *Stats {
 	return b.telemetry.stats

--- a/mqtt/broker/delivery.go
+++ b/mqtt/broker/delivery.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"time"
 
+	corebroker "github.com/absmach/fluxmq/broker"
 	"github.com/absmach/fluxmq/broker/events"
 	"github.com/absmach/fluxmq/cluster"
 	core "github.com/absmach/fluxmq/mqtt"
@@ -288,7 +289,7 @@ func isReservedUserPropertyKey(key string) bool {
 func (b *Broker) DeliverToClient(ctx context.Context, clientID string, msg *cluster.Message) error {
 	s := b.Get(clientID)
 	if s == nil {
-		return fmt.Errorf("session not found: %s", clientID)
+		return fmt.Errorf("%w: session not found: %s", corebroker.ErrClientNotConnected, clientID)
 	}
 
 	// cluster.Message comes from cluster - create storage.Message with zero-copy buffer
@@ -310,7 +311,7 @@ func (b *Broker) DeliverToClient(ctx context.Context, clientID string, msg *clus
 func (b *Broker) DeliverToSessionByID(ctx context.Context, clientID string, msg any) error {
 	s := b.Get(clientID)
 	if s == nil {
-		return fmt.Errorf("session not found: %s", clientID)
+		return fmt.Errorf("%w: session not found: %s", corebroker.ErrClientNotConnected, clientID)
 	}
 
 	// Convert queue message to storage message

--- a/pkg/proto/cluster/v1/broker.pb.go
+++ b/pkg/proto/cluster/v1/broker.pb.go
@@ -1353,11 +1353,14 @@ func (x *RouteQueueMessageRequest) GetSequence() int64 {
 }
 
 type RouteQueueMessageResponse struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Success       bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
-	Error         string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Success bool                   `protobuf:"varint,1,opt,name=success,proto3" json:"success,omitempty"`
+	Error   string                 `protobuf:"bytes,2,opt,name=error,proto3" json:"error,omitempty"`
+	// client_not_connected signals the delivery target had no live connection,
+	// so the sender can evict the stale consumer without parsing error text.
+	ClientNotConnected bool `protobuf:"varint,3,opt,name=client_not_connected,json=clientNotConnected,proto3" json:"client_not_connected,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *RouteQueueMessageResponse) Reset() {
@@ -1402,6 +1405,13 @@ func (x *RouteQueueMessageResponse) GetError() string {
 		return x.Error
 	}
 	return ""
+}
+
+func (x *RouteQueueMessageResponse) GetClientNotConnected() bool {
+	if x != nil {
+		return x.ClientNotConnected
+	}
+	return false
 }
 
 type RouteQueueBatchRequest struct {
@@ -1449,13 +1459,16 @@ func (x *RouteQueueBatchRequest) GetMessages() []*RouteQueueMessageRequest {
 }
 
 type RouteQueueBatchError struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Index         uint32                 `protobuf:"varint,1,opt,name=index,proto3" json:"index,omitempty"`
-	ClientId      string                 `protobuf:"bytes,2,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
-	QueueName     string                 `protobuf:"bytes,3,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
-	Error         string                 `protobuf:"bytes,4,opt,name=error,proto3" json:"error,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Index     uint32                 `protobuf:"varint,1,opt,name=index,proto3" json:"index,omitempty"`
+	ClientId  string                 `protobuf:"bytes,2,opt,name=client_id,json=clientId,proto3" json:"client_id,omitempty"`
+	QueueName string                 `protobuf:"bytes,3,opt,name=queue_name,json=queueName,proto3" json:"queue_name,omitempty"`
+	Error     string                 `protobuf:"bytes,4,opt,name=error,proto3" json:"error,omitempty"`
+	// client_not_connected signals the delivery target had no live connection,
+	// so the sender can evict the stale consumer without parsing error text.
+	ClientNotConnected bool `protobuf:"varint,5,opt,name=client_not_connected,json=clientNotConnected,proto3" json:"client_not_connected,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *RouteQueueBatchError) Reset() {
@@ -1514,6 +1527,13 @@ func (x *RouteQueueBatchError) GetError() string {
 		return x.Error
 	}
 	return ""
+}
+
+func (x *RouteQueueBatchError) GetClientNotConnected() bool {
+	if x != nil {
+		return x.ClientNotConnected
+	}
+	return false
 }
 
 type RouteQueueBatchResponse struct {
@@ -2479,18 +2499,20 @@ const file_cluster_v1_broker_proto_rawDesc = "" +
 	"\bsequence\x18\x06 \x01(\x03R\bsequence\x1a=\n" +
 	"\x0fPropertiesEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"K\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"}\n" +
 	"\x19RouteQueueMessageResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x14\n" +
-	"\x05error\x18\x02 \x01(\tR\x05error\"a\n" +
+	"\x05error\x18\x02 \x01(\tR\x05error\x120\n" +
+	"\x14client_not_connected\x18\x03 \x01(\bR\x12clientNotConnected\"a\n" +
 	"\x16RouteQueueBatchRequest\x12G\n" +
-	"\bmessages\x18\x01 \x03(\v2+.fluxmq.cluster.v1.RouteQueueMessageRequestR\bmessages\"~\n" +
+	"\bmessages\x18\x01 \x03(\v2+.fluxmq.cluster.v1.RouteQueueMessageRequestR\bmessages\"\xb0\x01\n" +
 	"\x14RouteQueueBatchError\x12\x14\n" +
 	"\x05index\x18\x01 \x01(\rR\x05index\x12\x1b\n" +
 	"\tclient_id\x18\x02 \x01(\tR\bclientId\x12\x1d\n" +
 	"\n" +
 	"queue_name\x18\x03 \x01(\tR\tqueueName\x12\x14\n" +
-	"\x05error\x18\x04 \x01(\tR\x05error\"\xac\x01\n" +
+	"\x05error\x18\x04 \x01(\tR\x05error\x120\n" +
+	"\x14client_not_connected\x18\x05 \x01(\bR\x12clientNotConnected\"\xac\x01\n" +
 	"\x17RouteQueueBatchResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12\x14\n" +
 	"\x05error\x18\x02 \x01(\tR\x05error\x12\x1c\n" +

--- a/proto/cluster/v1/broker.proto
+++ b/proto/cluster/v1/broker.proto
@@ -213,6 +213,9 @@ message RouteQueueMessageRequest {
 message RouteQueueMessageResponse {
   bool success = 1;
   string error = 2;
+  // client_not_connected signals the delivery target had no live connection,
+  // so the sender can evict the stale consumer without parsing error text.
+  bool client_not_connected = 3;
 }
 
 message RouteQueueBatchRequest {
@@ -224,6 +227,9 @@ message RouteQueueBatchError {
   string client_id = 2;
   string queue_name = 3;
   string error = 4;
+  // client_not_connected signals the delivery target had no live connection,
+  // so the sender can evict the stale consumer without parsing error text.
+  bool client_not_connected = 5;
 }
 
 message RouteQueueBatchResponse {

--- a/queue/consumer/manager.go
+++ b/queue/consumer/manager.go
@@ -236,10 +236,58 @@ func (m *Manager) ClaimBatchStream(ctx context.Context, queueName, groupID, cons
 		return nil, err
 	}
 
+	messages, newCursor, err := m.peekBatchStreamLocked(ctx, group, filter, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := m.updateStreamCursorLocked(ctx, group, newCursor); err != nil {
+		return nil, err
+	}
+
+	return messages, nil
+}
+
+// PeekBatchStream retrieves stream messages without advancing the consumer
+// group cursor. Call CommitStreamCursor after successful delivery.
+func (m *Manager) PeekBatchStream(ctx context.Context, queueName, groupID, _ string, filter *Filter, limit int) ([]*types.Message, uint64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if limit <= 0 {
+		limit = m.config.ClaimBatchSize
+	}
+
+	group, err := m.groupStore.GetConsumerGroup(ctx, queueName, groupID)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return m.peekBatchStreamLocked(ctx, group, filter, limit)
+}
+
+// CommitStreamCursor advances a stream consumer group's cursor after delivery
+// has succeeded.
+func (m *Manager) CommitStreamCursor(ctx context.Context, queueName, groupID string, cursor uint64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	group, err := m.groupStore.GetConsumerGroup(ctx, queueName, groupID)
+	if err != nil {
+		return err
+	}
+	if group.Mode != types.GroupModeStream {
+		return ErrCommitOffsetOnlyForStreamMode
+	}
+
+	return m.updateStreamCursorLocked(ctx, group, cursor)
+}
+
+func (m *Manager) peekBatchStreamLocked(ctx context.Context, group *types.ConsumerGroup, filter *Filter, limit int) ([]*types.Message, uint64, error) {
 	cursor := group.GetCursor()
 	tail, err := m.queueStore.Tail(ctx, group.QueueName)
 	if err != nil {
-		return nil, err
+		return nil, cursor.Cursor, err
 	}
 
 	var messages []*types.Message
@@ -254,7 +302,7 @@ func (m *Manager) ClaimBatchStream(ctx context.Context, queueName, groupID, cons
 			if err == storage.ErrOffsetOutOfRange {
 				continue
 			}
-			return nil, err
+			return nil, cursor.Cursor, err
 		}
 
 		// Skip expired messages
@@ -274,34 +322,39 @@ func (m *Manager) ClaimBatchStream(ctx context.Context, queueName, groupID, cons
 	}
 
 	if len(messages) == 0 {
-		return nil, ErrNoMessages
+		return nil, cursor.Cursor, ErrNoMessages
 	}
 
-	if newCursor > cursor.Cursor {
-		if err := m.groupStore.UpdateCursor(ctx, group.QueueName, group.ID, newCursor); err != nil {
-			return nil, err
-		}
-		// Only auto-commit if the group has AutoCommit enabled.
-		if group.AutoCommit {
-			if m.config.AutoCommitInterval <= 0 {
-				if err := m.groupStore.UpdateCommitted(ctx, group.QueueName, group.ID, newCursor); err != nil {
-					return nil, err
-				}
-			} else {
-				key := group.QueueName + "/" + group.ID
-				now := time.Now()
-				last, ok := m.lastCommit[key]
-				if !ok || now.Sub(last) >= m.config.AutoCommitInterval {
-					if err := m.groupStore.UpdateCommitted(ctx, group.QueueName, group.ID, newCursor); err != nil {
-						return nil, err
-					}
-					m.lastCommit[key] = now
-				}
-			}
-		}
+	return messages, newCursor, nil
+}
+
+func (m *Manager) updateStreamCursorLocked(ctx context.Context, group *types.ConsumerGroup, newCursor uint64) error {
+	cursor := group.GetCursor()
+	if newCursor <= cursor.Cursor {
+		return nil
+	}
+	if err := m.groupStore.UpdateCursor(ctx, group.QueueName, group.ID, newCursor); err != nil {
+		return err
 	}
 
-	return messages, nil
+	if !group.AutoCommit {
+		return nil
+	}
+	if m.config.AutoCommitInterval <= 0 {
+		return m.groupStore.UpdateCommitted(ctx, group.QueueName, group.ID, newCursor)
+	}
+
+	key := group.QueueName + "/" + group.ID
+	now := time.Now()
+	last, ok := m.lastCommit[key]
+	if ok && now.Sub(last) < m.config.AutoCommitInterval {
+		return nil
+	}
+	if err := m.groupStore.UpdateCommitted(ctx, group.QueueName, group.ID, newCursor); err != nil {
+		return err
+	}
+	m.lastCommit[key] = now
+	return nil
 }
 
 // claimFromCursor tries to claim a message from the cursor position.

--- a/queue/delivery.go
+++ b/queue/delivery.go
@@ -16,8 +16,16 @@ type Deliverer interface {
 	Deliver(ctx context.Context, clientID string, msg *storage.Message) error
 }
 
-// ClientConnectionChecker is optionally implemented by a Deliverer that can
-// tell whether a protocol client is still connected before queue cursors move.
+// ClientDeliveryTargetChecker is optionally implemented by a Deliverer that can
+// tell whether queue delivery has a valid target before queue cursors move. For
+// MQTT, a disconnected persistent session is still a valid delivery target
+// because the broker can enqueue QoS>0 messages for later delivery.
+type ClientDeliveryTargetChecker interface {
+	HasDeliveryTarget(clientID string) bool
+}
+
+// ClientConnectionChecker is kept for deliverers where only live connections
+// are valid queue delivery targets.
 type ClientConnectionChecker interface {
 	IsClientConnected(clientID string) bool
 }

--- a/queue/delivery.go
+++ b/queue/delivery.go
@@ -16,6 +16,12 @@ type Deliverer interface {
 	Deliver(ctx context.Context, clientID string, msg *storage.Message) error
 }
 
+// ClientConnectionChecker is optionally implemented by a Deliverer that can
+// tell whether a protocol client is still connected before queue cursors move.
+type ClientConnectionChecker interface {
+	IsClientConnected(clientID string) bool
+}
+
 // DeliveryTargetFunc adapts a plain function to the DeliveryTarget interface.
 type DeliveryTargetFunc func(ctx context.Context, clientID string, msg *storage.Message) error
 

--- a/queue/delivery_engine.go
+++ b/queue/delivery_engine.go
@@ -328,7 +328,7 @@ func (e *DeliveryEngine) deliverToGroup(ctx context.Context, config *types.Queue
 					slog.String("queue", config.Name),
 					slog.Int("batch_size", len(deliveries)),
 					slog.String("error", err.Error()))
-				if corebroker.IsClientNotConnected(err) {
+				if corebroker.IsErrClientNotConnected(err) {
 					e.unregisterConsumer(ctx, config.Name, group.ID, consumerID, err)
 				}
 				continue
@@ -359,7 +359,7 @@ func (e *DeliveryEngine) deliverToGroup(ctx context.Context, config *types.Queue
 						slog.String("client", consumerInfo.ClientID),
 						slog.String("topic", msg.Topic),
 						slog.String("error", err.Error()))
-					if corebroker.IsClientNotConnected(err) {
+					if corebroker.IsErrClientNotConnected(err) {
 						e.unregisterConsumer(ctx, config.Name, group.ID, consumerID, err)
 						break
 					}
@@ -476,7 +476,7 @@ func (e *DeliveryEngine) deliverToRemoteConsumers(ctx context.Context, config *t
 					slog.String("node", consumerInfo.ProxyNodeID),
 					slog.String("queue", config.Name),
 					slog.String("error", err.Error()))
-				if corebroker.IsClientNotConnected(err) {
+				if corebroker.IsErrClientNotConnected(err) {
 					e.unregisterConsumer(ctx, config.Name, groupID, consumerInfo.ConsumerID, err)
 				}
 				continue

--- a/queue/delivery_engine.go
+++ b/queue/delivery_engine.go
@@ -568,10 +568,8 @@ func (e *DeliveryEngine) routeRemoteBatch(ctx context.Context, nodeID string, de
 		if err == nil {
 			return nil
 		}
-		if corebroker.IsClientNotConnected(err) {
-			return err
-		}
-		// Fall back to single message RPC if batch routing fails.
+		// Batch router errors may be shared across coalesced requests. Fall back
+		// so any stale-client error is tied to this exact delivery.
 	}
 
 	for _, delivery := range deliveries {

--- a/queue/delivery_engine.go
+++ b/queue/delivery_engine.go
@@ -35,15 +35,16 @@ type RemoteBatchRouter interface {
 // remote consumers. It owns the scheduling loop and delivery state; the
 // Manager delegates all delivery work here.
 type DeliveryEngine struct {
-	queueStore       storage.QueueStore
-	groupStore       storage.ConsumerGroupStore
-	consumerManager  *consumer.Manager
-	local            Deliverer
-	remote           RemoteRouter // nil for single-node
-	localNodeID      string
-	distributionMode DistributionMode
-	batchSize        int
-	logger           *slog.Logger
+	queueStore        storage.QueueStore
+	groupStore        storage.ConsumerGroupStore
+	consumerManager   *consumer.Manager
+	local             Deliverer
+	remote            RemoteRouter // nil for single-node
+	localNodeID       string
+	distributionMode  DistributionMode
+	batchSize         int
+	logger            *slog.Logger
+	onConsumerRemoved func(context.Context, string, string, []string)
 
 	mu       sync.Mutex
 	enqueued map[string]struct{}
@@ -80,6 +81,10 @@ func NewDeliveryEngine(
 		queue:            make(chan string, 4096),
 		stopCh:           make(chan struct{}),
 	}
+}
+
+func (e *DeliveryEngine) setConsumerRemovedCallback(callback func(context.Context, string, string, []string)) {
+	e.onConsumerRemoved = callback
 }
 
 // Start launches the delivery loop goroutine.
@@ -517,15 +522,18 @@ func (e *DeliveryEngine) unregisterConsumer(ctx context.Context, queueName, grou
 	}
 	e.logger.LogAttrs(ctx, slog.LevelWarn, "removing stale queue consumer", attrs...)
 
-	if err := e.consumerManager.UnregisterConsumer(ctx, queueName, groupID, consumerID); err != nil &&
-		err != consumer.ErrConsumerNotFound &&
-		err != storage.ErrConsumerNotFound &&
-		err != storage.ErrQueueNotFound {
-		e.logger.Warn("failed to unregister stale queue consumer",
-			slog.String("queue", queueName),
-			slog.String("group", groupID),
-			slog.String("consumer", consumerID),
-			slog.String("error", err.Error()))
+	if err := e.consumerManager.UnregisterConsumer(ctx, queueName, groupID, consumerID); err != nil {
+		if err != consumer.ErrConsumerNotFound &&
+			err != storage.ErrConsumerNotFound &&
+			err != storage.ErrQueueNotFound {
+			e.logger.Warn("failed to unregister stale queue consumer",
+				slog.String("queue", queueName),
+				slog.String("group", groupID),
+				slog.String("consumer", consumerID),
+				slog.String("error", err.Error()))
+		}
+	} else if e.onConsumerRemoved != nil {
+		e.onConsumerRemoved(ctx, queueName, groupID, []string{consumerID})
 	}
 	if e.remote == nil {
 		return

--- a/queue/delivery_engine.go
+++ b/queue/delivery_engine.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	corebroker "github.com/absmach/fluxmq/broker"
 	"github.com/absmach/fluxmq/cluster"
 	"github.com/absmach/fluxmq/queue/consumer"
 	"github.com/absmach/fluxmq/queue/storage"
@@ -23,6 +24,7 @@ import (
 type RemoteRouter interface {
 	ListQueueConsumers(ctx context.Context, queueName string) ([]*cluster.QueueConsumerInfo, error)
 	RouteQueueMessage(ctx context.Context, nodeID, clientID, queueName string, msg *cluster.QueueMessage) error
+	UnregisterQueueConsumer(ctx context.Context, queueName, groupID, consumerID string) error
 }
 
 type RemoteBatchRouter interface {
@@ -250,20 +252,6 @@ func (e *DeliveryEngine) deliverToGroup(ctx context.Context, config *types.Queue
 
 	delivered := false
 	for _, consumerID := range consumers {
-		var msgs []*types.Message
-		var err error
-		if group.Mode == types.GroupModeStream {
-			msgs, err = e.consumerManager.ClaimBatchStream(ctx, config.Name, group.ID, consumerID, filter, e.batchSize)
-		} else {
-			msgs, err = e.consumerManager.ClaimBatch(ctx, config.Name, group.ID, consumerID, filter, e.batchSize)
-		}
-		if err != nil && err != consumer.ErrNoMessages {
-			continue
-		}
-		if len(msgs) > 0 {
-			delivered = true
-		}
-
 		freshGroup, err := e.groupStore.GetConsumerGroup(ctx, config.Name, group.ID)
 		if err != nil {
 			continue
@@ -274,12 +262,35 @@ func (e *DeliveryEngine) deliverToGroup(ctx context.Context, config *types.Queue
 			continue
 		}
 
-		if err := e.consumerManager.UpdateHeartbeat(ctx, config.Name, group.ID, consumerID); err != nil {
-			e.logger.Warn("failed to update consumer heartbeat",
-				slog.String("queue", config.Name),
-				slog.String("group", group.ID),
-				slog.String("consumer", consumerID),
-				slog.String("error", err.Error()))
+		remoteTarget := e.isRemoteConsumer(consumerInfo)
+		if !remoteTarget {
+			if e.local == nil {
+				continue
+			}
+			if e.localClientDisconnected(consumerInfo.ClientID) {
+				e.unregisterConsumer(ctx, config.Name, group.ID, consumerID,
+					corebroker.ErrClientNotConnected)
+				continue
+			}
+		}
+
+		var msgs []*types.Message
+		var nextCursor uint64
+		if group.Mode == types.GroupModeStream {
+			msgs, nextCursor, err = e.consumerManager.PeekBatchStream(ctx, config.Name, group.ID, consumerID, filter, e.batchSize)
+		} else {
+			msgs, err = e.consumerManager.ClaimBatch(ctx, config.Name, group.ID, consumerID, filter, e.batchSize)
+		}
+		if err == consumer.ErrNoMessages {
+			e.touchConsumerHeartbeat(ctx, config.Name, group.ID, consumerID)
+			continue
+		}
+		if err != nil {
+			continue
+		}
+		if len(msgs) == 0 {
+			e.touchConsumerHeartbeat(ctx, config.Name, group.ID, consumerID)
+			continue
 		}
 
 		var workCommitted uint64
@@ -288,26 +299,7 @@ func (e *DeliveryEngine) deliverToGroup(ctx context.Context, config *types.Queue
 			workCommitted, hasWorkCommitted = primaryCommitted(group.Pattern)
 		}
 
-		for _, msg := range msgs {
-			if e.remote != nil && consumerInfo.ProxyNodeID != "" && consumerInfo.ProxyNodeID != e.localNodeID {
-				continue
-			}
-			if e.local != nil {
-				deliveryMsg := createDeliveryMessage(msg, group.ID, config.Name)
-				if group.Mode == types.GroupModeStream {
-					decorateStreamDelivery(deliveryMsg, msg, workCommitted, hasWorkCommitted, config.PrimaryGroup)
-				}
-
-				if err := e.local.Deliver(ctx, consumerInfo.ClientID, deliveryMsg); err != nil {
-					e.logger.Warn("queue message delivery failed",
-						slog.String("client", consumerInfo.ClientID),
-						slog.String("topic", msg.Topic),
-						slog.String("error", err.Error()))
-				}
-			}
-		}
-
-		if e.remote != nil && consumerInfo.ProxyNodeID != "" && consumerInfo.ProxyNodeID != e.localNodeID && len(msgs) > 0 {
+		if remoteTarget {
 			deliveries := make([]cluster.QueueDelivery, 0, len(msgs))
 			for _, msg := range msgs {
 				deliveries = append(deliveries, cluster.QueueDelivery{
@@ -331,7 +323,62 @@ func (e *DeliveryEngine) deliverToGroup(ctx context.Context, config *types.Queue
 					slog.String("queue", config.Name),
 					slog.Int("batch_size", len(deliveries)),
 					slog.String("error", err.Error()))
+				if corebroker.IsClientNotConnected(err) {
+					e.unregisterConsumer(ctx, config.Name, group.ID, consumerID, err)
+				}
+				continue
 			}
+			if group.Mode == types.GroupModeStream {
+				e.commitStreamCursor(ctx, config.Name, group.ID, nextCursor)
+			}
+			e.touchConsumerHeartbeat(ctx, config.Name, group.ID, consumerID)
+			delivered = true
+			continue
+		}
+
+		var (
+			committedCursor uint64
+			deliveredAny    bool
+			allDelivered    = true
+		)
+		for _, msg := range msgs {
+			if e.local != nil {
+				deliveryMsg := createDeliveryMessage(msg, group.ID, config.Name)
+				if group.Mode == types.GroupModeStream {
+					decorateStreamDelivery(deliveryMsg, msg, workCommitted, hasWorkCommitted, config.PrimaryGroup)
+				}
+
+				if err := e.local.Deliver(ctx, consumerInfo.ClientID, deliveryMsg); err != nil {
+					allDelivered = false
+					e.logger.Warn("queue message delivery failed",
+						slog.String("client", consumerInfo.ClientID),
+						slog.String("topic", msg.Topic),
+						slog.String("error", err.Error()))
+					if corebroker.IsClientNotConnected(err) {
+						e.unregisterConsumer(ctx, config.Name, group.ID, consumerID, err)
+						break
+					}
+					if group.Mode == types.GroupModeStream {
+						break
+					}
+					continue
+				}
+				deliveredAny = true
+				delivered = true
+				if group.Mode == types.GroupModeStream {
+					committedCursor = msg.Sequence + 1
+				}
+			}
+		}
+
+		if group.Mode == types.GroupModeStream && deliveredAny {
+			if allDelivered {
+				committedCursor = nextCursor
+			}
+			e.commitStreamCursor(ctx, config.Name, group.ID, committedCursor)
+		}
+		if deliveredAny {
+			e.touchConsumerHeartbeat(ctx, config.Name, group.ID, consumerID)
 		}
 	}
 
@@ -386,17 +433,15 @@ func (e *DeliveryEngine) deliverToRemoteConsumers(ctx context.Context, config *t
 
 		for _, consumerInfo := range groupConsumers {
 			var msgs []*types.Message
+			var nextCursor uint64
 			var err error
 			if group.Mode == types.GroupModeStream {
-				msgs, err = e.consumerManager.ClaimBatchStream(ctx, config.Name, groupID, consumerInfo.ConsumerID, filter, e.batchSize)
+				msgs, nextCursor, err = e.consumerManager.PeekBatchStream(ctx, config.Name, groupID, consumerInfo.ConsumerID, filter, e.batchSize)
 			} else {
 				msgs, err = e.consumerManager.ClaimBatch(ctx, config.Name, groupID, consumerInfo.ConsumerID, filter, e.batchSize)
 			}
 			if err != nil {
 				continue
-			}
-			if len(msgs) > 0 {
-				delivered = true
 			}
 
 			if len(msgs) == 0 {
@@ -426,18 +471,88 @@ func (e *DeliveryEngine) deliverToRemoteConsumers(ctx context.Context, config *t
 					slog.String("node", consumerInfo.ProxyNodeID),
 					slog.String("queue", config.Name),
 					slog.String("error", err.Error()))
-			} else {
-				e.logger.Debug("routed queue message batch to remote consumer",
-					slog.String("client", consumerInfo.ClientID),
-					slog.String("node", consumerInfo.ProxyNodeID),
-					slog.String("queue", config.Name),
-					slog.Int("batch_size", len(deliveries)),
-					slog.Uint64("last_offset", msgs[len(msgs)-1].Sequence))
+				if corebroker.IsClientNotConnected(err) {
+					e.unregisterConsumer(ctx, config.Name, groupID, consumerInfo.ConsumerID, err)
+				}
+				continue
 			}
+
+			if group.Mode == types.GroupModeStream {
+				e.commitStreamCursor(ctx, config.Name, groupID, nextCursor)
+			}
+			delivered = true
+			e.logger.Debug("routed queue message batch to remote consumer",
+				slog.String("client", consumerInfo.ClientID),
+				slog.String("node", consumerInfo.ProxyNodeID),
+				slog.String("queue", config.Name),
+				slog.Int("batch_size", len(deliveries)),
+				slog.Uint64("last_offset", msgs[len(msgs)-1].Sequence))
 		}
 	}
 
 	return delivered
+}
+
+func (e *DeliveryEngine) isRemoteConsumer(consumerInfo *types.ConsumerInfo) bool {
+	return e.remote != nil && consumerInfo.ProxyNodeID != "" && consumerInfo.ProxyNodeID != e.localNodeID
+}
+
+func (e *DeliveryEngine) localClientDisconnected(clientID string) bool {
+	checker, ok := e.local.(ClientConnectionChecker)
+	return ok && !checker.IsClientConnected(clientID)
+}
+
+func (e *DeliveryEngine) unregisterConsumer(ctx context.Context, queueName, groupID, consumerID string, reason error) {
+	attrs := []slog.Attr{
+		slog.String("queue", queueName),
+		slog.String("group", groupID),
+		slog.String("consumer", consumerID),
+	}
+	if reason != nil {
+		attrs = append(attrs, slog.String("reason", reason.Error()))
+	}
+	e.logger.LogAttrs(ctx, slog.LevelWarn, "removing stale queue consumer", attrs...)
+
+	if err := e.consumerManager.UnregisterConsumer(ctx, queueName, groupID, consumerID); err != nil &&
+		err != consumer.ErrConsumerNotFound &&
+		err != storage.ErrConsumerNotFound &&
+		err != storage.ErrQueueNotFound {
+		e.logger.Warn("failed to unregister stale queue consumer",
+			slog.String("queue", queueName),
+			slog.String("group", groupID),
+			slog.String("consumer", consumerID),
+			slog.String("error", err.Error()))
+	}
+	if e.remote == nil {
+		return
+	}
+	if err := e.remote.UnregisterQueueConsumer(ctx, queueName, groupID, consumerID); err != nil {
+		e.logger.Warn("failed to unregister stale queue consumer from cluster",
+			slog.String("queue", queueName),
+			slog.String("group", groupID),
+			slog.String("consumer", consumerID),
+			slog.String("error", err.Error()))
+	}
+}
+
+func (e *DeliveryEngine) touchConsumerHeartbeat(ctx context.Context, queueName, groupID, consumerID string) {
+	if err := e.consumerManager.UpdateHeartbeat(ctx, queueName, groupID, consumerID); err != nil {
+		e.logger.Warn("failed to update consumer heartbeat",
+			slog.String("queue", queueName),
+			slog.String("group", groupID),
+			slog.String("consumer", consumerID),
+			slog.String("error", err.Error()))
+	}
+}
+
+func (e *DeliveryEngine) commitStreamCursor(ctx context.Context, queueName, groupID string, cursor uint64) {
+	if err := e.consumerManager.CommitStreamCursor(ctx, queueName, groupID, cursor); err != nil {
+		e.logger.Warn("failed to commit stream cursor after delivery",
+			slog.String("queue", queueName),
+			slog.String("group", groupID),
+			slog.Uint64("cursor", cursor),
+			slog.String("error", err.Error()))
+	}
 }
 
 func (e *DeliveryEngine) routeRemoteBatch(ctx context.Context, nodeID string, deliveries []cluster.QueueDelivery) error {

--- a/queue/delivery_engine.go
+++ b/queue/delivery_engine.go
@@ -267,7 +267,7 @@ func (e *DeliveryEngine) deliverToGroup(ctx context.Context, config *types.Queue
 			if e.local == nil {
 				continue
 			}
-			if e.localClientDisconnected(consumerInfo.ClientID) {
+			if e.localDeliveryTargetMissing(consumerInfo.ClientID) {
 				e.unregisterConsumer(ctx, config.Name, group.ID, consumerID,
 					corebroker.ErrClientNotConnected)
 				continue
@@ -497,7 +497,11 @@ func (e *DeliveryEngine) isRemoteConsumer(consumerInfo *types.ConsumerInfo) bool
 	return e.remote != nil && consumerInfo.ProxyNodeID != "" && consumerInfo.ProxyNodeID != e.localNodeID
 }
 
-func (e *DeliveryEngine) localClientDisconnected(clientID string) bool {
+func (e *DeliveryEngine) localDeliveryTargetMissing(clientID string) bool {
+	targetChecker, ok := e.local.(ClientDeliveryTargetChecker)
+	if ok {
+		return !targetChecker.HasDeliveryTarget(clientID)
+	}
 	checker, ok := e.local.(ClientConnectionChecker)
 	return ok && !checker.IsClientConnected(clientID)
 }
@@ -560,8 +564,12 @@ func (e *DeliveryEngine) routeRemoteBatch(ctx context.Context, nodeID string, de
 		return nil
 	}
 	if batchRouter, ok := e.remote.(RemoteBatchRouter); ok {
-		if err := batchRouter.RouteQueueBatch(ctx, nodeID, deliveries); err == nil {
+		err := batchRouter.RouteQueueBatch(ctx, nodeID, deliveries)
+		if err == nil {
 			return nil
+		}
+		if corebroker.IsClientNotConnected(err) {
+			return err
 		}
 		// Fall back to single message RPC if batch routing fails.
 	}

--- a/queue/delivery_engine_test.go
+++ b/queue/delivery_engine_test.go
@@ -376,6 +376,7 @@ type routedEntry struct {
 
 type mockRemoteRouter struct {
 	mu        sync.Mutex
+	routeErr  error
 	consumers []*cluster.QueueConsumerInfo
 	routed    []routedEntry
 	removed   []routedEntry
@@ -403,7 +404,7 @@ func (r *mockRemoteRouter) RouteQueueMessage(ctx context.Context, nodeID, client
 		queueName: queueName,
 		msg:       msg,
 	})
-	return nil
+	return r.routeErr
 }
 
 func (r *mockRemoteRouter) UnregisterQueueConsumer(ctx context.Context, queueName, groupID, consumerID string) error {
@@ -857,6 +858,9 @@ func TestDeliverStreamRemovesConsumerOnClientNotConnectedError(t *testing.T) {
 
 func TestDeliverStreamRemovesRemoteConsumerOnBatchClientNotConnectedError(t *testing.T) {
 	remote := &batchRemoteRouter{
+		mockRemoteRouter: mockRemoteRouter{
+			routeErr: corebroker.ErrClientNotConnected,
+		},
 		batchErr: errors.New("route queue batch failed after 3 retries: 1 deliveries still failing: client remote-client queue events: client not connected"),
 	}
 
@@ -898,6 +902,52 @@ func TestDeliverStreamRemovesRemoteConsumerOnBatchClientNotConnectedError(t *tes
 	}
 	if len(remote.removed) != 1 {
 		t.Fatalf("expected remote unregister, got %d", len(remote.removed))
+	}
+}
+
+func TestDeliverStreamKeepsRemoteConsumerWhenCoalescedBatchErrorFallsBackSuccessfully(t *testing.T) {
+	remote := &batchRemoteRouter{
+		batchErr: errors.New("route queue batch failed after 3 retries: 1 deliveries still failing: client other-client queue events: client not connected"),
+	}
+
+	engine, logStore, groupStore := newTestEngine(t, nil, remote)
+	ctx := context.Background()
+
+	queueCfg := types.DefaultQueueConfig("events", "$queue/events/#")
+	queueCfg.Type = types.QueueTypeStream
+	logStore.CreateQueue(ctx, queueCfg) //nolint:errcheck // test setup
+
+	group := types.NewConsumerGroupState("events", "readers", "")
+	group.Mode = types.GroupModeStream
+	group.SetConsumer("remote-c1", &types.ConsumerInfo{
+		ID:          "remote-c1",
+		ClientID:    "remote-client",
+		ProxyNodeID: "node-2",
+	})
+	groupStore.CreateConsumerGroup(ctx, group) //nolint:errcheck // test setup
+
+	logStore.Append(ctx, "events", &types.Message{ //nolint:errcheck // test setup
+		ID:      "1",
+		Topic:   "$queue/events/new",
+		Payload: []byte("payload"),
+	})
+
+	if !engine.DeliverQueue(ctx, "events") {
+		t.Fatal("expected fallback delivery to succeed")
+	}
+
+	updated, err := groupStore.GetConsumerGroup(ctx, "events", "readers")
+	if err != nil {
+		t.Fatalf("get group failed: %v", err)
+	}
+	if updated.GetConsumer("remote-c1") == nil {
+		t.Fatal("expected remote consumer to remain registered")
+	}
+	if cursor := updated.GetCursor().Cursor; cursor != 1 {
+		t.Fatalf("expected cursor to advance to 1, got %d", cursor)
+	}
+	if len(remote.removed) != 0 {
+		t.Fatalf("expected no remote unregister, got %d", len(remote.removed))
 	}
 }
 

--- a/queue/delivery_engine_test.go
+++ b/queue/delivery_engine_test.go
@@ -5,6 +5,7 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"sync"
@@ -51,6 +52,7 @@ func newTestEngine(t *testing.T, local Deliverer, remote RemoteRouter) (*Deliver
 
 type checkingDeliverer struct {
 	mu         sync.Mutex
+	targets    map[string]bool
 	connected  map[string]bool
 	delivered  []*brokerstorage.Message
 	deliverErr error
@@ -65,6 +67,13 @@ func (d *checkingDeliverer) Deliver(ctx context.Context, clientID string, msg *b
 	defer d.mu.Unlock()
 	d.delivered = append(d.delivered, msg)
 	return nil
+}
+
+func (d *checkingDeliverer) HasDeliveryTarget(clientID string) bool {
+	if d.targets != nil {
+		return d.targets[clientID]
+	}
+	return d.IsClientConnected(clientID)
 }
 
 func (d *checkingDeliverer) IsClientConnected(clientID string) bool {
@@ -408,6 +417,25 @@ func (r *mockRemoteRouter) UnregisterQueueConsumer(ctx context.Context, queueNam
 	return nil
 }
 
+type batchRemoteRouter struct {
+	mockRemoteRouter
+	batchErr error
+}
+
+func (r *batchRemoteRouter) RouteQueueBatch(ctx context.Context, nodeID string, deliveries []cluster.QueueDelivery) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, delivery := range deliveries {
+		r.routed = append(r.routed, routedEntry{
+			nodeID:    nodeID,
+			clientID:  delivery.ClientID,
+			queueName: delivery.QueueName,
+			msg:       delivery.Message,
+		})
+	}
+	return r.batchErr
+}
+
 func TestDLQCallbackOnMaxDeliveryCount(t *testing.T) {
 	var mu sync.Mutex
 	var dlqCalls []struct {
@@ -664,9 +692,9 @@ func TestDeliverStreamSkipsExpiredMessages(t *testing.T) {
 	}
 }
 
-func TestDeliverStreamDoesNotAdvanceCursorForDisconnectedConsumer(t *testing.T) {
+func TestDeliverStreamDoesNotAdvanceCursorForMissingLocalTarget(t *testing.T) {
 	local := &checkingDeliverer{
-		connected: map[string]bool{"dead-client": false},
+		targets: map[string]bool{"dead-client": false},
 	}
 
 	engine, logStore, groupStore := newTestEngine(t, local, nil)
@@ -707,9 +735,49 @@ func TestDeliverStreamDoesNotAdvanceCursorForDisconnectedConsumer(t *testing.T) 
 	}
 }
 
+func TestDeliverStreamKeepsConsumerForQueueableOfflineTarget(t *testing.T) {
+	local := &checkingDeliverer{
+		targets:   map[string]bool{"offline-client": true},
+		connected: map[string]bool{"offline-client": false},
+	}
+
+	engine, logStore, groupStore := newTestEngine(t, local, nil)
+	ctx := context.Background()
+
+	queueCfg := types.DefaultQueueConfig("events", "$queue/events/#")
+	queueCfg.Type = types.QueueTypeStream
+	logStore.CreateQueue(ctx, queueCfg) //nolint:errcheck // test setup
+
+	group := types.NewConsumerGroupState("events", "readers", "")
+	group.Mode = types.GroupModeStream
+	group.SetConsumer("c1", &types.ConsumerInfo{ID: "c1", ClientID: "offline-client"})
+	groupStore.CreateConsumerGroup(ctx, group) //nolint:errcheck // test setup
+
+	logStore.Append(ctx, "events", &types.Message{ //nolint:errcheck // test setup
+		ID:      "1",
+		Topic:   "$queue/events/new",
+		Payload: []byte("payload"),
+	})
+
+	if !engine.DeliverQueue(ctx, "events") {
+		t.Fatal("expected delivery to queueable offline target")
+	}
+
+	updated, err := groupStore.GetConsumerGroup(ctx, "events", "readers")
+	if err != nil {
+		t.Fatalf("get group failed: %v", err)
+	}
+	if updated.GetConsumer("c1") == nil {
+		t.Fatal("expected queueable offline consumer to remain registered")
+	}
+	if cursor := updated.GetCursor().Cursor; cursor != 1 {
+		t.Fatalf("expected cursor to advance to 1, got %d", cursor)
+	}
+}
+
 func TestDeliverStreamCommitsCursorAfterSuccessfulDelivery(t *testing.T) {
 	local := &checkingDeliverer{
-		connected: map[string]bool{"client-1": true},
+		targets: map[string]bool{"client-1": true},
 	}
 
 	engine, logStore, groupStore := newTestEngine(t, local, nil)
@@ -749,7 +817,7 @@ func TestDeliverStreamCommitsCursorAfterSuccessfulDelivery(t *testing.T) {
 
 func TestDeliverStreamRemovesConsumerOnClientNotConnectedError(t *testing.T) {
 	local := &checkingDeliverer{
-		connected:  map[string]bool{"client-1": true},
+		targets:    map[string]bool{"client-1": true},
 		deliverErr: corebroker.ErrClientNotConnected,
 	}
 
@@ -784,6 +852,52 @@ func TestDeliverStreamRemovesConsumerOnClientNotConnectedError(t *testing.T) {
 	}
 	if cursor := updated.GetCursor().Cursor; cursor != 0 {
 		t.Fatalf("expected cursor to stay at 0, got %d", cursor)
+	}
+}
+
+func TestDeliverStreamRemovesRemoteConsumerOnBatchClientNotConnectedError(t *testing.T) {
+	remote := &batchRemoteRouter{
+		batchErr: errors.New("route queue batch failed after 3 retries: 1 deliveries still failing: client remote-client queue events: client not connected"),
+	}
+
+	engine, logStore, groupStore := newTestEngine(t, nil, remote)
+	ctx := context.Background()
+
+	queueCfg := types.DefaultQueueConfig("events", "$queue/events/#")
+	queueCfg.Type = types.QueueTypeStream
+	logStore.CreateQueue(ctx, queueCfg) //nolint:errcheck // test setup
+
+	group := types.NewConsumerGroupState("events", "readers", "")
+	group.Mode = types.GroupModeStream
+	group.SetConsumer("remote-c1", &types.ConsumerInfo{
+		ID:          "remote-c1",
+		ClientID:    "remote-client",
+		ProxyNodeID: "node-2",
+	})
+	groupStore.CreateConsumerGroup(ctx, group) //nolint:errcheck // test setup
+
+	logStore.Append(ctx, "events", &types.Message{ //nolint:errcheck // test setup
+		ID:      "1",
+		Topic:   "$queue/events/new",
+		Payload: []byte("payload"),
+	})
+
+	if engine.DeliverQueue(ctx, "events") {
+		t.Fatal("expected no successful delivery")
+	}
+
+	updated, err := groupStore.GetConsumerGroup(ctx, "events", "readers")
+	if err != nil {
+		t.Fatalf("get group failed: %v", err)
+	}
+	if updated.GetConsumer("remote-c1") != nil {
+		t.Fatal("expected stale remote consumer to be removed")
+	}
+	if cursor := updated.GetCursor().Cursor; cursor != 0 {
+		t.Fatalf("expected cursor to stay at 0, got %d", cursor)
+	}
+	if len(remote.removed) != 1 {
+		t.Fatalf("expected remote unregister, got %d", len(remote.removed))
 	}
 }
 

--- a/queue/delivery_engine_test.go
+++ b/queue/delivery_engine_test.go
@@ -20,6 +20,15 @@ import (
 	brokerstorage "github.com/absmach/fluxmq/storage"
 )
 
+const (
+	testRemoteConsumerID = "remote-c1"
+	testRemoteClientID   = "remote-client"
+	testEventsTopic      = "$queue/events/new"
+	testDeadClientID     = "dead-client"
+	testOfflineClientID  = "offline-client"
+	testClientOneID      = "client-1"
+)
+
 func newTestEngine(t *testing.T, local Deliverer, remote RemoteRouter) (*DeliveryEngine, *memlog.Store, *mockGroupStore) {
 	t.Helper()
 
@@ -237,9 +246,9 @@ func TestDeliverQueueRemoteConsumer(t *testing.T) {
 	mockRemote.consumers = []*cluster.QueueConsumerInfo{
 		{
 			QueueName:   "tasks",
-			GroupID:     testGroupWorkers,
-			ConsumerID:  "remote-c1",
-			ClientID:    "remote-client",
+			GroupID:     "workers",
+			ConsumerID:  testRemoteConsumerID,
+			ClientID:    testRemoteClientID,
 			Pattern:     "",
 			Mode:        string(types.GroupModeQueue),
 			ProxyNodeID: testNode2,
@@ -675,7 +684,7 @@ func TestDeliverStreamSkipsExpiredMessages(t *testing.T) {
 	})
 	logStore.Append(ctx, testQueueEvents, &types.Message{ //nolint:errcheck // test setup
 		ID:      "valid",
-		Topic:   "$queue/events/new",
+		Topic:   testEventsTopic,
 		Payload: []byte("fresh"),
 	})
 
@@ -695,7 +704,7 @@ func TestDeliverStreamSkipsExpiredMessages(t *testing.T) {
 
 func TestDeliverStreamDoesNotAdvanceCursorForMissingLocalTarget(t *testing.T) {
 	local := &checkingDeliverer{
-		targets: map[string]bool{"dead-client": false},
+		targets: map[string]bool{testDeadClientID: false},
 	}
 
 	engine, logStore, groupStore := newTestEngine(t, local, nil)
@@ -707,12 +716,12 @@ func TestDeliverStreamDoesNotAdvanceCursorForMissingLocalTarget(t *testing.T) {
 
 	group := types.NewConsumerGroupState("events", "readers", "")
 	group.Mode = types.GroupModeStream
-	group.SetConsumer("c1", &types.ConsumerInfo{ID: "c1", ClientID: "dead-client"})
+	group.SetConsumer("c1", &types.ConsumerInfo{ID: "c1", ClientID: testDeadClientID})
 	groupStore.CreateConsumerGroup(ctx, group) //nolint:errcheck // test setup
 
 	logStore.Append(ctx, "events", &types.Message{ //nolint:errcheck // test setup
 		ID:      "1",
-		Topic:   "$queue/events/new",
+		Topic:   testEventsTopic,
 		Payload: []byte("payload"),
 	})
 
@@ -738,8 +747,8 @@ func TestDeliverStreamDoesNotAdvanceCursorForMissingLocalTarget(t *testing.T) {
 
 func TestDeliverStreamKeepsConsumerForQueueableOfflineTarget(t *testing.T) {
 	local := &checkingDeliverer{
-		targets:   map[string]bool{"offline-client": true},
-		connected: map[string]bool{"offline-client": false},
+		targets:   map[string]bool{testOfflineClientID: true},
+		connected: map[string]bool{testOfflineClientID: false},
 	}
 
 	engine, logStore, groupStore := newTestEngine(t, local, nil)
@@ -751,12 +760,12 @@ func TestDeliverStreamKeepsConsumerForQueueableOfflineTarget(t *testing.T) {
 
 	group := types.NewConsumerGroupState("events", "readers", "")
 	group.Mode = types.GroupModeStream
-	group.SetConsumer("c1", &types.ConsumerInfo{ID: "c1", ClientID: "offline-client"})
+	group.SetConsumer("c1", &types.ConsumerInfo{ID: "c1", ClientID: testOfflineClientID})
 	groupStore.CreateConsumerGroup(ctx, group) //nolint:errcheck // test setup
 
 	logStore.Append(ctx, "events", &types.Message{ //nolint:errcheck // test setup
 		ID:      "1",
-		Topic:   "$queue/events/new",
+		Topic:   testEventsTopic,
 		Payload: []byte("payload"),
 	})
 
@@ -778,7 +787,7 @@ func TestDeliverStreamKeepsConsumerForQueueableOfflineTarget(t *testing.T) {
 
 func TestDeliverStreamCommitsCursorAfterSuccessfulDelivery(t *testing.T) {
 	local := &checkingDeliverer{
-		targets: map[string]bool{"client-1": true},
+		targets: map[string]bool{testClientOneID: true},
 	}
 
 	engine, logStore, groupStore := newTestEngine(t, local, nil)
@@ -790,12 +799,12 @@ func TestDeliverStreamCommitsCursorAfterSuccessfulDelivery(t *testing.T) {
 
 	group := types.NewConsumerGroupState("events", "readers", "")
 	group.Mode = types.GroupModeStream
-	group.SetConsumer("c1", &types.ConsumerInfo{ID: "c1", ClientID: "client-1"})
+	group.SetConsumer("c1", &types.ConsumerInfo{ID: "c1", ClientID: testClientOneID})
 	groupStore.CreateConsumerGroup(ctx, group) //nolint:errcheck // test setup
 
 	logStore.Append(ctx, "events", &types.Message{ //nolint:errcheck // test setup
 		ID:      "1",
-		Topic:   "$queue/events/new",
+		Topic:   testEventsTopic,
 		Payload: []byte("payload"),
 	})
 
@@ -818,7 +827,7 @@ func TestDeliverStreamCommitsCursorAfterSuccessfulDelivery(t *testing.T) {
 
 func TestDeliverStreamRemovesConsumerOnClientNotConnectedError(t *testing.T) {
 	local := &checkingDeliverer{
-		targets:    map[string]bool{"client-1": true},
+		targets:    map[string]bool{testClientOneID: true},
 		deliverErr: corebroker.ErrClientNotConnected,
 	}
 
@@ -831,12 +840,12 @@ func TestDeliverStreamRemovesConsumerOnClientNotConnectedError(t *testing.T) {
 
 	group := types.NewConsumerGroupState("events", "readers", "")
 	group.Mode = types.GroupModeStream
-	group.SetConsumer("c1", &types.ConsumerInfo{ID: "c1", ClientID: "client-1"})
+	group.SetConsumer("c1", &types.ConsumerInfo{ID: "c1", ClientID: testClientOneID})
 	groupStore.CreateConsumerGroup(ctx, group) //nolint:errcheck // test setup
 
 	logStore.Append(ctx, "events", &types.Message{ //nolint:errcheck // test setup
 		ID:      "1",
-		Topic:   "$queue/events/new",
+		Topic:   testEventsTopic,
 		Payload: []byte("payload"),
 	})
 
@@ -873,16 +882,16 @@ func TestDeliverStreamRemovesRemoteConsumerOnBatchClientNotConnectedError(t *tes
 
 	group := types.NewConsumerGroupState("events", "readers", "")
 	group.Mode = types.GroupModeStream
-	group.SetConsumer("remote-c1", &types.ConsumerInfo{
-		ID:          "remote-c1",
-		ClientID:    "remote-client",
+	group.SetConsumer(testRemoteConsumerID, &types.ConsumerInfo{
+		ID:          testRemoteConsumerID,
+		ClientID:    testRemoteClientID,
 		ProxyNodeID: "node-2",
 	})
 	groupStore.CreateConsumerGroup(ctx, group) //nolint:errcheck // test setup
 
 	logStore.Append(ctx, "events", &types.Message{ //nolint:errcheck // test setup
 		ID:      "1",
-		Topic:   "$queue/events/new",
+		Topic:   testEventsTopic,
 		Payload: []byte("payload"),
 	})
 
@@ -894,7 +903,7 @@ func TestDeliverStreamRemovesRemoteConsumerOnBatchClientNotConnectedError(t *tes
 	if err != nil {
 		t.Fatalf("get group failed: %v", err)
 	}
-	if updated.GetConsumer("remote-c1") != nil {
+	if updated.GetConsumer(testRemoteConsumerID) != nil {
 		t.Fatal("expected stale remote consumer to be removed")
 	}
 	if cursor := updated.GetCursor().Cursor; cursor != 0 {
@@ -919,16 +928,16 @@ func TestDeliverStreamKeepsRemoteConsumerWhenCoalescedBatchErrorFallsBackSuccess
 
 	group := types.NewConsumerGroupState("events", "readers", "")
 	group.Mode = types.GroupModeStream
-	group.SetConsumer("remote-c1", &types.ConsumerInfo{
-		ID:          "remote-c1",
-		ClientID:    "remote-client",
+	group.SetConsumer(testRemoteConsumerID, &types.ConsumerInfo{
+		ID:          testRemoteConsumerID,
+		ClientID:    testRemoteClientID,
 		ProxyNodeID: "node-2",
 	})
 	groupStore.CreateConsumerGroup(ctx, group) //nolint:errcheck // test setup
 
 	logStore.Append(ctx, "events", &types.Message{ //nolint:errcheck // test setup
 		ID:      "1",
-		Topic:   "$queue/events/new",
+		Topic:   testEventsTopic,
 		Payload: []byte("payload"),
 	})
 
@@ -940,7 +949,7 @@ func TestDeliverStreamKeepsRemoteConsumerWhenCoalescedBatchErrorFallsBackSuccess
 	if err != nil {
 		t.Fatalf("get group failed: %v", err)
 	}
-	if updated.GetConsumer("remote-c1") == nil {
+	if updated.GetConsumer(testRemoteConsumerID) == nil {
 		t.Fatal("expected remote consumer to remain registered")
 	}
 	if cursor := updated.GetCursor().Cursor; cursor != 1 {

--- a/queue/delivery_engine_test.go
+++ b/queue/delivery_engine_test.go
@@ -6,6 +6,7 @@ package queue
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"sync"
@@ -870,7 +871,7 @@ func TestDeliverStreamRemovesRemoteConsumerOnBatchClientNotConnectedError(t *tes
 		mockRemoteRouter: mockRemoteRouter{
 			routeErr: corebroker.ErrClientNotConnected,
 		},
-		batchErr: errors.New("route queue batch failed after 3 retries: 1 deliveries still failing: client remote-client queue events: client not connected"),
+		batchErr: fmt.Errorf("%w: route queue batch failed after 3 retries: client remote-client queue events", corebroker.ErrClientNotConnected),
 	}
 
 	engine, logStore, groupStore := newTestEngine(t, nil, remote)
@@ -916,7 +917,9 @@ func TestDeliverStreamRemovesRemoteConsumerOnBatchClientNotConnectedError(t *tes
 
 func TestDeliverStreamKeepsRemoteConsumerWhenCoalescedBatchErrorFallsBackSuccessfully(t *testing.T) {
 	remote := &batchRemoteRouter{
-		batchErr: errors.New("route queue batch failed after 3 retries: 1 deliveries still failing: client other-client queue events: client not connected"),
+		// Batch fails for a coalesced peer, but the single-RPC fallback for this
+		// consumer succeeds, so the consumer must survive regardless of the cause.
+		batchErr: errors.New("coalesced route queue batch failure"),
 	}
 
 	engine, logStore, groupStore := newTestEngine(t, nil, remote)

--- a/queue/delivery_engine_test.go
+++ b/queue/delivery_engine_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	corebroker "github.com/absmach/fluxmq/broker"
 	"github.com/absmach/fluxmq/cluster"
 	"github.com/absmach/fluxmq/queue/consumer"
 	memlog "github.com/absmach/fluxmq/queue/storage/memory/log"
@@ -46,6 +47,39 @@ func newTestEngine(t *testing.T, local Deliverer, remote RemoteRouter) (*Deliver
 	)
 
 	return engine, logStore, groupStore
+}
+
+type checkingDeliverer struct {
+	mu         sync.Mutex
+	connected  map[string]bool
+	delivered  []*brokerstorage.Message
+	deliverErr error
+}
+
+func (d *checkingDeliverer) Deliver(ctx context.Context, clientID string, msg *brokerstorage.Message) error {
+	if d.deliverErr != nil {
+		return d.deliverErr
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.delivered = append(d.delivered, msg)
+	return nil
+}
+
+func (d *checkingDeliverer) IsClientConnected(clientID string) bool {
+	if d.connected == nil {
+		return true
+	}
+	return d.connected[clientID]
+}
+
+func (d *checkingDeliverer) deliveredMessages() []*brokerstorage.Message {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	result := make([]*brokerstorage.Message, len(d.delivered))
+	copy(result, d.delivered)
+	return result
 }
 
 func TestScheduleDedup(t *testing.T) {
@@ -335,6 +369,7 @@ type mockRemoteRouter struct {
 	mu        sync.Mutex
 	consumers []*cluster.QueueConsumerInfo
 	routed    []routedEntry
+	removed   []routedEntry
 }
 
 func (r *mockRemoteRouter) ListQueueConsumers(ctx context.Context, queueName string) ([]*cluster.QueueConsumerInfo, error) {
@@ -358,6 +393,17 @@ func (r *mockRemoteRouter) RouteQueueMessage(ctx context.Context, nodeID, client
 		clientID:  clientID,
 		queueName: queueName,
 		msg:       msg,
+	})
+	return nil
+}
+
+func (r *mockRemoteRouter) UnregisterQueueConsumer(ctx context.Context, queueName, groupID, consumerID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.removed = append(r.removed, routedEntry{
+		nodeID:    groupID,
+		clientID:  consumerID,
+		queueName: queueName,
 	})
 	return nil
 }
@@ -615,6 +661,129 @@ func TestDeliverStreamSkipsExpiredMessages(t *testing.T) {
 	}
 	if string(delivered[0].GetPayload()) != "fresh" {
 		t.Fatalf("expected fresh payload, got %s", string(delivered[0].GetPayload()))
+	}
+}
+
+func TestDeliverStreamDoesNotAdvanceCursorForDisconnectedConsumer(t *testing.T) {
+	local := &checkingDeliverer{
+		connected: map[string]bool{"dead-client": false},
+	}
+
+	engine, logStore, groupStore := newTestEngine(t, local, nil)
+	ctx := context.Background()
+
+	queueCfg := types.DefaultQueueConfig("events", "$queue/events/#")
+	queueCfg.Type = types.QueueTypeStream
+	logStore.CreateQueue(ctx, queueCfg) //nolint:errcheck // test setup
+
+	group := types.NewConsumerGroupState("events", "readers", "")
+	group.Mode = types.GroupModeStream
+	group.SetConsumer("c1", &types.ConsumerInfo{ID: "c1", ClientID: "dead-client"})
+	groupStore.CreateConsumerGroup(ctx, group) //nolint:errcheck // test setup
+
+	logStore.Append(ctx, "events", &types.Message{ //nolint:errcheck // test setup
+		ID:      "1",
+		Topic:   "$queue/events/new",
+		Payload: []byte("payload"),
+	})
+
+	if engine.DeliverQueue(ctx, "events") {
+		t.Fatal("expected no delivery for disconnected consumer")
+	}
+
+	if got := len(local.deliveredMessages()); got != 0 {
+		t.Fatalf("expected 0 deliveries, got %d", got)
+	}
+
+	updated, err := groupStore.GetConsumerGroup(ctx, "events", "readers")
+	if err != nil {
+		t.Fatalf("get group failed: %v", err)
+	}
+	if updated.GetConsumer("c1") != nil {
+		t.Fatal("expected disconnected consumer to be removed")
+	}
+	if cursor := updated.GetCursor().Cursor; cursor != 0 {
+		t.Fatalf("expected cursor to stay at 0, got %d", cursor)
+	}
+}
+
+func TestDeliverStreamCommitsCursorAfterSuccessfulDelivery(t *testing.T) {
+	local := &checkingDeliverer{
+		connected: map[string]bool{"client-1": true},
+	}
+
+	engine, logStore, groupStore := newTestEngine(t, local, nil)
+	ctx := context.Background()
+
+	queueCfg := types.DefaultQueueConfig("events", "$queue/events/#")
+	queueCfg.Type = types.QueueTypeStream
+	logStore.CreateQueue(ctx, queueCfg) //nolint:errcheck // test setup
+
+	group := types.NewConsumerGroupState("events", "readers", "")
+	group.Mode = types.GroupModeStream
+	group.SetConsumer("c1", &types.ConsumerInfo{ID: "c1", ClientID: "client-1"})
+	groupStore.CreateConsumerGroup(ctx, group) //nolint:errcheck // test setup
+
+	logStore.Append(ctx, "events", &types.Message{ //nolint:errcheck // test setup
+		ID:      "1",
+		Topic:   "$queue/events/new",
+		Payload: []byte("payload"),
+	})
+
+	if !engine.DeliverQueue(ctx, "events") {
+		t.Fatal("expected successful delivery")
+	}
+
+	if got := len(local.deliveredMessages()); got != 1 {
+		t.Fatalf("expected 1 delivery, got %d", got)
+	}
+
+	updated, err := groupStore.GetConsumerGroup(ctx, "events", "readers")
+	if err != nil {
+		t.Fatalf("get group failed: %v", err)
+	}
+	if cursor := updated.GetCursor().Cursor; cursor != 1 {
+		t.Fatalf("expected cursor to advance to 1, got %d", cursor)
+	}
+}
+
+func TestDeliverStreamRemovesConsumerOnClientNotConnectedError(t *testing.T) {
+	local := &checkingDeliverer{
+		connected:  map[string]bool{"client-1": true},
+		deliverErr: corebroker.ErrClientNotConnected,
+	}
+
+	engine, logStore, groupStore := newTestEngine(t, local, nil)
+	ctx := context.Background()
+
+	queueCfg := types.DefaultQueueConfig("events", "$queue/events/#")
+	queueCfg.Type = types.QueueTypeStream
+	logStore.CreateQueue(ctx, queueCfg) //nolint:errcheck // test setup
+
+	group := types.NewConsumerGroupState("events", "readers", "")
+	group.Mode = types.GroupModeStream
+	group.SetConsumer("c1", &types.ConsumerInfo{ID: "c1", ClientID: "client-1"})
+	groupStore.CreateConsumerGroup(ctx, group) //nolint:errcheck // test setup
+
+	logStore.Append(ctx, "events", &types.Message{ //nolint:errcheck // test setup
+		ID:      "1",
+		Topic:   "$queue/events/new",
+		Payload: []byte("payload"),
+	})
+
+	if engine.DeliverQueue(ctx, "events") {
+		t.Fatal("expected no successful delivery")
+	}
+
+	updated, err := groupStore.GetConsumerGroup(ctx, "events", "readers")
+	if err != nil {
+		t.Fatalf("get group failed: %v", err)
+	}
+	if updated.GetConsumer("c1") != nil {
+		t.Fatal("expected stale consumer to be removed")
+	}
+	if cursor := updated.GetCursor().Cursor; cursor != 0 {
+		t.Fatalf("expected cursor to stay at 0, got %d", cursor)
 	}
 }
 

--- a/queue/manager.go
+++ b/queue/manager.go
@@ -200,6 +200,11 @@ func NewManager(queueStore storage.QueueStore, groupStore storage.ConsumerGroupS
 		config.DeliveryBatchSize,
 		logger,
 	)
+	engine.setConsumerRemovedCallback(func(ctx context.Context, queueName, groupID string, consumerIDs []string) {
+		if mgr != nil {
+			mgr.handleConsumersRemoved(ctx, queueName, groupID, consumerIDs)
+		}
+	})
 
 	mgr = &Manager{
 		queueStore:      queueStore,
@@ -1507,12 +1512,23 @@ func (m *Manager) cleanupStaleConsumers() {
 					slog.Int("count", len(removed)),
 					slog.String("queue", queueConfig.Name),
 					slog.String("group", group.ID))
-				if m.config.OnConsumerRemoved != nil {
-					m.config.OnConsumerRemoved(queueConfig.Name, group.ID, removed)
-				}
+				m.handleConsumersRemoved(ctx, queueConfig.Name, group.ID, removed)
 			}
 		}
 	}
+}
+
+func (m *Manager) handleConsumersRemoved(ctx context.Context, queueName, groupID string, consumerIDs []string) {
+	if len(consumerIDs) == 0 {
+		return
+	}
+	for _, consumerID := range consumerIDs {
+		m.untrackSubscription(consumerID, queueName, groupID)
+	}
+	if m.config.OnConsumerRemoved != nil {
+		m.config.OnConsumerRemoved(queueName, groupID, append([]string(nil), consumerIDs...))
+	}
+	m.checkEphemeralDisconnect(ctx, queueName)
 }
 
 func (m *Manager) runRetentionLoop() {

--- a/queue/manager_test.go
+++ b/queue/manager_test.go
@@ -368,7 +368,7 @@ func TestStreamGroupDeliversWithoutPEL(t *testing.T) {
 	}
 
 	cursor := &types.CursorOption{Position: types.CursorEarliest, Mode: types.GroupModeStream}
-	if err := mgr.SubscribeWithCursor(context.Background(), testQueueEvents, "", "client-1", "streamer", "", cursor); err != nil {
+	if err := mgr.SubscribeWithCursor(context.Background(), testQueueEvents, "", testClientOneID, "streamer", "", cursor); err != nil {
 		t.Fatalf("SubscribeWithCursor failed: %v", err)
 	}
 
@@ -420,7 +420,7 @@ func TestPublishNormalizesClientIDProperty(t *testing.T) {
 	if err := mgr.CreateQueue(ctx, types.DefaultQueueConfig("orders", "$queue/orders/#")); err != nil {
 		t.Fatalf("CreateQueue failed: %v", err)
 	}
-	if err := mgr.Subscribe(ctx, "orders", "", "client-1", testGroupWorkers, ""); err != nil {
+	if err := mgr.Subscribe(ctx, "orders", "", testClientOneID, testGroupWorkers, ""); err != nil {
 		t.Fatalf("Subscribe failed: %v", err)
 	}
 
@@ -494,7 +494,7 @@ func TestStreamRejectAdvancesCursor(t *testing.T) {
 	}
 
 	cursor := &types.CursorOption{Position: types.CursorEarliest, Mode: types.GroupModeStream}
-	if err := mgr.SubscribeWithCursor(context.Background(), testQueueEvents, "", "client-1", "streamer", "", cursor); err != nil {
+	if err := mgr.SubscribeWithCursor(context.Background(), testQueueEvents, "", testClientOneID, "streamer", "", cursor); err != nil {
 		t.Fatalf("SubscribeWithCursor failed: %v", err)
 	}
 
@@ -1142,7 +1142,7 @@ func TestCrossNodeMessageRouting(t *testing.T) {
 		t.Fatalf("Subscribe local client failed: %v", err)
 	}
 
-	remoteClientID := "remote-client"
+	remoteClientID := testRemoteClientID
 	if err := manager.Subscribe(ctx, testQueueTest, "#", remoteClientID, "", remoteNodeID); err != nil {
 		t.Fatalf("Subscribe remote client failed: %v", err)
 	}
@@ -1228,7 +1228,7 @@ func TestRemoteRoutingIncludesAckMetadata(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	if err := manager.Subscribe(ctx, "tasks", "", "remote-client", testGroupWorkers, testNode2); err != nil {
+	if err := manager.Subscribe(ctx, "tasks", "", testRemoteClientID, testGroupWorkers, testNode2); err != nil {
 		t.Fatalf("Subscribe failed: %v", err)
 	}
 
@@ -1398,7 +1398,7 @@ func TestSubscribeWithCursorStreamDefaultResumesStoredCursor(t *testing.T) {
 		Position: types.CursorDefault,
 		Mode:     types.GroupModeStream,
 	}
-	if err := manager.SubscribeWithCursor(context.Background(), testQueueEvents, "", "client-1", "streamers", "", cursor); err != nil {
+	if err := manager.SubscribeWithCursor(context.Background(), testQueueEvents, "", testClientOneID, "streamers", "", cursor); err != nil {
 		t.Fatalf("SubscribeWithCursor failed: %v", err)
 	}
 
@@ -1554,7 +1554,7 @@ func TestSubscribeWithCursorReplicatedQueueRoutesStateThroughCoordinator(t *test
 		Position: types.CursorEarliest,
 		Mode:     types.GroupModeStream,
 	}
-	if err := manager.SubscribeWithCursor(ctx, "orders", "#", "client-1", "", "", cursor); err != nil {
+	if err := manager.SubscribeWithCursor(ctx, "orders", "#", testClientOneID, "", "", cursor); err != nil {
 		t.Fatalf("SubscribeWithCursor failed: %v", err)
 	}
 
@@ -1969,7 +1969,7 @@ func TestDeliveryStaleConsumerStartsEphemeralExpiry(t *testing.T) {
 	manager := NewManager(
 		logStore,
 		groupStore,
-		&targetCheckingDeliverer{targets: map[string]bool{"dead-client": false}},
+		&targetCheckingDeliverer{targets: map[string]bool{testDeadClientID: false}},
 		config,
 		slog.New(slog.NewTextHandler(io.Discard, nil)),
 		nil,
@@ -1982,7 +1982,7 @@ func TestDeliveryStaleConsumerStartsEphemeralExpiry(t *testing.T) {
 	}
 
 	group := types.NewConsumerGroupState("ephemeral-events", "readers", "")
-	group.SetConsumer("dead-client", &types.ConsumerInfo{ID: "dead-client", ClientID: "dead-client"})
+	group.SetConsumer(testDeadClientID, &types.ConsumerInfo{ID: testDeadClientID, ClientID: testDeadClientID})
 	if err := groupStore.CreateConsumerGroup(ctx, group); err != nil {
 		t.Fatalf("CreateConsumerGroup failed: %v", err)
 	}
@@ -2004,7 +2004,7 @@ func TestDeliveryStaleConsumerStartsEphemeralExpiry(t *testing.T) {
 	if gotGroup != "readers" {
 		t.Fatalf("expected callback group readers, got %q", gotGroup)
 	}
-	if len(gotConsumerIDs) != 1 || gotConsumerIDs[0] != "dead-client" {
+	if len(gotConsumerIDs) != 1 || gotConsumerIDs[0] != testDeadClientID {
 		t.Fatalf("expected callback consumers [dead-client], got %v", gotConsumerIDs)
 	}
 }
@@ -2037,8 +2037,8 @@ func TestCleanupStaleConsumersStartsEphemeralExpiry(t *testing.T) {
 
 	staleTime := time.Now().Add(-time.Hour)
 	info := &types.ConsumerInfo{
-		ID:            "dead-client",
-		ClientID:      "dead-client",
+		ID:            testDeadClientID,
+		ClientID:      testDeadClientID,
 		RegisteredAt:  staleTime,
 		LastHeartbeat: staleTime,
 	}
@@ -2162,22 +2162,22 @@ func TestSubscriptionTrackingReferenceCounts(t *testing.T) {
 		nil,
 	)
 
-	manager.trackSubscription("client-1", "orders", "workers@#")
-	manager.trackSubscription("client-1", "orders", "workers@#")
+	manager.trackSubscription(testClientOneID, "orders", "workers@#")
+	manager.trackSubscription(testClientOneID, "orders", "workers@#")
 
-	targets := manager.getSubscriptionTargets("client-1")
+	targets := manager.getSubscriptionTargets(testClientOneID)
 	if len(targets) != 1 {
 		t.Fatalf("expected 1 tracked target after duplicate subscriptions, got %d", len(targets))
 	}
 
-	manager.untrackSubscription("client-1", "orders", "workers@#")
-	targets = manager.getSubscriptionTargets("client-1")
+	manager.untrackSubscription(testClientOneID, "orders", "workers@#")
+	targets = manager.getSubscriptionTargets(testClientOneID)
 	if len(targets) != 1 {
 		t.Fatalf("expected tracked target to remain after first untrack, got %d", len(targets))
 	}
 
-	manager.untrackSubscription("client-1", "orders", "workers@#")
-	targets = manager.getSubscriptionTargets("client-1")
+	manager.untrackSubscription(testClientOneID, "orders", "workers@#")
+	targets = manager.getSubscriptionTargets(testClientOneID)
 	if len(targets) != 0 {
 		t.Fatalf("expected no tracked targets after reference count reaches zero, got %d", len(targets))
 	}
@@ -2196,16 +2196,16 @@ func TestSubscriptionTrackingPrunesStaleEntries(t *testing.T) {
 		nil,
 	)
 
-	manager.trackSubscription("client-1", "orders", "workers@#")
+	manager.trackSubscription(testClientOneID, "orders", "workers@#")
 
 	key := manager.subscriptionRefKey("orders", "workers@#")
 	manager.subscriptionsMu.Lock()
-	manager.subscriptions["client-1"][key].lastSeen = time.Now().Add(-time.Minute)
+	manager.subscriptions[testClientOneID][key].lastSeen = time.Now().Add(-time.Minute)
 	manager.subscriptionsMu.Unlock()
 
 	manager.pruneStaleSubscriptions()
 
-	targets := manager.getSubscriptionTargets("client-1")
+	targets := manager.getSubscriptionTargets(testClientOneID)
 	if len(targets) != 0 {
 		t.Fatalf("expected stale tracked target to be pruned, got %d entries", len(targets))
 	}
@@ -2221,13 +2221,13 @@ func TestUpdateHeartbeatRemovesStaleTrackedTargets(t *testing.T) {
 		nil,
 	)
 
-	manager.trackSubscription("client-1", "orders", "workers@#")
+	manager.trackSubscription(testClientOneID, "orders", "workers@#")
 
-	if err := manager.UpdateHeartbeat(context.Background(), "client-1"); err != nil {
+	if err := manager.UpdateHeartbeat(context.Background(), testClientOneID); err != nil {
 		t.Fatalf("UpdateHeartbeat failed: %v", err)
 	}
 
-	targets := manager.getSubscriptionTargets("client-1")
+	targets := manager.getSubscriptionTargets(testClientOneID)
 	if len(targets) != 0 {
 		t.Fatalf("expected stale tracked target to be removed after heartbeat update, got %d entries", len(targets))
 	}

--- a/queue/manager_test.go
+++ b/queue/manager_test.go
@@ -25,6 +25,18 @@ import (
 
 const node1 = "node-1"
 
+type targetCheckingDeliverer struct {
+	targets map[string]bool
+}
+
+func (d *targetCheckingDeliverer) Deliver(context.Context, string, *brokerstorage.Message) error {
+	return nil
+}
+
+func (d *targetCheckingDeliverer) HasDeliveryTarget(clientID string) bool {
+	return d.targets[clientID]
+}
+
 // mockGroupStore implements storage.ConsumerGroupStore for testing.
 type mockGroupStore struct {
 	mu     sync.RWMutex
@@ -1937,6 +1949,111 @@ func TestEphemeralQueue_DisconnectAndCleanup(t *testing.T) {
 	}
 	if !cfg.LastConsumerDisconnect.IsZero() {
 		t.Error("Expected LastConsumerDisconnect to be cleared after new consumer subscribes")
+	}
+}
+
+func TestDeliveryStaleConsumerStartsEphemeralExpiry(t *testing.T) {
+	logStore := memlog.New()
+	groupStore := newMockGroupStore()
+
+	var gotQueue, gotGroup string
+	var gotConsumerIDs []string
+
+	config := DefaultConfig()
+	config.OnConsumerRemoved = func(queueName, groupID string, consumerIDs []string) {
+		gotQueue = queueName
+		gotGroup = groupID
+		gotConsumerIDs = consumerIDs
+	}
+
+	manager := NewManager(
+		logStore,
+		groupStore,
+		&targetCheckingDeliverer{targets: map[string]bool{"dead-client": false}},
+		config,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		nil,
+	)
+	ctx := context.Background()
+
+	queueCfg := types.DefaultEphemeralQueueConfig("ephemeral-events", "$queue/ephemeral-events/#")
+	if err := manager.CreateQueue(ctx, queueCfg); err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+
+	group := types.NewConsumerGroupState("ephemeral-events", "readers", "")
+	group.SetConsumer("dead-client", &types.ConsumerInfo{ID: "dead-client", ClientID: "dead-client"})
+	if err := groupStore.CreateConsumerGroup(ctx, group); err != nil {
+		t.Fatalf("CreateConsumerGroup failed: %v", err)
+	}
+
+	if manager.deliverQueue(ctx, "ephemeral-events") {
+		t.Fatal("expected no delivery for missing target")
+	}
+
+	cfg, err := logStore.GetQueue(ctx, "ephemeral-events")
+	if err != nil {
+		t.Fatalf("GetQueue failed: %v", err)
+	}
+	if cfg.LastConsumerDisconnect.IsZero() {
+		t.Fatal("expected LastConsumerDisconnect to be set after delivery removed last stale consumer")
+	}
+	if gotQueue != "ephemeral-events" {
+		t.Fatalf("expected callback queue ephemeral-events, got %q", gotQueue)
+	}
+	if gotGroup != "readers" {
+		t.Fatalf("expected callback group readers, got %q", gotGroup)
+	}
+	if len(gotConsumerIDs) != 1 || gotConsumerIDs[0] != "dead-client" {
+		t.Fatalf("expected callback consumers [dead-client], got %v", gotConsumerIDs)
+	}
+}
+
+func TestCleanupStaleConsumersStartsEphemeralExpiry(t *testing.T) {
+	logStore := memlog.New()
+	groupStore := newMockGroupStore()
+
+	config := DefaultConfig()
+	config.ConsumerTimeout = time.Millisecond
+	manager := NewManager(
+		logStore,
+		groupStore,
+		DeliveryTargetFunc(func(context.Context, string, *brokerstorage.Message) error { return nil }),
+		config,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		nil,
+	)
+	ctx := context.Background()
+
+	queueCfg := types.DefaultEphemeralQueueConfig("ephemeral-events", "$queue/ephemeral-events/#")
+	if err := manager.CreateQueue(ctx, queueCfg); err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+
+	group := types.NewConsumerGroupState("ephemeral-events", "readers", "")
+	if err := groupStore.CreateConsumerGroup(ctx, group); err != nil {
+		t.Fatalf("CreateConsumerGroup failed: %v", err)
+	}
+
+	staleTime := time.Now().Add(-time.Hour)
+	info := &types.ConsumerInfo{
+		ID:            "dead-client",
+		ClientID:      "dead-client",
+		RegisteredAt:  staleTime,
+		LastHeartbeat: staleTime,
+	}
+	if err := groupStore.RegisterConsumer(ctx, "ephemeral-events", "readers", info); err != nil {
+		t.Fatalf("RegisterConsumer failed: %v", err)
+	}
+
+	manager.cleanupStaleConsumers()
+
+	cfg, err := logStore.GetQueue(ctx, "ephemeral-events")
+	if err != nil {
+		t.Fatalf("GetQueue failed: %v", err)
+	}
+	if cfg.LastConsumerDisconnect.IsZero() {
+		t.Fatal("expected LastConsumerDisconnect to be set after heartbeat cleanup removed last stale consumer")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add a shared `ErrClientNotConnected` signal and connection checks for MQTT, AMQP 1.0, and AMQP 0.9.1 delivery targets.
- Change stream queue delivery to peek messages first and commit the stream cursor only after successful local or remote delivery.
- Remove stale queue consumers when their backing protocol client is disconnected or returns a not-connected delivery error.
- Add regression tests for disconnected stream consumers, successful cursor commits, and stale-consumer cleanup.

## Root Cause

Stream consumer delivery advanced the consumer-group cursor while claiming messages, before the delivery target had been verified or delivery had succeeded. A stale AMQP/MQTT queue consumer could therefore consume cursor progress without receiving messages, causing stream delivery to stall or skip work for live consumers.

## Impact

Queue stream cursors now advance only after confirmed delivery. Disconnected local and remote consumers are removed from the group so stale registrations do not keep blocking queue delivery.

## Validation

- `go test ./queue ./mqtt/broker ./amqp/broker ./amqp1/broker ./cmd`