### PR TITLE
Fix local session takeover on persistent-session reconnect

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -317,6 +317,11 @@ type AMQP091Config struct {
 	MTLS  AMQP091ListenerConfig `yaml:"mtls"`
 }
 
+// DefaultMaxInflightMessages is the fallback for Session.MaxInflightMessages
+// when it is unset (<= 0). Shared by the broker and the session so the
+// send-quota clamp is consistent across the first CONNECT.
+const DefaultMaxInflightMessages = 256
+
 // InflightOverflowMode controls what happens when a session's inflight window is full.
 type InflightOverflowMode int
 

--- a/mqtt/broker/broker_test.go
+++ b/mqtt/broker/broker_test.go
@@ -102,8 +102,8 @@ func TestBroker_HandleV5Connect(t *testing.T) {
 		KeepAlive:       60,
 	}
 
-	t.Log("Calling HandleConnect via V5Handler")
-	handler := NewV5Handler(b)
+	t.Log("Calling HandleConnect via v5Handler")
+	handler := newV5Handler(b)
 	err := handler.HandleConnect(conn, connect)
 	t.Logf("HandleConnect returned: %v", err)
 

--- a/mqtt/broker/conn_context.go
+++ b/mqtt/broker/conn_context.go
@@ -72,3 +72,11 @@ func (c *connCtx) ProcessRetries() {
 func (c *connCtx) Disconnect(graceful bool) error {
 	return c.Session.DisconnectIf(graceful, c.epoch)
 }
+
+// current reports whether this is still the active connection generation. A
+// superseded goroutine reads and writes its own closed socket, so its read and
+// dispatch failures are expected teardown — not packet or protocol errors —
+// and must not be counted as such.
+func (c *connCtx) current() bool {
+	return c.Session.Epoch() == c.epoch
+}

--- a/mqtt/broker/conn_context.go
+++ b/mqtt/broker/conn_context.go
@@ -36,27 +36,6 @@ func (c *connCtx) WritePacket(pkt packets.ControlPacket) error {
 	return c.conn.WritePacket(pkt)
 }
 
-func (c *connCtx) WriteControlPacket(pkt packets.ControlPacket, onSent func()) error {
-	if c.conn == nil {
-		return session.ErrNotConnected
-	}
-	return c.conn.WriteControlPacket(pkt, onSent)
-}
-
-func (c *connCtx) WriteDataPacket(pkt packets.ControlPacket, onSent func()) error {
-	if c.conn == nil {
-		return session.ErrNotConnected
-	}
-	return c.conn.WriteDataPacket(pkt, onSent)
-}
-
-func (c *connCtx) TryWriteDataPacket(pkt packets.ControlPacket, onSent func()) error {
-	if c.conn == nil {
-		return session.ErrNotConnected
-	}
-	return c.conn.TryWriteDataPacket(pkt, onSent)
-}
-
 // ProcessRetries resends due inflight messages on the bound connection rather
 // than the session's current connection, so a superseded goroutine cannot
 // redeliver onto the replacement.

--- a/mqtt/broker/conn_context.go
+++ b/mqtt/broker/conn_context.go
@@ -64,7 +64,7 @@ func (c *connCtx) ProcessRetries() {
 	if c.conn == nil {
 		return
 	}
-	c.Session.ProcessRetriesTo(c.conn)
+	c.Session.ProcessRetriesTo(c.conn, c.epoch)
 }
 
 // Disconnect tears down only if this is still the current connection

--- a/mqtt/broker/conn_context.go
+++ b/mqtt/broker/conn_context.go
@@ -1,0 +1,74 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	core "github.com/absmach/fluxmq/mqtt"
+	"github.com/absmach/fluxmq/mqtt/packets"
+	"github.com/absmach/fluxmq/mqtt/session"
+)
+
+// connCtx binds a session to the specific connection generation a runSession
+// goroutine owns. All client-response writes target that connection and
+// teardown is scoped to its epoch.
+//
+// This is what makes a local session takeover generation-safe without holding
+// a lock across handler work: once a connection has been superseded, conn is
+// the closed old socket and epoch is stale, so a leftover goroutine's writes
+// fail harmlessly and its Disconnect is a no-op. It can neither write to nor
+// disconnect the replacement connection, and because no lock is held across a
+// handler, a write that blocks on a stalled old connection never stalls the
+// takeover.
+//
+// connCtx embeds *session.Session, so handlers transparently see the full
+// session API; only the connection-bound operations are overridden here.
+type connCtx struct {
+	*session.Session
+	conn  core.Connection
+	epoch uint64
+}
+
+func (c *connCtx) WritePacket(pkt packets.ControlPacket) error {
+	if c.conn == nil {
+		return session.ErrNotConnected
+	}
+	return c.conn.WritePacket(pkt)
+}
+
+func (c *connCtx) WriteControlPacket(pkt packets.ControlPacket, onSent func()) error {
+	if c.conn == nil {
+		return session.ErrNotConnected
+	}
+	return c.conn.WriteControlPacket(pkt, onSent)
+}
+
+func (c *connCtx) WriteDataPacket(pkt packets.ControlPacket, onSent func()) error {
+	if c.conn == nil {
+		return session.ErrNotConnected
+	}
+	return c.conn.WriteDataPacket(pkt, onSent)
+}
+
+func (c *connCtx) TryWriteDataPacket(pkt packets.ControlPacket, onSent func()) error {
+	if c.conn == nil {
+		return session.ErrNotConnected
+	}
+	return c.conn.TryWriteDataPacket(pkt, onSent)
+}
+
+// ProcessRetries resends due inflight messages on the bound connection rather
+// than the session's current connection, so a superseded goroutine cannot
+// redeliver onto the replacement.
+func (c *connCtx) ProcessRetries() {
+	if c.conn == nil {
+		return
+	}
+	c.Session.ProcessRetriesTo(c.conn)
+}
+
+// Disconnect tears down only if this is still the current connection
+// generation, so a stale DISCONNECT cannot close the replacement connection.
+func (c *connCtx) Disconnect(graceful bool) error {
+	return c.Session.DisconnectIf(graceful, c.epoch)
+}

--- a/mqtt/broker/connection.go
+++ b/mqtt/broker/connection.go
@@ -36,7 +36,7 @@ func HandleConnection(ctx context.Context, broker *Broker, conn core.Connection)
 			conn.Close()
 			return
 		}
-		handler := NewV3Handler(broker)
+		handler := newV3Handler(broker)
 		handler.HandleConnect(conn, p3) //nolint:errcheck,contextcheck // handler manages connection lifecycle; disconnect cleanup uses background context
 		return
 	}
@@ -49,7 +49,7 @@ func HandleConnection(ctx context.Context, broker *Broker, conn core.Connection)
 			conn.Close()
 			return
 		}
-		handler := NewV5Handler(broker)
+		handler := newV5Handler(broker)
 		handler.HandleConnect(conn, p5) //nolint:errcheck,contextcheck // handler manages connection lifecycle; disconnect cleanup uses background context
 		return
 	}

--- a/mqtt/broker/delivery.go
+++ b/mqtt/broker/delivery.go
@@ -51,42 +51,44 @@ func (b *Broker) DeliverToSession(ctx context.Context, s *session.Session, msg *
 		return 0, nil
 	}
 
-	// Capture the target connection and its generation as a delivery lease. The
-	// quota is acquired for this generation and the PUBLISH is written to this
-	// connection, so a takeover landing mid-delivery cannot make this delivery
-	// write through, or consume the quota of, the replacement connection.
-	conn, gen := s.ConnEpoch()
+	// Capture the target connection, protocol version, and generation as a
+	// delivery lease. The PUBLISH is encoded for the captured version and
+	// written to the captured connection, and quota is acquired for the captured
+	// generation — so a takeover landing mid-delivery cannot make this delivery
+	// write to, encode for, or consume the quota of, the replacement connection.
+	conn, version, gen := s.DeliveryLease()
 	if conn == nil {
-		if msg.QoS > 0 {
-			err := s.OfflineQueue().Enqueue(msg)
-			msg.ReleasePayload()
-			storage.ReleaseMessage(msg)
-			return 0, err
-		}
-		msg.ReleasePayload()
-		storage.ReleaseMessage(msg)
-		return 0, nil
+		return b.deliverOffline(s, msg)
 	}
 
 	if msg.QoS == 0 {
-		err := b.DeliverMessage(conn, s, msg, nil)
-		if err == nil {
-			// Webhook: message delivered (QoS 0)
-			if b.telemetry.webhooks != nil {
-				b.telemetry.webhooks.Notify(context.Background(), events.MessageDelivered{ //nolint:errcheck,contextcheck // fire-and-forget webhook notification
-					ClientID:     s.ID,
-					MessageTopic: msg.Topic,
-					QoS:          msg.QoS,
-					PayloadSize:  len(msg.GetPayload()),
-				})
-			}
+		err := b.DeliverMessage(conn, version, msg, nil)
+		if err == nil && b.telemetry.webhooks != nil {
+			b.telemetry.webhooks.Notify(context.Background(), events.MessageDelivered{ //nolint:errcheck,contextcheck // fire-and-forget webhook notification
+				ClientID:     s.ID,
+				MessageTopic: msg.Topic,
+				QoS:          msg.QoS,
+				PayloadSize:  len(msg.GetPayload()),
+			})
 		}
-		// QoS 0 message delivered - release buffer and return message to pool
 		msg.ReleasePayload()
 		storage.ReleaseMessage(msg)
 		return 0, err
 	}
 
+	return b.deliverQoS(ctx, s, msg, conn, version, gen, 0)
+}
+
+// maxLeaseRetries bounds how many times a delivery re-leases against a newer
+// connection generation before giving up to the offline queue, so a takeover
+// storm cannot spin forever.
+const maxLeaseRetries = 8
+
+// deliverQoS delivers a QoS 1/2 message under the lease (conn, version, gen). If
+// the generation is superseded by a takeover, it re-leases against the current
+// connection and retries, rather than mis-routing the message to capacity
+// handling that the replacement connection may never drain.
+func (b *Broker) deliverQoS(ctx context.Context, s *session.Session, msg *storage.Message, conn core.Connection, version byte, gen uint64, attempt int) (uint16, error) {
 	packetID := s.NextPacketID()
 	msg.PacketID = packetID
 
@@ -95,20 +97,16 @@ func (b *Broker) DeliverToSession(ctx context.Context, s *session.Session, msg *
 	// pending queue when the quota is exhausted.
 	if s.SendBackpressure() {
 		if !s.AcquireSendQuota(packetID, gen) {
-			// Generation superseded by a takeover, or session disconnected
-			// while waiting. Re-queue for the (new) connection.
-			if msg.QoS > 0 {
-				err := s.OfflineQueue().Enqueue(msg)
-				msg.ReleasePayload()
-				storage.ReleaseMessage(msg)
-				return 0, err
-			}
-			msg.ReleasePayload()
-			storage.ReleaseMessage(msg)
-			return 0, nil
+			return b.releaseLease(ctx, s, msg, gen, attempt)
 		}
 	} else if !s.TryAcquireSendQuota(packetID, gen) {
-		// Quota exhausted (or generation superseded); defer into the pending queue.
+		// A superseded generation must be retried against the current connection,
+		// not treated as capacity exhaustion (the replacement may never produce
+		// an ACK to drain the pending queue).
+		if newConn, newVersion, curGen := s.DeliveryLease(); curGen != gen && newConn != nil && attempt < maxLeaseRetries {
+			return b.deliverQoS(ctx, s, msg, newConn, newVersion, curGen, attempt+1)
+		}
+		// Genuine quota exhaustion: defer into the pending queue.
 		if s.TryEnqueuePending(msg, nil) {
 			return 0, nil
 		}
@@ -139,7 +137,7 @@ func (b *Broker) DeliverToSession(ctx context.Context, s *session.Session, msg *
 	onSent := func() {
 		s.Inflight().MarkSent(packetID)
 	}
-	if err := b.DeliverMessage(conn, s, msg, onSent); err != nil {
+	if err := b.DeliverMessage(conn, version, msg, onSent); err != nil {
 		if errors.Is(err, core.ErrSendQueueFull) {
 			// Send queue full; message stays in inflight and will be retried
 			// by ProcessRetries once the queue drains.
@@ -160,6 +158,29 @@ func (b *Broker) DeliverToSession(ctx context.Context, s *session.Session, msg *
 	}
 
 	return packetID, nil
+}
+
+// releaseLease handles a backpressure acquire that returned false: a takeover
+// (retry against the new generation) or a disconnect (offline queue).
+func (b *Broker) releaseLease(ctx context.Context, s *session.Session, msg *storage.Message, gen uint64, attempt int) (uint16, error) {
+	if newConn, newVersion, curGen := s.DeliveryLease(); curGen != gen && newConn != nil && attempt < maxLeaseRetries {
+		return b.deliverQoS(ctx, s, msg, newConn, newVersion, curGen, attempt+1)
+	}
+	return b.deliverOffline(s, msg)
+}
+
+// deliverOffline parks a message for an offline (or unreachable) session: QoS>0
+// goes to the offline queue, QoS 0 is dropped.
+func (b *Broker) deliverOffline(s *session.Session, msg *storage.Message) (uint16, error) {
+	if msg.QoS > 0 {
+		err := s.OfflineQueue().Enqueue(msg)
+		msg.ReleasePayload()
+		storage.ReleaseMessage(msg)
+		return 0, err
+	}
+	msg.ReleasePayload()
+	storage.ReleaseMessage(msg)
+	return 0, nil
 }
 
 // AckMessage acknowledges a message by packet ID and releases the buffer.
@@ -186,17 +207,18 @@ func (b *Broker) AckMessage(s *session.Session, packetID uint16) error {
 	return nil
 }
 
-// DeliverMessage sends a message packet to the given connection (the delivery
-// lease's captured connection), using s only for protocol version and packet
-// shaping. Writing to the captured connection rather than the session's current
-// one keeps a delivery bound to the generation it acquired quota for.
-func (b *Broker) DeliverMessage(conn core.Connection, s *session.Session, msg *storage.Message, onSent func()) error {
+// DeliverMessage encodes a message for the given protocol version and writes it
+// to the given connection — both captured in the delivery lease — so a delivery
+// stays bound to the generation it acquired quota for, and a cross-version
+// takeover cannot encode a packet for one protocol and write it to a connection
+// of the other.
+func (b *Broker) DeliverMessage(conn core.Connection, version byte, msg *storage.Message, onSent func()) error {
 	b.telemetry.stats.IncrementPublishSent()
 	b.telemetry.stats.AddBytesSent(uint64(len(msg.GetPayload())))
 
 	var pub packets.ControlPacket
 
-	switch s.Version {
+	switch version {
 	case 5:
 		p := v5.AcquirePublish()
 

--- a/mqtt/broker/delivery.go
+++ b/mqtt/broker/delivery.go
@@ -135,7 +135,14 @@ func (b *Broker) deliverQoS(ctx context.Context, s *session.Session, msg *storag
 	s.Inflight().MarkDeliveryAttempted(packetID)
 
 	onSent := func() {
-		s.Inflight().MarkSent(packetID)
+		// Only mark sent while this generation is still current. If a takeover
+		// superseded the lease and the asynchronously queued packet flushed on
+		// the old connection, leave the inflight entry un-sent so the
+		// replacement connection retransmits it immediately rather than waiting
+		// out the retry timeout.
+		if s.Epoch() == gen {
+			s.Inflight().MarkSent(packetID)
+		}
 	}
 	if err := b.DeliverMessage(conn, version, msg, onSent); err != nil {
 		if errors.Is(err, core.ErrSendQueueFull) {
@@ -185,7 +192,7 @@ func (b *Broker) deliverOffline(s *session.Session, msg *storage.Message) (uint1
 
 // AckMessage acknowledges a message by packet ID and releases the buffer.
 func (b *Broker) AckMessage(s *session.Session, packetID uint16) error {
-	msg, err := s.Inflight().Ack(packetID)
+	msg, err := s.Inflight().Ack(packetID, messages.Outbound)
 	if err != nil {
 		return err
 	}

--- a/mqtt/broker/delivery.go
+++ b/mqtt/broker/delivery.go
@@ -135,14 +135,12 @@ func (b *Broker) deliverQoS(ctx context.Context, s *session.Session, msg *storag
 	s.Inflight().MarkDeliveryAttempted(packetID)
 
 	onSent := func() {
-		// Only mark sent while this generation is still current. If a takeover
-		// superseded the lease and the asynchronously queued packet flushed on
-		// the old connection, leave the inflight entry un-sent so the
-		// replacement connection retransmits it immediately rather than waiting
-		// out the retry timeout.
-		if s.Epoch() == gen {
-			s.Inflight().MarkSent(packetID)
-		}
+		// Mark sent only while this generation is still current, atomically under
+		// the session lock. If a takeover superseded the lease and the
+		// asynchronously queued packet flushed on the old connection, the entry
+		// stays un-sent so the replacement connection retransmits it immediately
+		// rather than waiting out the retry timeout.
+		s.MarkSentIfEpoch(packetID, gen)
 	}
 	if err := b.DeliverMessage(conn, version, msg, onSent); err != nil {
 		if errors.Is(err, core.ErrSendQueueFull) {
@@ -192,7 +190,7 @@ func (b *Broker) deliverOffline(s *session.Session, msg *storage.Message) (uint1
 
 // AckMessage acknowledges a message by packet ID and releases the buffer.
 func (b *Broker) AckMessage(s *session.Session, packetID uint16) error {
-	msg, err := s.Inflight().Ack(packetID, messages.Outbound)
+	msg, err := s.Inflight().Ack(packetID)
 	if err != nil {
 		return err
 	}

--- a/mqtt/broker/delivery.go
+++ b/mqtt/broker/delivery.go
@@ -5,20 +5,15 @@ package broker
 
 import (
 	"context"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"log/slog"
-	"strconv"
 	"time"
 
 	corebroker "github.com/absmach/fluxmq/broker"
 	"github.com/absmach/fluxmq/broker/events"
 	"github.com/absmach/fluxmq/cluster"
 	core "github.com/absmach/fluxmq/mqtt"
-	"github.com/absmach/fluxmq/mqtt/packets"
-	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
-	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/mqtt/session"
 	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/storage/messages"
@@ -231,48 +226,9 @@ func (b *Broker) DeliverMessage(conn core.Connection, version byte, msg *storage
 	b.telemetry.stats.IncrementPublishSent()
 	b.telemetry.stats.AddBytesSent(uint64(len(msg.GetPayload())))
 
-	var pub packets.ControlPacket
-
-	switch version {
-	case 5:
-		p := v5.AcquirePublish()
-
-		// Calculate remaining message expiry interval
-		if msg.MessageExpiry != nil && !msg.Expiry.IsZero() {
-			remaining := time.Until(msg.Expiry)
-
-			if remaining > 0 {
-				// Send remaining expiry in seconds
-				remainingSec := uint32(remaining.Seconds())
-				p.Properties.MessageExpiry = &remainingSec
-			}
-		}
-
-		p.FixedHeader = packets.FixedHeader{
-			PacketType: packets.PublishType,
-			QoS:        msg.QoS,
-			Retain:     msg.Retain,
-		}
-		p.TopicName = msg.Topic
-		p.Payload = msg.GetPayload()
-		p.ID = msg.PacketID
-		applyPublishProperties(p.Properties, msg)
-
-		pub = p
-	default:
-		p := v3.AcquirePublish()
-
-		p.FixedHeader = packets.FixedHeader{
-			PacketType: packets.PublishType,
-			QoS:        msg.QoS,
-			Retain:     msg.Retain,
-		}
-		p.TopicName = msg.Topic
-		p.Payload = msg.GetPayload()
-		p.ID = msg.PacketID
-
-		pub = p
-	}
+	// First send (dup=false). EncodePublish is the single encoder shared with the
+	// retransmission path so the two cannot drift on v5 properties.
+	pub := session.EncodePublish(msg, msg.PacketID, version, false)
 
 	// The send loop calls pub.Release() after Pack() completes.
 	// onSent carries only application-level callbacks (e.g. MarkSent).
@@ -282,80 +238,6 @@ func (b *Broker) DeliverMessage(conn core.Connection, version byte, msg *storage
 		pub.Release()
 	}
 	return err
-}
-
-func applyPublishProperties(props *v5.PublishProperties, msg *storage.Message) {
-	if props == nil || msg == nil {
-		return
-	}
-
-	// Prefer explicit fields; fall back to mapped properties.
-	if msg.ContentType != "" {
-		props.ContentType = msg.ContentType
-	} else if v := msg.Properties["content-type"]; v != "" {
-		props.ContentType = v
-	}
-
-	if msg.ResponseTopic != "" {
-		props.ResponseTopic = msg.ResponseTopic
-	} else if v := msg.Properties["response-topic"]; v != "" {
-		props.ResponseTopic = v
-	}
-
-	if len(msg.CorrelationData) > 0 {
-		props.CorrelationData = msg.CorrelationData
-	} else if v := msg.Properties["correlation-id"]; v != "" {
-		if decoded, err := base64.StdEncoding.DecodeString(v); err == nil {
-			props.CorrelationData = decoded
-		} else {
-			props.CorrelationData = []byte(v)
-		}
-	}
-
-	if msg.PayloadFormat != nil {
-		props.PayloadFormat = msg.PayloadFormat
-	} else if v := msg.Properties["payload-format"]; v != "" {
-		if n, err := strconv.ParseUint(v, 10, 8); err == nil {
-			pf := byte(n)
-			props.PayloadFormat = &pf
-		}
-	}
-
-	// Build User properties slice directly without intermediate map.
-	// Skip entirely when no properties exist (common case).
-	var userCount int
-	if msg.Properties != nil {
-		for k := range msg.Properties {
-			if !isReservedUserPropertyKey(k) {
-				userCount++
-			}
-		}
-	}
-	userCount += len(msg.UserProperties)
-
-	if userCount > 0 {
-		props.User = make([]v5.User, 0, userCount)
-		if msg.Properties != nil {
-			for k, v := range msg.Properties {
-				if isReservedUserPropertyKey(k) {
-					continue
-				}
-				props.User = append(props.User, v5.User{Key: k, Value: v})
-			}
-		}
-		for k, v := range msg.UserProperties {
-			props.User = append(props.User, v5.User{Key: k, Value: v})
-		}
-	}
-}
-
-func isReservedUserPropertyKey(key string) bool {
-	switch key {
-	case "content-type", "response-topic", "correlation-id", "payload-format":
-		return true
-	default:
-		return false
-	}
 }
 
 // DeliverToClient implements cluster.MessageHandler.DeliverToClient.

--- a/mqtt/broker/delivery.go
+++ b/mqtt/broker/delivery.go
@@ -51,8 +51,25 @@ func (b *Broker) DeliverToSession(ctx context.Context, s *session.Session, msg *
 		return 0, nil
 	}
 
+	// Capture the target connection and its generation as a delivery lease. The
+	// quota is acquired for this generation and the PUBLISH is written to this
+	// connection, so a takeover landing mid-delivery cannot make this delivery
+	// write through, or consume the quota of, the replacement connection.
+	conn, gen := s.ConnEpoch()
+	if conn == nil {
+		if msg.QoS > 0 {
+			err := s.OfflineQueue().Enqueue(msg)
+			msg.ReleasePayload()
+			storage.ReleaseMessage(msg)
+			return 0, err
+		}
+		msg.ReleasePayload()
+		storage.ReleaseMessage(msg)
+		return 0, nil
+	}
+
 	if msg.QoS == 0 {
-		err := b.DeliverMessage(s, msg, nil)
+		err := b.DeliverMessage(conn, s, msg, nil)
 		if err == nil {
 			// Webhook: message delivered (QoS 0)
 			if b.telemetry.webhooks != nil {
@@ -77,8 +94,9 @@ func (b *Broker) DeliverToSession(ctx context.Context, s *session.Session, msg *
 	// Backpressure mode blocks until a token frees; queue mode falls back to the
 	// pending queue when the quota is exhausted.
 	if s.SendBackpressure() {
-		if !s.AcquireSendQuota(packetID) {
-			// Session disconnected while waiting for quota.
+		if !s.AcquireSendQuota(packetID, gen) {
+			// Generation superseded by a takeover, or session disconnected
+			// while waiting. Re-queue for the (new) connection.
 			if msg.QoS > 0 {
 				err := s.OfflineQueue().Enqueue(msg)
 				msg.ReleasePayload()
@@ -89,8 +107,8 @@ func (b *Broker) DeliverToSession(ctx context.Context, s *session.Session, msg *
 			storage.ReleaseMessage(msg)
 			return 0, nil
 		}
-	} else if !s.TryAcquireSendQuota(packetID) {
-		// Quota exhausted; defer into the pending queue.
+	} else if !s.TryAcquireSendQuota(packetID, gen) {
+		// Quota exhausted (or generation superseded); defer into the pending queue.
 		if s.TryEnqueuePending(msg, nil) {
 			return 0, nil
 		}
@@ -103,7 +121,7 @@ func (b *Broker) DeliverToSession(ctx context.Context, s *session.Session, msg *
 	if err := s.Inflight().Add(packetID, msg, messages.Outbound); err != nil {
 		// Persistent inflight store is full (server cap, bidirectional). Release
 		// the quota token and try the pending queue.
-		s.ReleaseSendQuota(packetID)
+		s.ReleaseSendQuota(packetID, gen)
 		if s.TryEnqueuePending(msg, nil) {
 			// Deferred delivery; packet ID assigned at drain time.
 			return 0, nil
@@ -121,7 +139,7 @@ func (b *Broker) DeliverToSession(ctx context.Context, s *session.Session, msg *
 	onSent := func() {
 		s.Inflight().MarkSent(packetID)
 	}
-	if err := b.DeliverMessage(s, msg, onSent); err != nil {
+	if err := b.DeliverMessage(conn, s, msg, onSent); err != nil {
 		if errors.Is(err, core.ErrSendQueueFull) {
 			// Send queue full; message stays in inflight and will be retried
 			// by ProcessRetries once the queue drains.
@@ -155,9 +173,11 @@ func (b *Broker) AckMessage(s *session.Session, packetID uint16) error {
 		storage.ReleaseMessage(msg)
 	}
 
-	// Release the send-quota token (PUBACK/PUBCOMP) and pull through one pending
+	// Release the send-quota token (PUBACK/PUBCOMP) under the current generation
+	// — the live token is always held by the current connection (a retransmit
+	// re-acquires under the new generation) — and pull through one pending
 	// message (queue mode) to keep the pipeline full.
-	s.ReleaseSendQuota(packetID)
+	s.ReleaseSendQuota(packetID, s.Epoch())
 	s.DrainOnePending(func(pending *storage.Message, _ func()) error {
 		_, err := b.DeliverToSession(context.Background(), s, pending)
 		return err
@@ -166,8 +186,11 @@ func (b *Broker) AckMessage(s *session.Session, packetID uint16) error {
 	return nil
 }
 
-// DeliverMessage sends a message packet to the session's connection.
-func (b *Broker) DeliverMessage(s *session.Session, msg *storage.Message, onSent func()) error {
+// DeliverMessage sends a message packet to the given connection (the delivery
+// lease's captured connection), using s only for protocol version and packet
+// shaping. Writing to the captured connection rather than the session's current
+// one keeps a delivery bound to the generation it acquired quota for.
+func (b *Broker) DeliverMessage(conn core.Connection, s *session.Session, msg *storage.Message, onSent func()) error {
 	b.telemetry.stats.IncrementPublishSent()
 	b.telemetry.stats.AddBytesSent(uint64(len(msg.GetPayload())))
 
@@ -216,7 +239,7 @@ func (b *Broker) DeliverMessage(s *session.Session, msg *storage.Message, onSent
 
 	// The send loop calls pub.Release() after Pack() completes.
 	// onSent carries only application-level callbacks (e.g. MarkSent).
-	err := s.TryWriteDataPacket(pub, onSent)
+	err := conn.TryWriteDataPacket(pub, onSent)
 	if err != nil {
 		// TryWriteDataPacket failed without enqueuing; release immediately.
 		pub.Release()

--- a/mqtt/broker/delivery.go
+++ b/mqtt/broker/delivery.go
@@ -70,27 +70,40 @@ func (b *Broker) DeliverToSession(ctx context.Context, s *session.Session, msg *
 		return 0, err
 	}
 
-	// Backpressure mode: acquire an inflight slot before proceeding.
-	// Blocks until an ACK frees a slot; no-op when deliverSlots is nil.
-	if !s.AcquireDeliverSlot() {
-		// Session disconnected while waiting for a slot.
-		if msg.QoS > 0 {
-			err := s.OfflineQueue().Enqueue(msg)
+	packetID := s.NextPacketID()
+	msg.PacketID = packetID
+
+	// Acquire a send-quota (Receive Maximum) token for this outbound PUBLISH.
+	// Backpressure mode blocks until a token frees; queue mode falls back to the
+	// pending queue when the quota is exhausted.
+	if s.SendBackpressure() {
+		if !s.AcquireSendQuota(packetID) {
+			// Session disconnected while waiting for quota.
+			if msg.QoS > 0 {
+				err := s.OfflineQueue().Enqueue(msg)
+				msg.ReleasePayload()
+				storage.ReleaseMessage(msg)
+				return 0, err
+			}
 			msg.ReleasePayload()
 			storage.ReleaseMessage(msg)
-			return 0, err
+			return 0, nil
+		}
+	} else if !s.TryAcquireSendQuota(packetID) {
+		// Quota exhausted; defer into the pending queue.
+		if s.TryEnqueuePending(msg, nil) {
+			return 0, nil
 		}
 		msg.ReleasePayload()
 		storage.ReleaseMessage(msg)
 		return 0, nil
 	}
 
-	packetID := s.NextPacketID()
-	msg.PacketID = packetID
 	// Inflight storage takes ownership - it will release when message is ACK'd or expires
 	if err := s.Inflight().Add(packetID, msg, messages.Outbound); err != nil {
-		// Inflight is full (pending queue mode or unexpected). Try the pending queue.
-		s.ReleaseDeliverSlot()
+		// Persistent inflight store is full (server cap, bidirectional). Release
+		// the quota token and try the pending queue.
+		s.ReleaseSendQuota(packetID)
 		if s.TryEnqueuePending(msg, nil) {
 			// Deferred delivery; packet ID assigned at drain time.
 			return 0, nil
@@ -142,9 +155,9 @@ func (b *Broker) AckMessage(s *session.Session, packetID uint16) error {
 		storage.ReleaseMessage(msg)
 	}
 
-	// Return the inflight slot (backpressure mode) and pull through one pending
-	// message (pending queue mode) to keep the pipeline full.
-	s.ReleaseDeliverSlot()
+	// Release the send-quota token (PUBACK/PUBCOMP) and pull through one pending
+	// message (queue mode) to keep the pipeline full.
+	s.ReleaseSendQuota(packetID)
 	s.DrainOnePending(func(pending *storage.Message, _ func()) error {
 		_, err := b.DeliverToSession(context.Background(), s, pending)
 		return err

--- a/mqtt/broker/delivery.go
+++ b/mqtt/broker/delivery.go
@@ -84,6 +84,18 @@ func (b *Broker) DeliverToSession(ctx context.Context, s *session.Session, msg *
 // storm cannot spin forever.
 const maxLeaseRetries = 8
 
+// retrySupersededLease re-leases against the current connection generation and
+// retries delivery when gen was superseded by a takeover. retried reports
+// whether a retry was performed (bounded by maxLeaseRetries); when it is false
+// the caller handles genuine quota exhaustion or an offline session.
+func (b *Broker) retrySupersededLease(ctx context.Context, s *session.Session, msg *storage.Message, gen uint64, attempt int) (packetID uint16, retried bool, err error) {
+	if newConn, newVersion, curGen := s.DeliveryLease(); curGen != gen && newConn != nil && attempt < maxLeaseRetries {
+		packetID, err = b.deliverQoS(ctx, s, msg, newConn, newVersion, curGen, attempt+1)
+		return packetID, true, err
+	}
+	return 0, false, nil
+}
+
 // deliverQoS delivers a QoS 1/2 message under the lease (conn, version, gen). If
 // the generation is superseded by a takeover, it re-leases against the current
 // connection and retries, rather than mis-routing the message to capacity
@@ -103,8 +115,8 @@ func (b *Broker) deliverQoS(ctx context.Context, s *session.Session, msg *storag
 		// A superseded generation must be retried against the current connection,
 		// not treated as capacity exhaustion (the replacement may never produce
 		// an ACK to drain the pending queue).
-		if newConn, newVersion, curGen := s.DeliveryLease(); curGen != gen && newConn != nil && attempt < maxLeaseRetries {
-			return b.deliverQoS(ctx, s, msg, newConn, newVersion, curGen, attempt+1)
+		if pid, retried, err := b.retrySupersededLease(ctx, s, msg, gen, attempt); retried {
+			return pid, err
 		}
 		// Genuine quota exhaustion: defer into the pending queue.
 		if s.TryEnqueuePending(msg, nil) {
@@ -168,8 +180,8 @@ func (b *Broker) deliverQoS(ctx context.Context, s *session.Session, msg *storag
 // releaseLease handles a backpressure acquire that returned false: a takeover
 // (retry against the new generation) or a disconnect (offline queue).
 func (b *Broker) releaseLease(ctx context.Context, s *session.Session, msg *storage.Message, gen uint64, attempt int) (uint16, error) {
-	if newConn, newVersion, curGen := s.DeliveryLease(); curGen != gen && newConn != nil && attempt < maxLeaseRetries {
-		return b.deliverQoS(ctx, s, msg, newConn, newVersion, curGen, attempt+1)
+	if pid, retried, err := b.retrySupersededLease(ctx, s, msg, gen, attempt); retried {
+		return pid, err
 	}
 	return b.deliverOffline(s, msg)
 }
@@ -177,15 +189,13 @@ func (b *Broker) releaseLease(ctx context.Context, s *session.Session, msg *stor
 // deliverOffline parks a message for an offline (or unreachable) session: QoS>0
 // goes to the offline queue, QoS 0 is dropped.
 func (b *Broker) deliverOffline(s *session.Session, msg *storage.Message) (uint16, error) {
+	var err error
 	if msg.QoS > 0 {
-		err := s.OfflineQueue().Enqueue(msg)
-		msg.ReleasePayload()
-		storage.ReleaseMessage(msg)
-		return 0, err
+		err = s.OfflineQueue().Enqueue(msg)
 	}
 	msg.ReleasePayload()
 	storage.ReleaseMessage(msg)
-	return 0, nil
+	return 0, err
 }
 
 // AckMessage acknowledges a message by packet ID and releases the buffer.

--- a/mqtt/broker/delivery_test.go
+++ b/mqtt/broker/delivery_test.go
@@ -30,7 +30,8 @@ func TestDeliverToSession_MarkSentAfterWireWrite(t *testing.T) {
 	})
 
 	conn := core.NewConnection(serverConn, 1, false)
-	require.NoError(t, s.Connect(conn))
+	_, errConn := s.Connect(conn)
+	require.NoError(t, errConn)
 
 	msg := storage.AcquireMessage()
 	msg.Topic = testTopic

--- a/mqtt/broker/expiry_test.go
+++ b/mqtt/broker/expiry_test.go
@@ -81,7 +81,7 @@ func TestMessageExpiry_V5Handler(t *testing.T) {
 	b := NewBroker(store, cl, WithLogger(logger))
 
 	s, _, _ := b.CreateSession("client1", 5, session.Options{CleanStart: true})
-	handler := NewV5Handler(b)
+	handler := newV5Handler(b)
 
 	// Subscribe to test topic
 	b.subscribe(s, testTopic, 1, storage.SubscribeOptions{}) //nolint:errcheck // test setup

--- a/mqtt/broker/expiry_test.go
+++ b/mqtt/broker/expiry_test.go
@@ -98,7 +98,7 @@ func TestMessageExpiry_V5Handler(t *testing.T) {
 	}
 
 	// Publish message
-	err := handler.HandlePublish(s, pub)
+	err := handler.HandlePublish(bindConn(s), pub)
 	if err != nil {
 		t.Fatalf("Failed to handle PUBLISH with expiry: %v", err)
 	}

--- a/mqtt/broker/external_identity_test.go
+++ b/mqtt/broker/external_identity_test.go
@@ -35,7 +35,7 @@ func TestV5ConnectStoresExternalIDOnSession(t *testing.T) {
 	}, nil))
 
 	conn := &mockConnection{}
-	handler := NewV5Handler(b)
+	handler := newV5Handler(b)
 	connect := &v5.Connect{
 		FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
 		ProtocolName:    "MQTT",
@@ -73,7 +73,7 @@ func TestV5PublishSetsExternalIDProperty(t *testing.T) {
 	require.NoError(t, err)
 	s.ExternalID = "ext-456"
 
-	handler := NewV5Handler(b)
+	handler := newV5Handler(b)
 	pub := &v5.Publish{
 		FixedHeader: packets.FixedHeader{PacketType: packets.PublishType, QoS: 0},
 		TopicName:   "telemetry/room1",

--- a/mqtt/broker/external_identity_test.go
+++ b/mqtt/broker/external_identity_test.go
@@ -83,7 +83,7 @@ func TestV5PublishSetsExternalIDProperty(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, handler.HandlePublish(s, pub))
+	require.NoError(t, handler.HandlePublish(bindConn(s), pub))
 	require.NotNil(t, gotProps)
 	require.Equal(t, "mqtt-client", gotProps[corebroker.ClientIDProperty])
 	require.Equal(t, "ext-456", gotProps[corebroker.ExternalIDProperty])

--- a/mqtt/broker/handler.go
+++ b/mqtt/broker/handler.go
@@ -48,39 +48,44 @@ func maybeUpdateQueueHeartbeat(b *Broker, s *session.Session) {
 }
 
 // Handler is the interface for packet handlers (V3, V5, etc).
+//
+// Post-CONNECT handlers receive a *connCtx rather than a *session.Session: it
+// binds response writes and teardown to the specific connection generation that
+// read the packet, so a superseded connection's leftover goroutine cannot write
+// to or disconnect the connection that replaced it.
 type Handler interface {
 	// HandleConnect handles CONNECT packets.
 	HandleConnect(conn core.Connection, pkt packets.ControlPacket) error
 
 	// HandlePublish handles PUBLISH packets.
-	HandlePublish(s *session.Session, pkt packets.ControlPacket) error
+	HandlePublish(s *connCtx, pkt packets.ControlPacket) error
 
 	// HandlePubAck handles PUBACK packets.
-	HandlePubAck(s *session.Session, pkt packets.ControlPacket) error
+	HandlePubAck(s *connCtx, pkt packets.ControlPacket) error
 
 	// HandlePubRec handles PUBREC packets.
-	HandlePubRec(s *session.Session, pkt packets.ControlPacket) error
+	HandlePubRec(s *connCtx, pkt packets.ControlPacket) error
 
 	// HandlePubRel handles PUBREL packets.
-	HandlePubRel(s *session.Session, pkt packets.ControlPacket) error
+	HandlePubRel(s *connCtx, pkt packets.ControlPacket) error
 
 	// HandlePubComp handles PUBCOMP packets.
-	HandlePubComp(s *session.Session, pkt packets.ControlPacket) error
+	HandlePubComp(s *connCtx, pkt packets.ControlPacket) error
 
 	// HandleSubscribe handles SUBSCRIBE packets.
-	HandleSubscribe(s *session.Session, pkt packets.ControlPacket) error
+	HandleSubscribe(s *connCtx, pkt packets.ControlPacket) error
 
 	// HandleUnsubscribe handles UNSUBSCRIBE packets.
-	HandleUnsubscribe(s *session.Session, pkt packets.ControlPacket) error
+	HandleUnsubscribe(s *connCtx, pkt packets.ControlPacket) error
 
 	// HandlePingReq handles PINGREQ packets.
-	HandlePingReq(s *session.Session) error
+	HandlePingReq(s *connCtx) error
 
 	// HandleDisconnect handles DISCONNECT packets.
-	HandleDisconnect(s *session.Session, pkt packets.ControlPacket) error
+	HandleDisconnect(s *connCtx, pkt packets.ControlPacket) error
 
 	// HandleAuth handles AUTH packets.
-	HandleAuth(s *session.Session, pkt packets.ControlPacket) error
+	HandleAuth(s *connCtx, pkt packets.ControlPacket) error
 }
 
 // Router is the message routing interface.

--- a/mqtt/broker/handler.go
+++ b/mqtt/broker/handler.go
@@ -47,13 +47,13 @@ func maybeUpdateQueueHeartbeat(b *Broker, s *session.Session) {
 	_ = b.queueManager.UpdateHeartbeat(ctx, s.ID)
 }
 
-// Handler is the interface for packet handlers (V3, V5, etc).
+// protocolHandler is the interface for packet handlers (V3, V5, etc).
 //
 // Post-CONNECT handlers receive a *connCtx rather than a *session.Session: it
 // binds response writes and teardown to the specific connection generation that
 // read the packet, so a superseded connection's leftover goroutine cannot write
 // to or disconnect the connection that replaced it.
-type Handler interface {
+type protocolHandler interface {
 	// HandleConnect handles CONNECT packets.
 	HandleConnect(conn core.Connection, pkt packets.ControlPacket) error
 

--- a/mqtt/broker/inflight_correctness_test.go
+++ b/mqtt/broker/inflight_correctness_test.go
@@ -1,0 +1,152 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"testing"
+	"time"
+
+	"github.com/absmach/fluxmq/config"
+	"github.com/absmach/fluxmq/mqtt/packets"
+	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
+	"github.com/absmach/fluxmq/mqtt/session"
+	"github.com/absmach/fluxmq/storage"
+	"github.com/absmach/fluxmq/storage/messages"
+	"github.com/stretchr/testify/require"
+)
+
+type duplicateRejectingInflight struct {
+	rejected     *storage.Message
+	baseAddCalls int
+	addErr       error
+}
+
+func (f *duplicateRejectingInflight) Add(_ uint16, _ *storage.Message, _ messages.Direction) error {
+	f.baseAddCalls++
+	return nil
+}
+
+func (f *duplicateRejectingInflight) AddInbound(_ uint16, msg *storage.Message) (bool, error) {
+	f.rejected = msg
+	return false, f.addErr
+}
+
+func (f *duplicateRejectingInflight) Ack(uint16) (*storage.Message, error) {
+	return nil, messages.ErrPacketNotFound
+}
+
+func (f *duplicateRejectingInflight) Get(uint16) (*messages.InflightMessage, bool) {
+	return nil, false
+}
+
+func (f *duplicateRejectingInflight) Has(uint16) bool {
+	return false
+}
+
+func (f *duplicateRejectingInflight) WasReceived(uint16) bool {
+	return false
+}
+
+func (f *duplicateRejectingInflight) MarkReceived(uint16) {}
+
+func (f *duplicateRejectingInflight) UpdateState(uint16, messages.InflightState) error {
+	return nil
+}
+
+func (f *duplicateRejectingInflight) ClearReceived(uint16) {}
+
+func (f *duplicateRejectingInflight) GetExpired(time.Duration) []*messages.InflightMessage {
+	return nil
+}
+
+func (f *duplicateRejectingInflight) MarkSent(uint16) {}
+
+func (f *duplicateRejectingInflight) MarkDeliveryAttempted(uint16) {}
+
+func (f *duplicateRejectingInflight) MarkRetry(uint16) error {
+	return nil
+}
+
+func (f *duplicateRejectingInflight) GetAll() []*messages.InflightMessage {
+	return nil
+}
+
+func (f *duplicateRejectingInflight) CleanupExpiredReceived(time.Duration) {}
+
+func newDuplicateReleaseSession(t *testing.T, version byte, inflight messages.Inflight) (*session.Session, *captureConnection) {
+	t.Helper()
+
+	s := session.New(
+		"publisher",
+		version,
+		session.Options{CleanStart: true},
+		inflight,
+		messages.NewMessageQueue(8, true),
+		config.SessionConfig{MaxInflightMessages: 8},
+	)
+	conn := &captureConnection{}
+	_, err := s.Connect(conn)
+	require.NoError(t, err)
+	return s, conn
+}
+
+func TestV3QoS2DuplicateReleasesUnacceptedMessage(t *testing.T) {
+	b := newComplianceTestBroker(t)
+	inflight := &duplicateRejectingInflight{}
+	s, conn := newDuplicateReleaseSession(t, packets.V311, inflight)
+
+	err := newV3Handler(b).HandlePublish(bindConn(s), &v3.Publish{
+		FixedHeader: packets.FixedHeader{PacketType: packets.PublishType, QoS: 2, Dup: true},
+		TopicName:   "duplicate/v3",
+		ID:          7,
+		Payload:     []byte("duplicate"),
+	})
+	require.NoError(t, err)
+	require.Zero(t, inflight.baseAddCalls)
+	require.NotNil(t, inflight.rejected)
+	require.Empty(t, inflight.rejected.Topic)
+	require.Nil(t, inflight.rejected.PayloadBuf)
+	require.Len(t, conn.packets, 1)
+	require.IsType(t, &v3.PubRec{}, conn.packets[0])
+}
+
+func TestV5QoS2DuplicateReleasesUnacceptedMessage(t *testing.T) {
+	b := newComplianceTestBroker(t)
+	inflight := &duplicateRejectingInflight{}
+	s, conn := newDuplicateReleaseSession(t, packets.V5, inflight)
+
+	err := newV5Handler(b).HandlePublish(bindConn(s), &v5.Publish{
+		FixedHeader: packets.FixedHeader{PacketType: packets.PublishType, QoS: 2, Dup: true},
+		TopicName:   "duplicate/v5",
+		ID:          7,
+		Payload:     []byte("duplicate"),
+	})
+	require.NoError(t, err)
+	require.Zero(t, inflight.baseAddCalls)
+	require.NotNil(t, inflight.rejected)
+	require.Empty(t, inflight.rejected.Topic)
+	require.Nil(t, inflight.rejected.PayloadBuf)
+	require.Len(t, conn.packets, 1)
+	require.IsType(t, &v5.PubRec{}, conn.packets[0])
+}
+
+func TestV5QoS2AdmissionFailureReleasesMessage(t *testing.T) {
+	b := newComplianceTestBroker(t)
+	inflight := &duplicateRejectingInflight{addErr: messages.ErrInflightFull}
+	s, conn := newDuplicateReleaseSession(t, packets.V5, inflight)
+
+	err := newV5Handler(b).HandlePublish(bindConn(s), &v5.Publish{
+		FixedHeader: packets.FixedHeader{PacketType: packets.PublishType, QoS: 2},
+		TopicName:   "full/v5",
+		ID:          8,
+		Payload:     []byte("rejected"),
+	})
+	require.ErrorIs(t, err, messages.ErrInflightFull)
+	require.Zero(t, inflight.baseAddCalls)
+	require.NotNil(t, inflight.rejected)
+	require.Empty(t, inflight.rejected.Topic)
+	require.Nil(t, inflight.rejected.PayloadBuf)
+	require.Empty(t, conn.packets)
+}

--- a/mqtt/broker/inflight_correctness_test.go
+++ b/mqtt/broker/inflight_correctness_test.go
@@ -45,17 +45,9 @@ func (f *duplicateRejectingInflight) Has(uint16) bool {
 	return false
 }
 
-func (f *duplicateRejectingInflight) WasReceived(uint16) bool {
-	return false
-}
-
-func (f *duplicateRejectingInflight) MarkReceived(uint16) {}
-
 func (f *duplicateRejectingInflight) UpdateState(uint16, messages.InflightState) error {
 	return nil
 }
-
-func (f *duplicateRejectingInflight) ClearReceived(uint16) {}
 
 func (f *duplicateRejectingInflight) GetExpired(time.Duration) []*messages.InflightMessage {
 	return nil
@@ -72,8 +64,6 @@ func (f *duplicateRejectingInflight) MarkRetry(uint16) error {
 func (f *duplicateRejectingInflight) GetAll() []*messages.InflightMessage {
 	return nil
 }
-
-func (f *duplicateRejectingInflight) CleanupExpiredReceived(time.Duration) {}
 
 func newDuplicateReleaseSession(t *testing.T, version byte, inflight messages.Inflight) (*session.Session, *captureConnection) {
 	t.Helper()

--- a/mqtt/broker/lifecycle.go
+++ b/mqtt/broker/lifecycle.go
@@ -21,7 +21,7 @@ const retryCheckInterval = 1 * time.Second
 // runSession runs the main packet loop for a session using a protocolHandler.
 // It handles both packet reading and message retry checking in a single goroutine
 // by using short read deadlines and processing retries on timeout.
-func (b *Broker) runSession(handler protocolHandler, s *session.Session, conn core.Connection, epoch uint64) error {
+func (b *Broker) runSession(handler protocolHandler, s *session.Session, conn core.Connection, epoch uint64, keepAlive time.Duration) error {
 	if conn == nil {
 		return nil
 	}
@@ -33,12 +33,6 @@ func (b *Broker) runSession(handler protocolHandler, s *session.Session, conn co
 	// This replaces holding a lock across handler work, so a blocked write on a
 	// stalled old connection never prevents a takeover.
 	cc := &connCtx{Session: s, conn: conn, epoch: epoch}
-
-	// Capture keep-alive once: it is fixed for this connection's lifetime. A
-	// concurrent local takeover rebinds s.KeepAlive under the session lock while
-	// this (soon-to-be-superseded) goroutine is still running, so reading the
-	// field in the loop would race the takeover.
-	keepAlive := s.KeepAlive
 
 	lastActivity := time.Now()
 	lastRetryCheck := time.Now()

--- a/mqtt/broker/lifecycle.go
+++ b/mqtt/broker/lifecycle.go
@@ -90,6 +90,15 @@ func (b *Broker) runSession(handler protocolHandler, s *session.Session, conn co
 		// (publish, (un)subscribe, ack inflight, topic aliases, retained
 		// delivery). Drop it and exit — our own socket has already been closed
 		// by the takeover.
+		//
+		// Known limitation: this is a point-in-time check, not held across
+		// dispatch. A takeover landing between this check and a mutation deep
+		// in a handler can still let that one in-flight packet commit. We
+		// accept that bounded window: the packet was genuinely sent by the
+		// client on the old connection just before it reconnected, and the
+		// only fully-closed alternatives are holding a lock across handler work
+		// (which deadlocks when a response write blocks on a stalled client) or
+		// threading a generation check into every shared-state commit point.
 		if !cc.current() {
 			b.telemetry.stats.DecrementConnections()
 			return nil

--- a/mqtt/broker/lifecycle.go
+++ b/mqtt/broker/lifecycle.go
@@ -26,6 +26,14 @@ func (b *Broker) runSession(handler Handler, s *session.Session, conn core.Conne
 		return nil
 	}
 
+	// Bind all response writes and teardown to this connection generation.
+	// After a takeover, cc.conn is the closed old socket and cc.epoch is stale,
+	// so a superseded goroutine's writes fail harmlessly and its Disconnect is a
+	// no-op — it can neither write to nor disconnect the replacement connection.
+	// This replaces holding a lock across handler work, so a blocked write on a
+	// stalled old connection never prevents a takeover.
+	cc := &connCtx{Session: s, conn: conn, epoch: epoch}
+
 	lastActivity := time.Now()
 	lastRetryCheck := time.Now()
 
@@ -58,13 +66,9 @@ func (b *Broker) runSession(handler Handler, s *session.Session, conn core.Conne
 					}
 				}
 				// Just a retry check interval timeout - process retries and
-				// continue. Guarded so a superseded goroutine cannot resend
-				// inflight messages onto the replacement connection.
-				if !s.BeginProcessing(epoch) {
-					return nil
-				}
-				s.ProcessRetries()
-				s.EndProcessing()
+				// continue. Retry resends go through cc, so a superseded
+				// goroutine cannot deliver onto the replacement connection.
+				cc.ProcessRetries()
 				lastRetryCheck = time.Now()
 				continue
 			}
@@ -84,24 +88,14 @@ func (b *Broker) runSession(handler Handler, s *session.Session, conn core.Conne
 		b.telemetry.stats.IncrementMessagesReceived()
 		s.Touch()
 
-		// Bind processing to this connection generation. If a takeover swapped
-		// in a newer connection, stop now: the session belongs to the new
-		// connection and dispatching here would write to or disconnect it.
-		if !s.BeginProcessing(epoch) {
-			return nil
-		}
-
 		// Throttled retry check: under sustained traffic the read loop never
 		// times out, so we check retries here but at most once per interval.
 		if time.Since(lastRetryCheck) >= retryCheckInterval {
-			s.ProcessRetries()
+			cc.ProcessRetries()
 			lastRetryCheck = time.Now()
 		}
 
-		dispatchErr := dispatchPacket(handler, s, pkt)
-		s.EndProcessing()
-
-		if dispatchErr != nil {
+		if dispatchErr := dispatchPacket(handler, cc, pkt); dispatchErr != nil {
 			if dispatchErr == io.EOF {
 				b.telemetry.stats.DecrementConnections()
 				return nil
@@ -114,7 +108,7 @@ func (b *Broker) runSession(handler Handler, s *session.Session, conn core.Conne
 	}
 }
 
-func dispatchPacket(handler Handler, s *session.Session, pkt packets.ControlPacket) error {
+func dispatchPacket(handler Handler, s *connCtx, pkt packets.ControlPacket) error {
 	switch pkt.Type() {
 	case packets.PublishType:
 		return handler.HandlePublish(s, pkt)

--- a/mqtt/broker/lifecycle.go
+++ b/mqtt/broker/lifecycle.go
@@ -34,6 +34,12 @@ func (b *Broker) runSession(handler protocolHandler, s *session.Session, conn co
 	// stalled old connection never prevents a takeover.
 	cc := &connCtx{Session: s, conn: conn, epoch: epoch}
 
+	// Capture keep-alive once: it is fixed for this connection's lifetime. A
+	// concurrent local takeover rebinds s.KeepAlive under the session lock while
+	// this (soon-to-be-superseded) goroutine is still running, so reading the
+	// field in the loop would race the takeover.
+	keepAlive := s.KeepAlive
+
 	lastActivity := time.Now()
 	lastRetryCheck := time.Now()
 
@@ -41,8 +47,8 @@ func (b *Broker) runSession(handler protocolHandler, s *session.Session, conn co
 		// Calculate read deadline: minimum of keep-alive and retry check interval
 		// This allows us to check retries periodically while respecting keep-alive
 		readTimeout := retryCheckInterval
-		if s.KeepAlive > 0 && s.KeepAlive < readTimeout {
-			readTimeout = s.KeepAlive
+		if keepAlive > 0 && keepAlive < readTimeout {
+			readTimeout = keepAlive
 		}
 		conn.SetReadDeadline(time.Now().Add(readTimeout)) //nolint:errcheck // fails only on closed connection
 
@@ -56,8 +62,8 @@ func (b *Broker) runSession(handler protocolHandler, s *session.Session, conn co
 			var netErr net.Error
 			if errors.As(err, &netErr) && netErr.Timeout() {
 				// Check if keep-alive has actually expired
-				if s.KeepAlive > 0 {
-					keepAliveDeadline := s.KeepAlive + s.KeepAlive/2
+				if keepAlive > 0 {
+					keepAliveDeadline := keepAlive + keepAlive/2
 					if time.Since(lastActivity) > keepAliveDeadline {
 						// Real keep-alive timeout - client is unresponsive
 						b.telemetry.stats.DecrementConnections()

--- a/mqtt/broker/lifecycle.go
+++ b/mqtt/broker/lifecycle.go
@@ -73,8 +73,10 @@ func (b *Broker) runSession(handler Handler, s *session.Session, conn core.Conne
 				continue
 			}
 
-			// Real error (EOF, connection closed, etc.)
-			if err != io.EOF && err != session.ErrNotConnected {
+			// Real error (EOF, connection closed, etc.). Only count it as a
+			// packet error on the live connection: a superseded goroutine's
+			// read fails because its own socket was closed by the takeover.
+			if err != io.EOF && err != session.ErrNotConnected && cc.current() {
 				b.telemetry.stats.IncrementPacketErrors()
 			}
 			b.telemetry.stats.DecrementConnections()
@@ -100,7 +102,12 @@ func (b *Broker) runSession(handler Handler, s *session.Session, conn core.Conne
 				b.telemetry.stats.DecrementConnections()
 				return nil
 			}
-			b.telemetry.stats.IncrementProtocolErrors()
+			// Only a live connection's dispatch failure is a protocol error.
+			// A superseded goroutine's handler write fails against its own
+			// closed socket; that is expected teardown, not a protocol error.
+			if cc.current() {
+				b.telemetry.stats.IncrementProtocolErrors()
+			}
 			b.telemetry.stats.DecrementConnections()
 			s.DisconnectIf(false, epoch) //nolint:errcheck // disconnect on protocol error; connection is being terminated
 			return dispatchErr

--- a/mqtt/broker/lifecycle.go
+++ b/mqtt/broker/lifecycle.go
@@ -20,7 +20,7 @@ const retryCheckInterval = 1 * time.Second
 // runSession runs the main packet loop for a session using a Handler.
 // It handles both packet reading and message retry checking in a single goroutine
 // by using short read deadlines and processing retries on timeout.
-func (b *Broker) runSession(handler Handler, s *session.Session) error {
+func (b *Broker) runSession(handler Handler, s *session.Session, epoch uint64) error {
 	conn := s.Conn()
 	if conn == nil {
 		return nil
@@ -38,7 +38,11 @@ func (b *Broker) runSession(handler Handler, s *session.Session) error {
 		}
 		conn.SetReadDeadline(time.Now().Add(readTimeout)) //nolint:errcheck // fails only on closed connection
 
-		pkt, err := s.ReadPacket()
+		// Read from this goroutine's own connection, not s.conn. A local
+		// takeover may have swapped s.conn to a newer connection; reading our
+		// captured conn ensures a superseded goroutine never touches the new
+		// socket and simply errors out when its own (closed) conn is torn down.
+		pkt, err := conn.ReadPacket()
 		if err != nil {
 			// Check if this is a timeout (expected for retry checking)
 			var netErr net.Error
@@ -49,7 +53,7 @@ func (b *Broker) runSession(handler Handler, s *session.Session) error {
 					if time.Since(lastActivity) > keepAliveDeadline {
 						// Real keep-alive timeout - client is unresponsive
 						b.telemetry.stats.DecrementConnections()
-						s.Disconnect(false) //nolint:errcheck // disconnect during keepalive timeout; connection already dead
+						s.DisconnectIf(false, epoch) //nolint:errcheck // disconnect during keepalive timeout; connection already dead
 						return err
 					}
 				}
@@ -64,7 +68,7 @@ func (b *Broker) runSession(handler Handler, s *session.Session) error {
 				b.telemetry.stats.IncrementPacketErrors()
 			}
 			b.telemetry.stats.DecrementConnections()
-			s.Disconnect(false) //nolint:errcheck // disconnect on read error; connection already failed
+			s.DisconnectIf(false, epoch) //nolint:errcheck // disconnect on read error; connection already failed
 			return err
 		}
 
@@ -88,7 +92,7 @@ func (b *Broker) runSession(handler Handler, s *session.Session) error {
 			}
 			b.telemetry.stats.IncrementProtocolErrors()
 			b.telemetry.stats.DecrementConnections()
-			s.Disconnect(false) //nolint:errcheck // disconnect on protocol error; connection is being terminated
+			s.DisconnectIf(false, epoch) //nolint:errcheck // disconnect on protocol error; connection is being terminated
 			return err
 		}
 	}

--- a/mqtt/broker/lifecycle.go
+++ b/mqtt/broker/lifecycle.go
@@ -18,10 +18,10 @@ import (
 // retryCheckInterval is how often we check for expired inflight messages.
 const retryCheckInterval = 1 * time.Second
 
-// runSession runs the main packet loop for a session using a Handler.
+// runSession runs the main packet loop for a session using a protocolHandler.
 // It handles both packet reading and message retry checking in a single goroutine
 // by using short read deadlines and processing retries on timeout.
-func (b *Broker) runSession(handler Handler, s *session.Session, conn core.Connection, epoch uint64) error {
+func (b *Broker) runSession(handler protocolHandler, s *session.Session, conn core.Connection, epoch uint64) error {
 	if conn == nil {
 		return nil
 	}
@@ -84,6 +84,17 @@ func (b *Broker) runSession(handler Handler, s *session.Session, conn core.Conne
 			return err
 		}
 
+		// Bind this packet to our connection generation. A takeover may have
+		// superseded us while the packet was in flight; dispatching it would
+		// mutate session state now owned by the replacement connection
+		// (publish, (un)subscribe, ack inflight, topic aliases, retained
+		// delivery). Drop it and exit — our own socket has already been closed
+		// by the takeover.
+		if !cc.current() {
+			b.telemetry.stats.DecrementConnections()
+			return nil
+		}
+
 		// Packet received - update activity time
 		lastActivity = time.Now()
 
@@ -115,7 +126,7 @@ func (b *Broker) runSession(handler Handler, s *session.Session, conn core.Conne
 	}
 }
 
-func dispatchPacket(handler Handler, s *connCtx, pkt packets.ControlPacket) error {
+func dispatchPacket(handler protocolHandler, s *connCtx, pkt packets.ControlPacket) error {
 	switch pkt.Type() {
 	case packets.PublishType:
 		return handler.HandlePublish(s, pkt)

--- a/mqtt/broker/lifecycle.go
+++ b/mqtt/broker/lifecycle.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"time"
 
+	core "github.com/absmach/fluxmq/mqtt"
 	"github.com/absmach/fluxmq/mqtt/packets"
 	"github.com/absmach/fluxmq/mqtt/session"
 )
@@ -20,8 +21,7 @@ const retryCheckInterval = 1 * time.Second
 // runSession runs the main packet loop for a session using a Handler.
 // It handles both packet reading and message retry checking in a single goroutine
 // by using short read deadlines and processing retries on timeout.
-func (b *Broker) runSession(handler Handler, s *session.Session, epoch uint64) error {
-	conn := s.Conn()
+func (b *Broker) runSession(handler Handler, s *session.Session, conn core.Connection, epoch uint64) error {
 	if conn == nil {
 		return nil
 	}
@@ -57,8 +57,14 @@ func (b *Broker) runSession(handler Handler, s *session.Session, epoch uint64) e
 						return err
 					}
 				}
-				// Just a retry check interval timeout - process retries and continue
+				// Just a retry check interval timeout - process retries and
+				// continue. Guarded so a superseded goroutine cannot resend
+				// inflight messages onto the replacement connection.
+				if !s.BeginProcessing(epoch) {
+					return nil
+				}
 				s.ProcessRetries()
+				s.EndProcessing()
 				lastRetryCheck = time.Now()
 				continue
 			}
@@ -78,6 +84,13 @@ func (b *Broker) runSession(handler Handler, s *session.Session, epoch uint64) e
 		b.telemetry.stats.IncrementMessagesReceived()
 		s.Touch()
 
+		// Bind processing to this connection generation. If a takeover swapped
+		// in a newer connection, stop now: the session belongs to the new
+		// connection and dispatching here would write to or disconnect it.
+		if !s.BeginProcessing(epoch) {
+			return nil
+		}
+
 		// Throttled retry check: under sustained traffic the read loop never
 		// times out, so we check retries here but at most once per interval.
 		if time.Since(lastRetryCheck) >= retryCheckInterval {
@@ -85,15 +98,18 @@ func (b *Broker) runSession(handler Handler, s *session.Session, epoch uint64) e
 			lastRetryCheck = time.Now()
 		}
 
-		if err := dispatchPacket(handler, s, pkt); err != nil {
-			if err == io.EOF {
+		dispatchErr := dispatchPacket(handler, s, pkt)
+		s.EndProcessing()
+
+		if dispatchErr != nil {
+			if dispatchErr == io.EOF {
 				b.telemetry.stats.DecrementConnections()
 				return nil
 			}
 			b.telemetry.stats.IncrementProtocolErrors()
 			b.telemetry.stats.DecrementConnections()
 			s.DisconnectIf(false, epoch) //nolint:errcheck // disconnect on protocol error; connection is being terminated
-			return err
+			return dispatchErr
 		}
 	}
 }

--- a/mqtt/broker/maxqos_test.go
+++ b/mqtt/broker/maxqos_test.go
@@ -66,7 +66,7 @@ func TestMaxQoS_V5Handler_Downgrade_QoS2to0(t *testing.T) {
 	b.SetMaxQoS(0)
 
 	s, _, _ := b.CreateSession("client1", 5, session.Options{CleanStart: true})
-	handler := NewV5Handler(b)
+	handler := newV5Handler(b)
 
 	// Subscribe to capture the message
 	b.subscribe(s, testTopic, 2, storage.SubscribeOptions{}) //nolint:errcheck // test setup
@@ -97,7 +97,7 @@ func TestMaxQoS_V5Handler_Downgrade_QoS1to0(t *testing.T) {
 	b.SetMaxQoS(0)
 
 	s, _, _ := b.CreateSession("client1", 5, session.Options{CleanStart: true})
-	handler := NewV5Handler(b)
+	handler := newV5Handler(b)
 
 	// Subscribe to capture the message
 	b.subscribe(s, testTopic, 1, storage.SubscribeOptions{}) //nolint:errcheck // test setup
@@ -126,7 +126,7 @@ func TestMaxQoS_V5Handler_NoDowngrade(t *testing.T) {
 	b.SetMaxQoS(2)
 
 	s, _, _ := b.CreateSession("client1", 5, session.Options{CleanStart: true})
-	handler := NewV5Handler(b)
+	handler := newV5Handler(b)
 
 	b.subscribe(s, testTopic, 0, storage.SubscribeOptions{}) //nolint:errcheck // test setup
 
@@ -153,7 +153,7 @@ func TestMaxQoS_V3Handler_Downgrade(t *testing.T) {
 	b.SetMaxQoS(0)
 
 	s, _, _ := b.CreateSession("client1", 4, session.Options{CleanStart: true})
-	handler := NewV3Handler(b)
+	handler := newV3Handler(b)
 
 	b.subscribe(s, testTopic, 1, storage.SubscribeOptions{}) //nolint:errcheck // test setup
 

--- a/mqtt/broker/maxqos_test.go
+++ b/mqtt/broker/maxqos_test.go
@@ -81,7 +81,7 @@ func TestMaxQoS_V5Handler_Downgrade_QoS2to0(t *testing.T) {
 
 	// HandlePublish will downgrade the QoS to 0 before publishing
 	// QoS 0 doesn't require acknowledgment so no connection needed
-	err := handler.HandlePublish(s, pub)
+	err := handler.HandlePublish(bindConn(s), pub)
 	if err != nil {
 		t.Fatalf("HandlePublish failed: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestMaxQoS_V5Handler_Downgrade_QoS1to0(t *testing.T) {
 		ID:          1,
 	}
 
-	err := handler.HandlePublish(s, pub)
+	err := handler.HandlePublish(bindConn(s), pub)
 	if err != nil {
 		t.Fatalf("HandlePublish failed: %v", err)
 	}
@@ -137,7 +137,7 @@ func TestMaxQoS_V5Handler_NoDowngrade(t *testing.T) {
 		Payload:     []byte("test data"),
 	}
 
-	err := handler.HandlePublish(s, pub)
+	err := handler.HandlePublish(bindConn(s), pub)
 	if err != nil {
 		t.Fatalf("HandlePublish failed: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestMaxQoS_V3Handler_Downgrade(t *testing.T) {
 		ID:          1,
 	}
 
-	err := handler.HandlePublish(s, pub)
+	err := handler.HandlePublish(bindConn(s), pub)
 	if err != nil {
 		t.Fatalf("HandlePublish failed: %v", err)
 	}

--- a/mqtt/broker/message_bench_test.go
+++ b/mqtt/broker/message_bench_test.go
@@ -544,7 +544,7 @@ func createBenchSession(tb testing.TB, broker *Broker, clientID string) *session
 
 	// Create a mock connection
 	conn := &mockBenchConn{clientID: clientID}
-	if err := s.Connect(conn); err != nil {
+	if _, err := s.Connect(conn); err != nil {
 		tb.Fatalf("Failed to connect session: %v", err)
 	}
 

--- a/mqtt/broker/publish.go
+++ b/mqtt/broker/publish.go
@@ -127,7 +127,17 @@ func (b *Broker) PublishWill(ctx context.Context, clientID string) error {
 		return err
 	}
 
-	// Create message from will (will payload is []byte, not RefCountedBuffer)
+	if err := b.publishWillMessage(ctx, will); err != nil {
+		return err
+	}
+
+	return b.stores.wills.Delete(ctx, clientID)
+}
+
+// publishWillMessage distributes a Will message. Used both for stored Wills
+// (PublishWill) and for the Will of a connection displaced by a takeover.
+func (b *Broker) publishWillMessage(ctx context.Context, will *storage.WillMessage) error {
+	// Will payload is []byte, not a RefCountedBuffer.
 	msg := &storage.Message{
 		Topic:      will.Topic,
 		ClientID:   will.ClientID,
@@ -137,15 +147,9 @@ func (b *Broker) PublishWill(ctx context.Context, clientID string) error {
 	}
 	msg.SetPayloadFromBytes(will.Payload)
 
-	if err := b.distribute(ctx, msg); err != nil {
-		msg.ReleasePayload()
-		return err
-	}
-
-	// Release the message buffer after distribution
+	err := b.distribute(ctx, msg)
 	msg.ReleasePayload()
-
-	return b.stores.wills.Delete(ctx, clientID)
+	return err
 }
 
 // handleRetained stores or clears a retained message.

--- a/mqtt/broker/session.go
+++ b/mqtt/broker/session.go
@@ -89,7 +89,7 @@ func (b *Broker) CreateSession(clientID string, version byte, opts session.Optio
 
 	serverReceiveMax := sessionCfg.MaxInflightMessages
 	if serverReceiveMax <= 0 {
-		serverReceiveMax = 256
+		serverReceiveMax = config.DefaultMaxInflightMessages
 	}
 	if serverReceiveMax > 65535 {
 		serverReceiveMax = 65535
@@ -98,7 +98,11 @@ func (b *Broker) CreateSession(clientID string, version byte, opts session.Optio
 	if receiveMax == 0 || int(receiveMax) > serverReceiveMax {
 		receiveMax = uint16(serverReceiveMax)
 	}
-	inflight := messages.NewInflightTracker(int(receiveMax))
+	// The persistent inflight store is the bidirectional server-side limit; it
+	// must not be sized by the client's outbound Receive Maximum, or an inbound
+	// QoS 2 transaction from a client advertising a small Receive Maximum could
+	// starve outbound delivery. The outbound quota is the session's send window.
+	inflight := messages.NewInflightTracker(serverReceiveMax)
 	offlineQueue := messages.NewMessageQueue(sessionCfg.MaxOfflineQueueSize, sessionCfg.OfflineQueuePolicy == config.OfflineQueuePolicyEvict)
 
 	// Restore from takeover state if present

--- a/mqtt/broker/session.go
+++ b/mqtt/broker/session.go
@@ -302,7 +302,12 @@ func (b *Broker) handleDisconnect(s *session.Session, graceful bool) {
 		}
 
 		for _, inf := range s.Inflight().GetAll() {
-			key := fmt.Sprintf("%s%s%d", s.ID, inflightPrefix, inf.PacketID)
+			// Key by direction so an inbound and outbound entry sharing a packet
+			// ID do not overwrite each other, and carry the direction and state
+			// on the message so they survive a restore.
+			key := fmt.Sprintf("%s%s%d/%d", s.ID, inflightPrefix, inf.Direction, inf.PacketID)
+			inf.Message.InflightDirection = byte(inf.Direction)
+			inf.Message.InflightState = byte(inf.State)
 			b.stores.messages.Store(key, inf.Message) //nolint:errcheck // best-effort inflight message persistence
 		}
 	}
@@ -346,8 +351,13 @@ func (b *Broker) restoreInflightFromStorage(clientID string, tracker messages.In
 	}
 
 	for _, msg := range inflightMsgs {
-		if msg.PacketID != 0 {
-			tracker.Add(msg.PacketID, msg, messages.Outbound) //nolint:errcheck // best-effort inflight restore; packet will be retried or dropped
+		if msg.PacketID == 0 {
+			continue
+		}
+		direction := messages.Direction(msg.InflightDirection)
+		tracker.Add(msg.PacketID, msg, direction) //nolint:errcheck // best-effort inflight restore; packet will be retried or dropped
+		if direction == messages.Outbound {
+			tracker.UpdateState(msg.PacketID, messages.InflightState(msg.InflightState)) //nolint:errcheck // restore the QoS 2 delivery phase
 		}
 	}
 
@@ -440,9 +450,13 @@ func (b *Broker) restoreInflightFromTakeover(state *clusterv1.SessionState, trac
 			Retain:   msg.Retain,
 			PacketID: uint16(msg.PacketId),
 		}
-		if err := tracker.Add(uint16(msg.PacketId), storeMsg, messages.Outbound); err != nil {
+		direction := messages.Direction(msg.Direction)
+		if err := tracker.Add(uint16(msg.PacketId), storeMsg, direction); err != nil {
 			b.logError("restore_inflight", err, slog.Uint64("packet_id", uint64(msg.PacketId)))
 			continue
+		}
+		if direction == messages.Outbound {
+			tracker.UpdateState(uint16(msg.PacketId), messages.InflightState(msg.State)) //nolint:errcheck // restore the QoS 2 delivery phase
 		}
 	}
 
@@ -547,6 +561,8 @@ func (b *Broker) GetSessionStateAndClose(ctx context.Context, clientID string) (
 			Qos:       uint32(msg.Message.QoS),
 			Retain:    msg.Message.Retain,
 			Timestamp: time.Now().Unix(),
+			Direction: uint32(msg.Direction),
+			State:     uint32(msg.State),
 		})
 	}
 

--- a/mqtt/broker/session.go
+++ b/mqtt/broker/session.go
@@ -298,6 +298,9 @@ func (b *Broker) handleDisconnect(s *session.Session, graceful bool) {
 		msgs := s.OfflineQueue().Drain()
 		for i, msg := range msgs {
 			key := fmt.Sprintf("%s%s%d", s.ID, queuePrefix, i)
+			// Materialise the payload into the serialized Payload field: the
+			// zero-copy PayloadBuf is not persisted (json:"-").
+			msg.Payload = append([]byte(nil), msg.GetPayload()...)
 			b.stores.messages.Store(key, msg) //nolint:errcheck // best-effort offline message persistence
 		}
 
@@ -306,6 +309,7 @@ func (b *Broker) handleDisconnect(s *session.Session, graceful bool) {
 			// ID do not overwrite each other, and carry the direction and state
 			// on the message so they survive a restore.
 			key := fmt.Sprintf("%s%s%d/%d", s.ID, inflightPrefix, inf.Direction, inf.PacketID)
+			inf.Message.Payload = append([]byte(nil), inf.Message.GetPayload()...)
 			inf.Message.InflightDirection = byte(inf.Direction)
 			inf.Message.InflightState = byte(inf.State)
 			b.stores.messages.Store(key, inf.Message) //nolint:errcheck // best-effort inflight message persistence
@@ -339,6 +343,38 @@ func (b *Broker) persistSessionInfo(s *session.Session) {
 	}
 }
 
+// restoreInflightEntry adds a restored inflight message to the tracker with a
+// validated direction and state. An invalid direction (corrupt persisted or
+// transferred value) is skipped rather than risking an out-of-range panic. For
+// inbound entries it rebuilds duplicate-detection state so a retransmitted QoS 2
+// PUBLISH after restore is recognised.
+func restoreInflightEntry(tracker messages.Inflight, packetID uint16, msg *storage.Message, rawDirection, rawState uint32) {
+	var direction messages.Direction
+	switch messages.Direction(rawDirection) {
+	case messages.Outbound:
+		direction = messages.Outbound
+	case messages.Inbound:
+		direction = messages.Inbound
+	default:
+		return // unknown/corrupt direction: skip
+	}
+
+	if err := tracker.Add(packetID, msg, direction); err != nil {
+		return
+	}
+
+	if direction == messages.Inbound {
+		tracker.MarkReceived(packetID) // rebuild QoS 2 duplicate detection
+		return
+	}
+
+	state := messages.StatePublishSent
+	if messages.InflightState(rawState) == messages.StatePubRecReceived {
+		state = messages.StatePubRecReceived
+	}
+	tracker.UpdateState(packetID, state) //nolint:errcheck // restore the QoS 2 delivery phase
+}
+
 // restoreInflightFromStorage restores inflight messages from storage.
 func (b *Broker) restoreInflightFromStorage(clientID string, tracker messages.Inflight) error {
 	if b.stores.messages == nil {
@@ -354,11 +390,7 @@ func (b *Broker) restoreInflightFromStorage(clientID string, tracker messages.In
 		if msg.PacketID == 0 {
 			continue
 		}
-		direction := messages.Direction(msg.InflightDirection)
-		tracker.Add(msg.PacketID, msg, direction) //nolint:errcheck // best-effort inflight restore; packet will be retried or dropped
-		if direction == messages.Outbound {
-			tracker.UpdateState(msg.PacketID, messages.InflightState(msg.InflightState)) //nolint:errcheck // restore the QoS 2 delivery phase
-		}
+		restoreInflightEntry(tracker, msg.PacketID, msg, uint32(msg.InflightDirection), uint32(msg.InflightState))
 	}
 
 	if err := b.stores.messages.DeleteByPrefix(clientID + inflightPrefix); err != nil {
@@ -445,19 +477,12 @@ func (b *Broker) restoreInflightFromTakeover(state *clusterv1.SessionState, trac
 	for _, msg := range state.InflightMessages {
 		storeMsg := &storage.Message{
 			Topic:    msg.Topic,
-			Payload:  msg.Payload,
+			Payload:  msg.GetPayload(),
 			QoS:      byte(msg.Qos),
 			Retain:   msg.Retain,
 			PacketID: uint16(msg.PacketId),
 		}
-		direction := messages.Direction(msg.Direction)
-		if err := tracker.Add(uint16(msg.PacketId), storeMsg, direction); err != nil {
-			b.logError("restore_inflight", err, slog.Uint64("packet_id", uint64(msg.PacketId)))
-			continue
-		}
-		if direction == messages.Outbound {
-			tracker.UpdateState(uint16(msg.PacketId), messages.InflightState(msg.State)) //nolint:errcheck // restore the QoS 2 delivery phase
-		}
+		restoreInflightEntry(tracker, uint16(msg.PacketId), storeMsg, msg.Direction, msg.State)
 	}
 
 	return nil
@@ -557,7 +582,7 @@ func (b *Broker) GetSessionStateAndClose(ctx context.Context, clientID string) (
 		state.InflightMessages = append(state.InflightMessages, &clusterv1.InflightMessage{
 			PacketId:  uint32(msg.PacketID),
 			Topic:     msg.Message.Topic,
-			Payload:   msg.Message.Payload,
+			Payload:   msg.Message.GetPayload(),
 			Qos:       uint32(msg.Message.QoS),
 			Retain:    msg.Message.Retain,
 			Timestamp: time.Now().Unix(),

--- a/mqtt/broker/session.go
+++ b/mqtt/broker/session.go
@@ -345,9 +345,10 @@ func (b *Broker) persistSessionInfo(s *session.Session) {
 
 // restoreInflightEntry adds a restored inflight message to the tracker with a
 // validated direction and state. An invalid direction (corrupt persisted or
-// transferred value) is skipped rather than risking an out-of-range panic. For
-// inbound entries it rebuilds duplicate-detection state so a retransmitted QoS 2
-// PUBLISH after restore is recognised.
+// transferred value) is skipped rather than risking an out-of-range panic. The
+// (direction, packetID) entry the Add restores is itself the inbound QoS 2
+// duplicate-detection state, so a retransmitted PUBLISH after restore is
+// recognised.
 func restoreInflightEntry(tracker messages.Inflight, packetID uint16, msg *storage.Message, rawDirection, rawState uint32) {
 	var direction messages.Direction
 	switch messages.Direction(rawDirection) {
@@ -364,8 +365,7 @@ func restoreInflightEntry(tracker messages.Inflight, packetID uint16, msg *stora
 	}
 
 	if direction == messages.Inbound {
-		tracker.MarkReceived(packetID) // rebuild QoS 2 duplicate detection
-		return
+		return // inbound entries carry no extra delivery state
 	}
 
 	state := messages.StatePublishSent

--- a/mqtt/broker/session_admin_test.go
+++ b/mqtt/broker/session_admin_test.go
@@ -36,7 +36,7 @@ func TestPersistSessionInfoTracksConnectedState(t *testing.T) {
 		t.Fatalf("expected stored session to start disconnected")
 	}
 
-	if err := s.Connect(&mockConnection{}); err != nil {
+	if _, err := s.Connect(&mockConnection{}); err != nil {
 		t.Fatalf("failed to connect session: %v", err)
 	}
 
@@ -311,7 +311,7 @@ func newTestBrokerWithSessions(t *testing.T) (*Broker, func()) {
 		}
 		s.AddSubscription(tc.filter, storage.SubscribeOptions{})
 
-		if err := s.Connect(&mockConnection{}); err != nil {
+		if _, err := s.Connect(&mockConnection{}); err != nil {
 			t.Fatalf("Connect(%q): %v", tc.id, err)
 		}
 		b.persistSessionInfo(s)

--- a/mqtt/broker/subscription_admin_test.go
+++ b/mqtt/broker/subscription_admin_test.go
@@ -288,7 +288,7 @@ func newTestBrokerWithSharedSubs(t *testing.T) (*Broker, func()) {
 			s.AddSubscription(sub.filter, storage.SubscribeOptions{})
 		}
 
-		if err := s.Connect(&mockConnection{}); err != nil {
+		if _, err := s.Connect(&mockConnection{}); err != nil {
 			t.Fatalf("Connect(%q): %v", tc.id, err)
 		}
 		b.persistSessionInfo(s)

--- a/mqtt/broker/takeover.go
+++ b/mqtt/broker/takeover.go
@@ -35,20 +35,24 @@ func (b *Broker) drainSuperseded(ctx context.Context, sc *session.Superseded) {
 		return
 	}
 
-	// Notify a displaced MQTT 5 client before closing the connection.
+	// Notify a displaced MQTT 5 client before closing the connection. Wait for
+	// the packet to actually be transmitted (the onSent callback fires after
+	// the send loop writes it to the socket), not merely enqueued, so an
+	// asynchronous send queue does not observe the close before flushing the
+	// DISCONNECT.
 	if sc.Version == core.ProtocolV5 {
 		d := &v5.Disconnect{
 			FixedHeader: packets.FixedHeader{PacketType: packets.DisconnectType},
 			ReasonCode:  reasonSessionTakenOver,
 		}
-		// Bounded best-effort: a stalled client must not delay the close.
-		done := make(chan struct{})
+		sent := make(chan struct{})
 		go func() {
-			sc.Conn.WritePacket(d) //nolint:errcheck // best-effort takeover notification
-			close(done)
+			// WriteControlPacket may block enqueueing on a stalled client.
+			sc.Conn.WriteControlPacket(d, func() { close(sent) }) //nolint:errcheck // best-effort takeover notification
 		}()
+		// Bounded: a stalled client must not delay the close indefinitely.
 		select {
-		case <-done:
+		case <-sent:
 		case <-time.After(supersededNotifyGrace):
 		}
 	}

--- a/mqtt/broker/takeover.go
+++ b/mqtt/broker/takeover.go
@@ -1,0 +1,68 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	core "github.com/absmach/fluxmq/mqtt"
+	"github.com/absmach/fluxmq/mqtt/packets"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
+	"github.com/absmach/fluxmq/mqtt/session"
+)
+
+// reasonSessionTakenOver is MQTT 5 reason code 0x8E, sent in a DISCONNECT to a
+// client whose session has been taken over by a new connection. [MQTT-3.1.4-3].
+const reasonSessionTakenOver = 0x8E
+
+// supersededNotifyGrace bounds how long the takeover waits to deliver the
+// "session taken over" DISCONNECT before closing the old socket, so a stalled
+// client cannot delay the close.
+const supersededNotifyGrace = time.Second
+
+// drainSuperseded retires a connection displaced by a local takeover: it
+// notifies an MQTT 5 client with a DISCONNECT (0x8E), closes the socket, and
+// publishes the displaced connection's Will when required. It is safe to run in
+// its own goroutine and must not block the replacement connection's setup.
+//
+// References: OASIS MQTT 5.0, sections 3.1.4 (session takeover) and 3.1.2.5
+// (Will lifecycle).
+func (b *Broker) drainSuperseded(ctx context.Context, sc *session.Superseded) {
+	if sc == nil || sc.Conn == nil {
+		return
+	}
+
+	// Notify a displaced MQTT 5 client before closing the connection.
+	if sc.Version == core.ProtocolV5 {
+		d := &v5.Disconnect{
+			FixedHeader: packets.FixedHeader{PacketType: packets.DisconnectType},
+			ReasonCode:  reasonSessionTakenOver,
+		}
+		// Bounded best-effort: a stalled client must not delay the close.
+		done := make(chan struct{})
+		go func() {
+			sc.Conn.WritePacket(d) //nolint:errcheck // best-effort takeover notification
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(supersededNotifyGrace):
+		}
+	}
+
+	// Closing unblocks any pending notify write and lets the displaced
+	// connection's runSession goroutine observe the closed socket and exit.
+	sc.Conn.Close() //nolint:errcheck // idempotent close of superseded connection
+
+	// Publish the displaced connection's Will if it has no delay. A Will with a
+	// delay is cancelled because the session continues under the new
+	// connection (a takeover is a reconnect of the same session).
+	if sc.Will != nil && sc.Will.Delay == 0 {
+		if err := b.publishWillMessage(ctx, sc.Will); err != nil {
+			b.logError("publish_superseded_will", err, slog.String("client_id", sc.Will.ClientID))
+		}
+	}
+}

--- a/mqtt/broker/takeover_test.go
+++ b/mqtt/broker/takeover_test.go
@@ -325,8 +325,9 @@ func TestHandleConnect_LocalTakeoverHighLatencyReconnect(t *testing.T) {
 
 	require.False(t, newConn.closed.Load(), "new connection must remain open after takeover")
 
-	// Give any stale teardown a chance to (incorrectly) fire, then re-assert.
-	time.Sleep(20 * time.Millisecond)
+	// oldWG.Wait above already guaranteed the superseded goroutine ran its
+	// teardown (DisconnectIf) and exited, so this re-assert is deterministic: the
+	// stale teardown has had its chance to (incorrectly) fire.
 	s := b.sessionsMap.Get(clientID)
 	require.NotNil(t, s)
 	require.True(t, s.IsConnected(), "new connection must survive the stale goroutine's teardown")
@@ -400,8 +401,9 @@ func TestHandleConnect_StaleDisconnectDoesNotCloseReplacement(t *testing.T) {
 
 	waitFor(t, func() bool { return oldConn.closed.Load() }, "old conn closed by takeover")
 
-	// Give the stale DISCONNECT a chance to (incorrectly) tear down the session.
-	time.Sleep(20 * time.Millisecond)
+	// oldWG.Wait above guaranteed the stale DISCONNECT was dispatched (a no-op via
+	// connCtx.Disconnect/DisconnectIf) and the goroutine exited, so this assert is
+	// deterministic.
 	s := b.sessionsMap.Get(clientID)
 	require.NotNil(t, s)
 	require.True(t, s.IsConnected(), "stale DISCONNECT must not disconnect the replacement")
@@ -576,11 +578,12 @@ func TestHandleConnect_StalePublishNotDispatched(t *testing.T) {
 		return s != nil && s.IsConnected() && s.Conn() == newConn
 	}, "new publisher session current")
 
-	// Release the stale PUBLISH. It must be dropped, not routed.
+	// Release the stale PUBLISH. It must be dropped, not routed. The drop happens
+	// synchronously in the old runSession goroutine (the cc.current() check
+	// precedes dispatch), so oldWG.Wait guarantees the decision is final.
 	close(oldConn.releaseRead)
 	oldWG.Wait()
 
-	time.Sleep(20 * time.Millisecond)
 	require.Empty(t, subConn.packets, "stale PUBLISH must not be delivered to subscribers")
 
 	newConn.Close()
@@ -713,12 +716,19 @@ func TestHandleConnect_V5TakeoverDelayedWillNotPublished(t *testing.T) {
 	// The old connection is still notified and closed, but the delayed Will
 	// must not be published.
 	waitFor(t, func() bool { return oldConn.closed.Load() }, "old connection closed by takeover")
-	time.Sleep(30 * time.Millisecond)
-	for _, p := range subConn.writtenPackets() {
-		if pub, ok := p.(*v5.Publish); ok && pub.TopicName == willTopic {
-			t.Fatal("delayed Will must not be published on takeover")
+
+	// The Will is published (if at all) by the asynchronous drainSuperseded
+	// goroutine, which the test cannot join. require.Never polls the subscriber
+	// throughout a settle window, asserting the delayed Will never arrives —
+	// deterministic where a single sleep+check would only sample one instant.
+	require.Never(t, func() bool {
+		for _, p := range subConn.writtenPackets() {
+			if pub, ok := p.(*v5.Publish); ok && pub.TopicName == willTopic {
+				return true
+			}
 		}
-	}
+		return false
+	}, 100*time.Millisecond, 5*time.Millisecond, "delayed Will must not be published on takeover")
 
 	oldWG.Wait()
 	newConn.Close()

--- a/mqtt/broker/takeover_test.go
+++ b/mqtt/broker/takeover_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/absmach/fluxmq/mqtt/packets"
 	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/mqtt/session"
 	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/storage/memory"
@@ -148,6 +149,84 @@ func (c *blockingWriteConn) Close() error {
 		close(c.closeCh)
 	})
 	return nil
+}
+
+// syncConn is a blocking-read connection that records written packets under a
+// mutex, so a test can safely inspect packets written from another goroutine
+// (e.g. the takeover drain goroutine).
+type syncConn struct {
+	mockConnection
+	mu        sync.Mutex
+	written   []packets.ControlPacket
+	closeOnce sync.Once
+	closeCh   chan struct{}
+	closed    atomic.Bool
+	reading   chan struct{}
+	readOnce  sync.Once
+}
+
+func newSyncConn() *syncConn {
+	return &syncConn{closeCh: make(chan struct{}), reading: make(chan struct{})}
+}
+
+func (c *syncConn) record(p packets.ControlPacket, onSent func()) error {
+	c.mu.Lock()
+	c.written = append(c.written, p)
+	c.mu.Unlock()
+	if onSent != nil {
+		onSent()
+	}
+	return nil
+}
+
+func (c *syncConn) WritePacket(p packets.ControlPacket) error { return c.record(p, nil) }
+func (c *syncConn) WriteControlPacket(p packets.ControlPacket, onSent func()) error {
+	return c.record(p, onSent)
+}
+
+func (c *syncConn) WriteDataPacket(p packets.ControlPacket, onSent func()) error {
+	return c.record(p, onSent)
+}
+
+func (c *syncConn) TryWriteDataPacket(p packets.ControlPacket, onSent func()) error {
+	return c.record(p, onSent)
+}
+
+func (c *syncConn) ReadPacket() (packets.ControlPacket, error) {
+	c.readOnce.Do(func() { close(c.reading) })
+	<-c.closeCh
+	return nil, io.EOF
+}
+
+func (c *syncConn) Close() error {
+	c.closeOnce.Do(func() {
+		c.closed.Store(true)
+		close(c.closeCh)
+	})
+	return nil
+}
+
+func (c *syncConn) writtenPackets() []packets.ControlPacket {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]packets.ControlPacket(nil), c.written...)
+}
+
+func v5Connect(clientID, willTopic string, willPayload []byte) *v5.Connect {
+	c := &v5.Connect{
+		FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
+		ProtocolName:    protocolNameMQTT,
+		ProtocolVersion: 5,
+		ClientID:        clientID,
+		CleanStart:      false,
+		KeepAlive:       60,
+	}
+	if willTopic != "" {
+		c.WillFlag = true
+		c.WillTopic = willTopic
+		c.WillPayload = willPayload
+	}
+	return c
 }
 
 // bindConn wraps a session in a connCtx bound to its current connection
@@ -491,6 +570,81 @@ func TestHandleConnect_StalePublishNotDispatched(t *testing.T) {
 	time.Sleep(20 * time.Millisecond)
 	require.Empty(t, subConn.packets, "stale PUBLISH must not be delivered to subscribers")
 
+	newConn.Close()
+	newWG.Wait()
+}
+
+// TestHandleConnect_V5TakeoverNotifiesAndPublishesWill guards finding #2: an
+// MQTT 5 takeover must send the displaced client a DISCONNECT with reason 0x8E
+// (session taken over) and publish that connection's zero-delay Will.
+// References: OASIS MQTT 5.0, sections 3.1.4 and 3.1.2.5.
+func TestHandleConnect_V5TakeoverNotifiesAndPublishesWill(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+	h := newV5Handler(b)
+
+	const clientID = "proplet-v5"
+	const willTopic = "devices/proplet-v5/status"
+
+	// Subscriber that should receive the displaced connection's Will.
+	sub, _, err := b.CreateSession("will-subscriber", 5, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	subConn := newSyncConn()
+	_, err = sub.Connect(subConn)
+	require.NoError(t, err)
+	require.NoError(t, b.subscribe(sub, willTopic, 0, storage.SubscribeOptions{}))
+
+	// Old connection with a zero-delay Will.
+	oldConn := newSyncConn()
+	var oldWG sync.WaitGroup
+	oldWG.Add(1)
+	go func() {
+		defer oldWG.Done()
+		h.HandleConnect(oldConn, v5Connect(clientID, willTopic, []byte("offline"))) //nolint:errcheck
+	}()
+
+	<-oldConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(clientID)
+		return s != nil && s.IsConnected()
+	}, "old v5 session connected")
+
+	// Take over with a new connection (no Will).
+	newConn := newSyncConn()
+	var newWG sync.WaitGroup
+	newWG.Add(1)
+	go func() {
+		defer newWG.Done()
+		h.HandleConnect(newConn, v5Connect(clientID, "", nil)) //nolint:errcheck
+	}()
+
+	<-newConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(clientID)
+		return s != nil && s.IsConnected() && s.Conn() == newConn
+	}, "new v5 session current")
+
+	// The drain runs asynchronously: the old connection gets a DISCONNECT 0x8E.
+	waitFor(t, func() bool {
+		for _, p := range oldConn.writtenPackets() {
+			if d, ok := p.(*v5.Disconnect); ok && d.ReasonCode == reasonSessionTakenOver {
+				return true
+			}
+		}
+		return false
+	}, "displaced client receives DISCONNECT 0x8E")
+
+	// The displaced connection's zero-delay Will is published to the subscriber.
+	waitFor(t, func() bool {
+		for _, p := range subConn.writtenPackets() {
+			if pub, ok := p.(*v5.Publish); ok && pub.TopicName == willTopic {
+				return true
+			}
+		}
+		return false
+	}, "displaced connection's Will is published")
+
+	oldWG.Wait()
 	newConn.Close()
 	newWG.Wait()
 }

--- a/mqtt/broker/takeover_test.go
+++ b/mqtt/broker/takeover_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/absmach/fluxmq/mqtt/packets"
+	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
+	"github.com/stretchr/testify/require"
+)
+
+// blockingConn is a mockConnection whose ReadPacket blocks until the
+// connection is closed. It models a TCP socket with no inbound data — and, on
+// a high-latency link, one whose FIN has not yet been processed when the
+// client reconnects.
+type blockingConn struct {
+	mockConnection
+	closeOnce sync.Once
+	closeCh   chan struct{}
+	closed    atomic.Bool
+	reading   chan struct{} // closed when ReadPacket is first entered
+	readOnce  sync.Once
+}
+
+func newBlockingConn() *blockingConn {
+	return &blockingConn{
+		closeCh: make(chan struct{}),
+		reading: make(chan struct{}),
+	}
+}
+
+func (c *blockingConn) ReadPacket() (packets.ControlPacket, error) {
+	c.readOnce.Do(func() { close(c.reading) })
+	<-c.closeCh
+	return nil, io.EOF
+}
+
+func (c *blockingConn) Close() error {
+	c.closeOnce.Do(func() {
+		c.closed.Store(true)
+		close(c.closeCh)
+	})
+	return nil
+}
+
+const protocolNameMQTT = "MQTT"
+
+func v3Connect(clientID string) *v3.Connect {
+	return &v3.Connect{
+		FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
+		ProtocolName:    protocolNameMQTT,
+		ProtocolVersion: 4,
+		ClientID:        clientID,
+		CleanSession:    false, // persistent session — the propeller#241 scenario
+		KeepAlive:       60,
+	}
+}
+
+func waitFor(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for: %s", msg)
+}
+
+// TestHandleConnect_LocalTakeoverHighLatencyReconnect reproduces propeller#241:
+// a persistent-session client reconnects with the same client ID while its
+// previous connection is still attached (the old FIN delayed by a high-latency
+// link). The broker must close the old connection and keep the new one — the
+// superseded runSession goroutine must NOT tear down the new connection.
+func TestHandleConnect_LocalTakeoverHighLatencyReconnect(t *testing.T) {
+	b := NewBroker(nil, nil)
+	defer b.Close()
+	h := NewV3Handler(b)
+
+	const clientID = "proplet-1"
+
+	// First connection: enters runSession and blocks reading (idle socket).
+	oldConn := newBlockingConn()
+	var oldWG sync.WaitGroup
+	oldWG.Add(1)
+	go func() {
+		defer oldWG.Done()
+		h.HandleConnect(oldConn, v3Connect(clientID)) //nolint:errcheck // returns io.EOF on takeover
+	}()
+
+	// Wait until the old connection's session is registered and reading.
+	<-oldConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(clientID)
+		return s != nil && s.IsConnected()
+	}, "old session connected")
+
+	// Second connection: same client ID, persistent session. This triggers the
+	// local takeover — old conn must be closed, new conn becomes current.
+	newConn := newBlockingConn()
+	var newWG sync.WaitGroup
+	newWG.Add(1)
+	go func() {
+		defer newWG.Done()
+		h.HandleConnect(newConn, v3Connect(clientID)) //nolint:errcheck // closed at cleanup
+	}()
+
+	// Old runSession goroutine unblocks (its socket was closed) and exits.
+	oldWG.Wait()
+	require.True(t, oldConn.closed.Load(), "takeover must close the old connection")
+
+	// New connection must own the session and stay connected, even after the
+	// stale old goroutine has fully torn down.
+	<-newConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(clientID)
+		return s != nil && s.IsConnected() && s.Conn() == newConn
+	}, "new session connected and current")
+
+	require.False(t, newConn.closed.Load(), "new connection must remain open after takeover")
+
+	// Give any stale teardown a chance to (incorrectly) fire, then re-assert.
+	time.Sleep(20 * time.Millisecond)
+	s := b.sessionsMap.Get(clientID)
+	require.NotNil(t, s)
+	require.True(t, s.IsConnected(), "new connection must survive the stale goroutine's teardown")
+	require.False(t, newConn.closed.Load())
+
+	// Cleanup: release the new connection so its runSession exits.
+	newConn.Close()
+	newWG.Wait()
+}

--- a/mqtt/broker/takeover_test.go
+++ b/mqtt/broker/takeover_test.go
@@ -49,6 +49,42 @@ func (c *blockingConn) Close() error {
 	return nil
 }
 
+// scriptedConn delivers exactly one packet, but only after releaseRead is
+// closed. This lets a test sequence a read so it completes *after* a takeover
+// has already swapped in the replacement connection — reproducing a stale
+// in-flight packet.
+type scriptedConn struct {
+	mockConnection
+	pkt         packets.ControlPacket
+	releaseRead chan struct{}
+	delivered   atomic.Bool
+	closed      atomic.Bool
+	reading     chan struct{}
+	readOnce    sync.Once
+}
+
+func newScriptedConn(pkt packets.ControlPacket) *scriptedConn {
+	return &scriptedConn{
+		pkt:         pkt,
+		releaseRead: make(chan struct{}),
+		reading:     make(chan struct{}),
+	}
+}
+
+func (c *scriptedConn) ReadPacket() (packets.ControlPacket, error) {
+	c.readOnce.Do(func() { close(c.reading) })
+	if !c.delivered.Swap(true) {
+		<-c.releaseRead // deliver the scripted packet only when the test allows
+		return c.pkt, nil
+	}
+	return nil, io.EOF
+}
+
+func (c *scriptedConn) Close() error {
+	c.closed.Store(true)
+	return nil
+}
+
 const protocolNameMQTT = "MQTT"
 
 func v3Connect(clientID string) *v3.Connect {
@@ -134,6 +170,72 @@ func TestHandleConnect_LocalTakeoverHighLatencyReconnect(t *testing.T) {
 	require.False(t, newConn.closed.Load())
 
 	// Cleanup: release the new connection so its runSession exits.
+	newConn.Close()
+	newWG.Wait()
+}
+
+// TestHandleConnect_StaleDisconnectDoesNotCloseReplacement reproduces the
+// second half of propeller#241: a DISCONNECT read on the old connection but
+// processed *after* the takeover must not tear down the replacement
+// connection. The processing guard skips dispatch for the superseded
+// generation, so the new connection survives.
+func TestHandleConnect_StaleDisconnectDoesNotCloseReplacement(t *testing.T) {
+	b := NewBroker(nil, nil)
+	defer b.Close()
+	h := NewV3Handler(b)
+
+	const clientID = "proplet-2"
+
+	// Old connection has a DISCONNECT queued, released only after takeover.
+	disconnect := &v3.Disconnect{
+		FixedHeader: packets.FixedHeader{PacketType: packets.DisconnectType},
+	}
+	oldConn := newScriptedConn(disconnect)
+	var oldWG sync.WaitGroup
+	oldWG.Add(1)
+	go func() {
+		defer oldWG.Done()
+		h.HandleConnect(oldConn, v3Connect(clientID)) //nolint:errcheck
+	}()
+
+	<-oldConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(clientID)
+		return s != nil && s.IsConnected()
+	}, "old session connected")
+
+	// Take over with a new connection. This completes the swap before the old
+	// goroutine ever returns from its read.
+	newConn := newBlockingConn()
+	var newWG sync.WaitGroup
+	newWG.Add(1)
+	go func() {
+		defer newWG.Done()
+		h.HandleConnect(newConn, v3Connect(clientID)) //nolint:errcheck
+	}()
+
+	<-newConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(clientID)
+		return s != nil && s.IsConnected() && s.Conn() == newConn
+	}, "new session connected and current")
+
+	// Now let the old connection deliver its stale DISCONNECT. Its goroutine
+	// must observe the superseded epoch and skip dispatch — without the guard
+	// it would call s.Disconnect() and close newConn.
+	close(oldConn.releaseRead)
+	oldWG.Wait()
+
+	require.True(t, oldConn.closed.Load(), "old conn closed by takeover")
+
+	// Give the stale DISCONNECT a chance to (incorrectly) tear down the session.
+	time.Sleep(20 * time.Millisecond)
+	s := b.sessionsMap.Get(clientID)
+	require.NotNil(t, s)
+	require.True(t, s.IsConnected(), "stale DISCONNECT must not disconnect the replacement")
+	require.Equal(t, newConn, s.Conn())
+	require.False(t, newConn.closed.Load())
+
 	newConn.Close()
 	newWG.Wait()
 }

--- a/mqtt/broker/takeover_test.go
+++ b/mqtt/broker/takeover_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/absmach/fluxmq/mqtt/packets"
 	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
+	"github.com/absmach/fluxmq/mqtt/session"
 	"github.com/stretchr/testify/require"
 )
 
@@ -83,6 +84,74 @@ func (c *scriptedConn) ReadPacket() (packets.ControlPacket, error) {
 func (c *scriptedConn) Close() error {
 	c.closed.Store(true)
 	return nil
+}
+
+// blockingWriteConn delivers one packet, then blocks in WritePacket until it is
+// closed — modelling a client that has stopped reading (full socket buffer) on
+// a high-latency link. A takeover must not stall behind such a write.
+type blockingWriteConn struct {
+	mockConnection
+	pkt         packets.ControlPacket
+	releaseRead chan struct{}
+	reading     chan struct{}
+	writing     chan struct{} // closed when WritePacket is first entered
+	closeCh     chan struct{}
+	delivered   atomic.Bool
+	closed      atomic.Bool
+	readOnce    sync.Once
+	writeOnce   sync.Once
+	closeOnce   sync.Once
+}
+
+func newBlockingWriteConn(pkt packets.ControlPacket) *blockingWriteConn {
+	return &blockingWriteConn{
+		pkt:         pkt,
+		releaseRead: make(chan struct{}),
+		reading:     make(chan struct{}),
+		writing:     make(chan struct{}),
+		closeCh:     make(chan struct{}),
+	}
+}
+
+func (c *blockingWriteConn) ReadPacket() (packets.ControlPacket, error) {
+	c.readOnce.Do(func() { close(c.reading) })
+	if !c.delivered.Swap(true) {
+		select {
+		case <-c.releaseRead:
+			return c.pkt, nil
+		case <-c.closeCh:
+			return nil, io.EOF
+		}
+	}
+	<-c.closeCh
+	return nil, io.EOF
+}
+
+func (c *blockingWriteConn) WritePacket(packets.ControlPacket) error {
+	if !c.delivered.Load() {
+		return nil // let the CONNACK (written before the PINGREQ) through
+	}
+	c.writeOnce.Do(func() { close(c.writing) })
+	<-c.closeCh // block until closed, like a peer that stopped reading
+	return io.ErrClosedPipe
+}
+
+func (c *blockingWriteConn) WriteControlPacket(pkt packets.ControlPacket, _ func()) error {
+	return c.WritePacket(pkt)
+}
+
+func (c *blockingWriteConn) Close() error {
+	c.closeOnce.Do(func() {
+		c.closed.Store(true)
+		close(c.closeCh)
+	})
+	return nil
+}
+
+// bindConn wraps a session in a connCtx bound to its current connection
+// generation, for tests that call Handle* methods directly.
+func bindConn(s *session.Session) *connCtx {
+	return &connCtx{Session: s, conn: s.Conn(), epoch: s.Epoch()}
 }
 
 const protocolNameMQTT = "MQTT"
@@ -169,9 +238,17 @@ func TestHandleConnect_LocalTakeoverHighLatencyReconnect(t *testing.T) {
 	require.True(t, s.IsConnected(), "new connection must survive the stale goroutine's teardown")
 	require.False(t, newConn.closed.Load())
 
+	// Exactly one active connection: the superseded goroutine must have
+	// decremented the counter on its way out, not leaked it.
+	require.Equal(t, uint64(1), b.telemetry.stats.GetCurrentConnections(),
+		"active-connection count must be 1 after takeover")
+
 	// Cleanup: release the new connection so its runSession exits.
 	newConn.Close()
 	newWG.Wait()
+	waitFor(t, func() bool {
+		return b.telemetry.stats.GetCurrentConnections() == 0
+	}, "active-connection count drains to zero")
 }
 
 // TestHandleConnect_StaleDisconnectDoesNotCloseReplacement reproduces the
@@ -220,9 +297,10 @@ func TestHandleConnect_StaleDisconnectDoesNotCloseReplacement(t *testing.T) {
 		return s != nil && s.IsConnected() && s.Conn() == newConn
 	}, "new session connected and current")
 
-	// Now let the old connection deliver its stale DISCONNECT. Its goroutine
-	// must observe the superseded epoch and skip dispatch — without the guard
-	// it would call s.Disconnect() and close newConn.
+	// Now let the old connection deliver its stale DISCONNECT. Its connCtx is
+	// bound to the superseded generation, so connCtx.Disconnect is a no-op via
+	// DisconnectIf — without that binding it would call Disconnect and close
+	// newConn.
 	close(oldConn.releaseRead)
 	oldWG.Wait()
 
@@ -235,7 +313,109 @@ func TestHandleConnect_StaleDisconnectDoesNotCloseReplacement(t *testing.T) {
 	require.True(t, s.IsConnected(), "stale DISCONNECT must not disconnect the replacement")
 	require.Equal(t, newConn, s.Conn())
 	require.False(t, newConn.closed.Load())
+	require.Equal(t, uint64(1), b.telemetry.stats.GetCurrentConnections(),
+		"active-connection count must be 1 after stale-DISCONNECT takeover")
 
 	newConn.Close()
 	newWG.Wait()
+}
+
+// TestHandleConnect_TakeoverNotBlockedByStalledWrite guards finding #1: a
+// takeover must complete even while the superseded connection's handler is
+// blocked writing to a peer that stopped reading. The previous design held a
+// processing lock across handler work, so the takeover deadlocked behind the
+// blocked write; generation-safe writes hold no such lock.
+func TestHandleConnect_TakeoverNotBlockedByStalledWrite(t *testing.T) {
+	b := NewBroker(nil, nil)
+	defer b.Close()
+	h := NewV3Handler(b)
+
+	const clientID = "proplet-stalled"
+
+	// Old connection: delivers a PINGREQ, whose PINGRESP write then blocks.
+	pingreq := &v3.PingReq{FixedHeader: packets.FixedHeader{PacketType: packets.PingReqType}}
+	oldConn := newBlockingWriteConn(pingreq)
+	var oldWG sync.WaitGroup
+	oldWG.Add(1)
+	go func() {
+		defer oldWG.Done()
+		h.HandleConnect(oldConn, v3Connect(clientID)) //nolint:errcheck
+	}()
+
+	<-oldConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(clientID)
+		return s != nil && s.IsConnected()
+	}, "old session connected")
+
+	// Deliver the PINGREQ and wait until the handler is stuck in the write.
+	close(oldConn.releaseRead)
+	<-oldConn.writing
+
+	// Take over while the old handler is blocked writing. This must not hang.
+	newConn := newBlockingConn()
+	var newWG sync.WaitGroup
+	newWG.Add(1)
+	go func() {
+		defer newWG.Done()
+		h.HandleConnect(newConn, v3Connect(clientID)) //nolint:errcheck
+	}()
+
+	<-newConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(clientID)
+		return s != nil && s.IsConnected() && s.Conn() == newConn
+	}, "takeover completes despite stalled write on old connection")
+
+	// The takeover closed the old connection, unblocking its write so its
+	// goroutine exits.
+	oldWG.Wait()
+	require.True(t, oldConn.closed.Load())
+
+	newConn.Close()
+	newWG.Wait()
+}
+
+// TestHandleConnect_RepeatedTakeoversDoNotLeakConnectionCount guards finding #2:
+// every superseded runSession goroutine must decrement the active-connection
+// counter exactly once. Repeated reconnects of the same client ID must leave
+// the count at one live connection, never inflating it.
+func TestHandleConnect_RepeatedTakeoversDoNotLeakConnectionCount(t *testing.T) {
+	b := NewBroker(nil, nil)
+	defer b.Close()
+	h := NewV3Handler(b)
+
+	const clientID = "proplet-loop"
+	const rounds = 8
+
+	var wg sync.WaitGroup
+	conns := make([]*blockingConn, rounds)
+
+	for i := range rounds {
+		conns[i] = newBlockingConn()
+		wg.Add(1)
+		go func(c *blockingConn) {
+			defer wg.Done()
+			h.HandleConnect(c, v3Connect(clientID)) //nolint:errcheck
+		}(conns[i])
+
+		<-conns[i].reading
+		// Wait until this connection owns the session and the previous
+		// goroutine has exited (count back to exactly one).
+		current := conns[i]
+		waitFor(t, func() bool {
+			s := b.sessionsMap.Get(clientID)
+			return s != nil && s.IsConnected() && s.Conn() == current &&
+				b.telemetry.stats.GetCurrentConnections() == 1
+		}, "single live connection after takeover round")
+	}
+
+	require.Equal(t, uint64(1), b.telemetry.stats.GetCurrentConnections())
+
+	// Close the surviving connection; count must drain to zero.
+	conns[rounds-1].Close()
+	wg.Wait()
+	waitFor(t, func() bool {
+		return b.telemetry.stats.GetCurrentConnections() == 0
+	}, "active-connection count drains to zero")
 }

--- a/mqtt/broker/takeover_test.go
+++ b/mqtt/broker/takeover_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/absmach/fluxmq/mqtt/packets"
 	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
 	"github.com/absmach/fluxmq/mqtt/session"
+	"github.com/absmach/fluxmq/storage"
+	"github.com/absmach/fluxmq/storage/memory"
 	"github.com/stretchr/testify/require"
 )
 
@@ -187,7 +189,7 @@ func waitFor(t *testing.T, cond func() bool, msg string) {
 func TestHandleConnect_LocalTakeoverHighLatencyReconnect(t *testing.T) {
 	b := NewBroker(nil, nil)
 	defer b.Close()
-	h := NewV3Handler(b)
+	h := newV3Handler(b)
 
 	const clientID = "proplet-1"
 
@@ -259,7 +261,7 @@ func TestHandleConnect_LocalTakeoverHighLatencyReconnect(t *testing.T) {
 func TestHandleConnect_StaleDisconnectDoesNotCloseReplacement(t *testing.T) {
 	b := NewBroker(nil, nil)
 	defer b.Close()
-	h := NewV3Handler(b)
+	h := newV3Handler(b)
 
 	const clientID = "proplet-2"
 
@@ -328,7 +330,7 @@ func TestHandleConnect_StaleDisconnectDoesNotCloseReplacement(t *testing.T) {
 func TestHandleConnect_TakeoverNotBlockedByStalledWrite(t *testing.T) {
 	b := NewBroker(nil, nil)
 	defer b.Close()
-	h := NewV3Handler(b)
+	h := newV3Handler(b)
 
 	const clientID = "proplet-stalled"
 
@@ -389,7 +391,7 @@ func TestHandleConnect_TakeoverNotBlockedByStalledWrite(t *testing.T) {
 func TestHandleConnect_RepeatedTakeoversDoNotLeakConnectionCount(t *testing.T) {
 	b := NewBroker(nil, nil)
 	defer b.Close()
-	h := NewV3Handler(b)
+	h := newV3Handler(b)
 
 	const clientID = "proplet-loop"
 	const rounds = 8
@@ -424,4 +426,71 @@ func TestHandleConnect_RepeatedTakeoversDoNotLeakConnectionCount(t *testing.T) {
 	waitFor(t, func() bool {
 		return b.telemetry.stats.GetCurrentConnections() == 0
 	}, "active-connection count drains to zero")
+}
+
+// TestHandleConnect_StalePublishNotDispatched guards finding #1: a PUBLISH read
+// on the old connection but processed after a takeover must not mutate shared
+// state — here, it must not be routed to subscribers through the broker. The
+// generation check drops the packet before dispatch.
+func TestHandleConnect_StalePublishNotDispatched(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+	h := newV3Handler(b)
+
+	const pubID = "publisher"
+	const topic = "devices/telemetry"
+
+	// A subscriber on a separate session; its connection captures deliveries.
+	sub, _, err := b.CreateSession("subscriber", 4, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	subConn := &captureConnection{}
+	_, err = sub.Connect(subConn)
+	require.NoError(t, err)
+	require.NoError(t, b.subscribe(sub, topic, 0, storage.SubscribeOptions{}))
+
+	// Publisher's old connection has a QoS0 PUBLISH queued, released only after
+	// the takeover.
+	pub := &v3.Publish{
+		FixedHeader: packets.FixedHeader{PacketType: packets.PublishType},
+		TopicName:   topic,
+		Payload:     []byte("stale"),
+	}
+	oldConn := newScriptedConn(pub)
+	var oldWG sync.WaitGroup
+	oldWG.Add(1)
+	go func() {
+		defer oldWG.Done()
+		h.HandleConnect(oldConn, v3Connect(pubID)) //nolint:errcheck
+	}()
+
+	<-oldConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(pubID)
+		return s != nil && s.IsConnected()
+	}, "old publisher session connected")
+
+	// Take over the publisher's client ID before the PUBLISH is processed.
+	newConn := newBlockingConn()
+	var newWG sync.WaitGroup
+	newWG.Add(1)
+	go func() {
+		defer newWG.Done()
+		h.HandleConnect(newConn, v3Connect(pubID)) //nolint:errcheck
+	}()
+
+	<-newConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(pubID)
+		return s != nil && s.IsConnected() && s.Conn() == newConn
+	}, "new publisher session current")
+
+	// Release the stale PUBLISH. It must be dropped, not routed.
+	close(oldConn.releaseRead)
+	oldWG.Wait()
+
+	time.Sleep(20 * time.Millisecond)
+	require.Empty(t, subConn.packets, "stale PUBLISH must not be delivered to subscribers")
+
+	newConn.Close()
+	newWG.Wait()
 }

--- a/mqtt/broker/takeover_test.go
+++ b/mqtt/broker/takeover_test.go
@@ -372,6 +372,12 @@ func TestHandleConnect_TakeoverNotBlockedByStalledWrite(t *testing.T) {
 	oldWG.Wait()
 	require.True(t, oldConn.closed.Load())
 
+	// The superseded goroutine's blocked PINGRESP write failed against its own
+	// closed socket. That is expected teardown and must not be counted as a
+	// protocol error on the broker.
+	require.Equal(t, uint64(0), b.telemetry.stats.GetProtocolErrors(),
+		"stale write failure must not be counted as a protocol error")
+
 	newConn.Close()
 	newWG.Wait()
 }

--- a/mqtt/broker/takeover_test.go
+++ b/mqtt/broker/takeover_test.go
@@ -952,8 +952,8 @@ func TestRestoreInflightFromTakeover_PreservesDirection(t *testing.T) {
 
 	state := &clusterv1.SessionState{
 		InflightMessages: []*clusterv1.InflightMessage{
-			{PacketId: 5, Topic: "out", Qos: 2, Direction: uint32(messages.Outbound)},
-			{PacketId: 5, Topic: "in", Qos: 2, Direction: uint32(messages.Inbound)},
+			{PacketId: 5, Topic: "out", Qos: 2, Direction: uint32(messages.Outbound), Payload: []byte("op")},
+			{PacketId: 5, Topic: "in", Qos: 2, Direction: uint32(messages.Inbound), Payload: []byte("ip")},
 		},
 	}
 	tracker := messages.NewInflightTracker(16)
@@ -962,7 +962,42 @@ func TestRestoreInflightFromTakeover_PreservesDirection(t *testing.T) {
 	gotOut, err := tracker.Ack(5)
 	require.NoError(t, err)
 	require.Equal(t, "out", gotOut.Topic)
+	require.Equal(t, "op", string(gotOut.GetPayload()), "payload must survive cluster transfer")
 	gotIn, err := tracker.AckInbound(5)
 	require.NoError(t, err)
 	require.Equal(t, "in", gotIn.Topic)
+	require.Equal(t, "ip", string(gotIn.GetPayload()))
+}
+
+// TestRestoreInflightFromTakeover_SkipsInvalidDirection guards finding #2: a
+// corrupt direction from transferred state is skipped, not panicking.
+func TestRestoreInflightFromTakeover_SkipsInvalidDirection(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+
+	state := &clusterv1.SessionState{
+		InflightMessages: []*clusterv1.InflightMessage{
+			{PacketId: 1, Topic: "ok", Qos: 1, Direction: uint32(messages.Outbound)},
+			{PacketId: 2, Topic: "bad", Qos: 1, Direction: 99}, // corrupt
+		},
+	}
+	tracker := messages.NewInflightTracker(16)
+	require.NoError(t, b.restoreInflightFromTakeover(state, tracker))
+
+	require.True(t, tracker.Has(1))
+	require.False(t, tracker.Has(2), "entry with invalid direction must be skipped")
+}
+
+// TestSession_AckInbound_UsesDirectionalAck guards finding #3: inbound
+// acknowledgement is reachable without the base Inflight interface declaring it.
+func TestSession_AckInbound_UsesDirectionalAck(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+	s, _, err := b.CreateSession("c", 5, session.Options{CleanStart: true})
+	require.NoError(t, err)
+
+	require.NoError(t, s.Inflight().Add(9, &storage.Message{Topic: "in"}, messages.Inbound))
+	got, err := s.AckInbound(9)
+	require.NoError(t, err)
+	require.Equal(t, "in", got.Topic)
 }

--- a/mqtt/broker/takeover_test.go
+++ b/mqtt/broker/takeover_test.go
@@ -213,6 +213,10 @@ func (c *syncConn) writtenPackets() []packets.ControlPacket {
 }
 
 func v5Connect(clientID, willTopic string, willPayload []byte) *v5.Connect {
+	return v5ConnectWillDelay(clientID, willTopic, willPayload, 0)
+}
+
+func v5ConnectWillDelay(clientID, willTopic string, willPayload []byte, willDelay uint32) *v5.Connect {
 	c := &v5.Connect{
 		FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
 		ProtocolName:    protocolNameMQTT,
@@ -225,6 +229,10 @@ func v5Connect(clientID, willTopic string, willPayload []byte) *v5.Connect {
 		c.WillFlag = true
 		c.WillTopic = willTopic
 		c.WillPayload = willPayload
+		if willDelay > 0 {
+			d := willDelay
+			c.WillProperties = &v5.WillProperties{WillDelayInterval: &d}
+		}
 	}
 	return c
 }
@@ -300,7 +308,7 @@ func TestHandleConnect_LocalTakeoverHighLatencyReconnect(t *testing.T) {
 
 	// Old runSession goroutine unblocks (its socket was closed) and exits.
 	oldWG.Wait()
-	require.True(t, oldConn.closed.Load(), "takeover must close the old connection")
+	waitFor(t, func() bool { return oldConn.closed.Load() }, "takeover must close the old connection")
 
 	// New connection must own the session and stay connected, even after the
 	// stale old goroutine has fully torn down.
@@ -385,7 +393,7 @@ func TestHandleConnect_StaleDisconnectDoesNotCloseReplacement(t *testing.T) {
 	close(oldConn.releaseRead)
 	oldWG.Wait()
 
-	require.True(t, oldConn.closed.Load(), "old conn closed by takeover")
+	waitFor(t, func() bool { return oldConn.closed.Load() }, "old conn closed by takeover")
 
 	// Give the stale DISCONNECT a chance to (incorrectly) tear down the session.
 	time.Sleep(20 * time.Millisecond)
@@ -451,7 +459,7 @@ func TestHandleConnect_TakeoverNotBlockedByStalledWrite(t *testing.T) {
 	// The takeover closed the old connection, unblocking its write so its
 	// goroutine exits.
 	oldWG.Wait()
-	require.True(t, oldConn.closed.Load())
+	waitFor(t, func() bool { return oldConn.closed.Load() }, "takeover closes the stalled connection")
 
 	// The superseded goroutine's blocked PINGRESP write failed against its own
 	// closed socket. That is expected teardown and must not be counted as a
@@ -643,6 +651,69 @@ func TestHandleConnect_V5TakeoverNotifiesAndPublishesWill(t *testing.T) {
 		}
 		return false
 	}, "displaced connection's Will is published")
+
+	oldWG.Wait()
+	newConn.Close()
+	newWG.Wait()
+}
+
+// TestHandleConnect_V5TakeoverDelayedWillNotPublished guards finding #1: a Will
+// with a non-zero Will Delay Interval must NOT be published when a takeover
+// closes the connection — the session continues under the new connection, so
+// the delayed Will is cancelled. [MQTT-3.1.2.5].
+func TestHandleConnect_V5TakeoverDelayedWillNotPublished(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+	h := newV5Handler(b)
+
+	const clientID = "proplet-delay"
+	const willTopic = "devices/proplet-delay/status"
+
+	sub, _, err := b.CreateSession("delay-sub", 5, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	subConn := newSyncConn()
+	_, err = sub.Connect(subConn)
+	require.NoError(t, err)
+	require.NoError(t, b.subscribe(sub, willTopic, 0, storage.SubscribeOptions{}))
+
+	// Old connection with a 60s-delayed Will.
+	oldConn := newSyncConn()
+	var oldWG sync.WaitGroup
+	oldWG.Add(1)
+	go func() {
+		defer oldWG.Done()
+		h.HandleConnect(oldConn, v5ConnectWillDelay(clientID, willTopic, []byte("offline"), 60)) //nolint:errcheck
+	}()
+
+	<-oldConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(clientID)
+		return s != nil && s.IsConnected()
+	}, "old v5 session connected")
+
+	newConn := newSyncConn()
+	var newWG sync.WaitGroup
+	newWG.Add(1)
+	go func() {
+		defer newWG.Done()
+		h.HandleConnect(newConn, v5Connect(clientID, "", nil)) //nolint:errcheck
+	}()
+
+	<-newConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(clientID)
+		return s != nil && s.IsConnected() && s.Conn() == newConn
+	}, "new v5 session current")
+
+	// The old connection is still notified and closed, but the delayed Will
+	// must not be published.
+	waitFor(t, func() bool { return oldConn.closed.Load() }, "old connection closed by takeover")
+	time.Sleep(30 * time.Millisecond)
+	for _, p := range subConn.writtenPackets() {
+		if pub, ok := p.(*v5.Publish); ok && pub.TopicName == willTopic {
+			t.Fatal("delayed Will must not be published on takeover")
+		}
+	}
 
 	oldWG.Wait()
 	newConn.Close()

--- a/mqtt/broker/takeover_test.go
+++ b/mqtt/broker/takeover_test.go
@@ -4,6 +4,7 @@
 package broker
 
 import (
+	"context"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -744,4 +745,91 @@ func TestCreateSession_InflightTrackerSizedByServerLimit(t *testing.T) {
 		require.NoError(t, s.Inflight().Add(i, m, messages.Inbound),
 			"inbound QoS 2 must not be limited by the client's outbound Receive Maximum")
 	}
+}
+
+// TestDeliverMessage_EncodesForLeaseVersion guards finding #1: the PUBLISH is
+// encoded for the version captured in the delivery lease, not the session's
+// mutable version, so a cross-version takeover cannot encode for one protocol
+// and write to a connection of the other.
+func TestDeliverMessage_EncodesForLeaseVersion(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+
+	v3msg := &storage.Message{Topic: "t", QoS: 1, PacketID: 1}
+	v3msg.SetPayloadFromBytes([]byte("x"))
+	v3conn := newSyncConn()
+	require.NoError(t, b.DeliverMessage(v3conn, 4, v3msg, nil))
+	require.Len(t, v3conn.writtenPackets(), 1)
+	require.IsType(t, &v3.Publish{}, v3conn.writtenPackets()[0])
+
+	v5msg := &storage.Message{Topic: "t", QoS: 1, PacketID: 2}
+	v5msg.SetPayloadFromBytes([]byte("x"))
+	v5conn := newSyncConn()
+	require.NoError(t, b.DeliverMessage(v5conn, 5, v5msg, nil))
+	require.Len(t, v5conn.writtenPackets(), 1)
+	require.IsType(t, &v5.Publish{}, v5conn.writtenPackets()[0])
+}
+
+// TestDeliverQoS_SupersededLeaseRetriesCurrentGeneration guards finding #2: a
+// delivery whose lease was superseded must retry against the current generation
+// and reach the connection, not be parked where nothing drains it.
+func TestDeliverQoS_SupersededLeaseRetriesCurrentGeneration(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+
+	s, _, err := b.CreateSession("c", 5, session.Options{CleanStart: true, ReceiveMaximum: 4})
+	require.NoError(t, err)
+	conn := newSyncConn()
+	_, err = s.Connect(conn)
+	require.NoError(t, err)
+	gen := s.Epoch()
+
+	msg := &storage.Message{Topic: "t", QoS: 1}
+	msg.SetPayloadFromBytes([]byte("x"))
+
+	// Deliver under a stale (superseded) generation: it must re-lease against the
+	// current generation and deliver, not fall back to the offline/pending path.
+	pid, err := b.deliverQoS(context.Background(), s, msg, conn, 5, gen-1, 0)
+	require.NoError(t, err)
+	require.NotZero(t, pid, "delivery must succeed against the current generation")
+	require.Len(t, conn.writtenPackets(), 1, "message must reach the live connection")
+}
+
+// TestConnAck_AdvertisesServerReceiveMaximum guards finding #3: CONNACK
+// advertises the server's actual inbound Receive Maximum, not the protocol
+// default of 65535.
+func TestConnAck_AdvertisesServerReceiveMaximum(t *testing.T) {
+	b := NewBroker(memory.New(), nil, WithSessionConfig(config.SessionConfig{
+		MaxInflightMessages: 50,
+		InflightOverflow:    config.InflightOverflowBackpressure,
+	}))
+	defer b.Close()
+	h := newV5Handler(b)
+
+	conn := newSyncConn()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		h.HandleConnect(conn, v5Connect("c", "", nil)) //nolint:errcheck
+	}()
+
+	<-conn.reading
+	var ack *v5.ConnAck
+	waitFor(t, func() bool {
+		for _, p := range conn.writtenPackets() {
+			if a, ok := p.(*v5.ConnAck); ok {
+				ack = a
+				return true
+			}
+		}
+		return false
+	}, "CONNACK written")
+
+	require.NotNil(t, ack.Properties)
+	require.NotNil(t, ack.Properties.ReceiveMax)
+	require.Equal(t, uint16(50), *ack.Properties.ReceiveMax)
+
+	conn.Close()
+	wg.Wait()
 }

--- a/mqtt/broker/takeover_test.go
+++ b/mqtt/broker/takeover_test.go
@@ -10,12 +10,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/absmach/fluxmq/config"
 	"github.com/absmach/fluxmq/mqtt/packets"
 	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
 	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/mqtt/session"
 	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/storage/memory"
+	"github.com/absmach/fluxmq/storage/messages"
 	"github.com/stretchr/testify/require"
 )
 
@@ -718,4 +720,28 @@ func TestHandleConnect_V5TakeoverDelayedWillNotPublished(t *testing.T) {
 	oldWG.Wait()
 	newConn.Close()
 	newWG.Wait()
+}
+
+// TestCreateSession_InflightTrackerSizedByServerLimit guards finding #2: the
+// persistent bidirectional inflight store is sized by the server limit, not the
+// client's outbound Receive Maximum, so inbound QoS 2 transactions are not
+// starved by a small advertised Receive Maximum.
+func TestCreateSession_InflightTrackerSizedByServerLimit(t *testing.T) {
+	b := NewBroker(memory.New(), nil, WithSessionConfig(config.SessionConfig{
+		MaxInflightMessages: 10,
+		InflightOverflow:    config.InflightOverflowBackpressure,
+	}))
+	defer b.Close()
+
+	s, _, err := b.CreateSession("c", 5, session.Options{CleanStart: true, ReceiveMaximum: 1})
+	require.NoError(t, err)
+	require.Equal(t, uint16(1), s.ReceiveMaximum, "outbound send quota is clamped to the client Receive Maximum")
+
+	// The store accepts several inbound QoS 2 transactions even though the
+	// outbound send quota is one.
+	for i := uint16(1); i <= 5; i++ {
+		m := &storage.Message{Topic: "t", QoS: 2}
+		require.NoError(t, s.Inflight().Add(i, m, messages.Inbound),
+			"inbound QoS 2 must not be limited by the client's outbound Receive Maximum")
+	}
 }

--- a/mqtt/broker/takeover_test.go
+++ b/mqtt/broker/takeover_test.go
@@ -5,6 +5,7 @@ package broker
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"sync"
 	"sync/atomic"
@@ -16,6 +17,7 @@ import (
 	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
 	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/mqtt/session"
+	clusterv1 "github.com/absmach/fluxmq/pkg/proto/cluster/v1"
 	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/storage/memory"
 	"github.com/absmach/fluxmq/storage/messages"
@@ -915,4 +917,52 @@ func TestDelivery_StaleOnSentDoesNotMarkSent(t *testing.T) {
 
 	oldConn.Close()
 	newConn.Close()
+}
+
+// TestRestoreInflightFromStorage_PreservesDirection guards finding #1: inbound
+// and outbound inflight entries that share a packet ID are persisted under
+// direction-qualified keys and restored to their original directions.
+func TestRestoreInflightFromStorage_PreservesDirection(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+
+	const clientID = "c"
+	out := &storage.Message{Topic: "out", PacketID: 5, QoS: 2, InflightDirection: byte(messages.Outbound)}
+	in := &storage.Message{Topic: "in", PacketID: 5, QoS: 2, InflightDirection: byte(messages.Inbound)}
+	require.NoError(t, b.stores.messages.Store(fmt.Sprintf("%s%s%d/%d", clientID, inflightPrefix, messages.Outbound, 5), out))
+	require.NoError(t, b.stores.messages.Store(fmt.Sprintf("%s%s%d/%d", clientID, inflightPrefix, messages.Inbound, 5), in))
+
+	tracker := messages.NewInflightTracker(16)
+	require.NoError(t, b.restoreInflightFromStorage(clientID, tracker))
+
+	gotOut, err := tracker.Ack(5)
+	require.NoError(t, err)
+	require.Equal(t, "out", gotOut.Topic)
+	gotIn, err := tracker.AckInbound(5)
+	require.NoError(t, err)
+	require.Equal(t, "in", gotIn.Topic)
+}
+
+// TestRestoreInflightFromTakeover_PreservesDirection guards finding #1 for the
+// cluster transfer path: the takeover state carries direction, and restoration
+// keeps inbound and outbound entries distinct.
+func TestRestoreInflightFromTakeover_PreservesDirection(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+
+	state := &clusterv1.SessionState{
+		InflightMessages: []*clusterv1.InflightMessage{
+			{PacketId: 5, Topic: "out", Qos: 2, Direction: uint32(messages.Outbound)},
+			{PacketId: 5, Topic: "in", Qos: 2, Direction: uint32(messages.Inbound)},
+		},
+	}
+	tracker := messages.NewInflightTracker(16)
+	require.NoError(t, b.restoreInflightFromTakeover(state, tracker))
+
+	gotOut, err := tracker.Ack(5)
+	require.NoError(t, err)
+	require.Equal(t, "out", gotOut.Topic)
+	gotIn, err := tracker.AckInbound(5)
+	require.NoError(t, err)
+	require.Equal(t, "in", gotIn.Topic)
 }

--- a/mqtt/broker/takeover_test.go
+++ b/mqtt/broker/takeover_test.go
@@ -833,3 +833,86 @@ func TestConnAck_AdvertisesServerReceiveMaximum(t *testing.T) {
 	conn.Close()
 	wg.Wait()
 }
+
+// deferConn captures the onSent callback of the last data write without invoking
+// it, so a test can fire it after a takeover to simulate an asynchronous flush
+// on the displaced connection.
+type deferConn struct {
+	mockConnection
+	mu        sync.Mutex
+	onSent    func()
+	reading   chan struct{}
+	closeCh   chan struct{}
+	readOnce  sync.Once
+	closeOnce sync.Once
+}
+
+func newDeferConn() *deferConn {
+	return &deferConn{reading: make(chan struct{}), closeCh: make(chan struct{})}
+}
+
+func (c *deferConn) capture(onSent func()) error {
+	c.mu.Lock()
+	c.onSent = onSent
+	c.mu.Unlock()
+	return nil
+}
+func (c *deferConn) WritePacket(packets.ControlPacket) error                    { return nil }
+func (c *deferConn) WriteControlPacket(_ packets.ControlPacket, f func()) error { return c.capture(f) }
+func (c *deferConn) WriteDataPacket(_ packets.ControlPacket, f func()) error    { return c.capture(f) }
+func (c *deferConn) TryWriteDataPacket(_ packets.ControlPacket, f func()) error { return c.capture(f) }
+func (c *deferConn) ReadPacket() (packets.ControlPacket, error) {
+	c.readOnce.Do(func() { close(c.reading) })
+	<-c.closeCh
+	return nil, io.EOF
+}
+
+func (c *deferConn) Close() error {
+	c.closeOnce.Do(func() { close(c.closeCh) })
+	return nil
+}
+
+func (c *deferConn) fireOnSent() {
+	c.mu.Lock()
+	f := c.onSent
+	c.mu.Unlock()
+	if f != nil {
+		f()
+	}
+}
+
+// TestDelivery_StaleOnSentDoesNotMarkSent guards finding #3: if a queued packet
+// flushes on the displaced connection after a takeover, its onSent must not mark
+// the shared inflight entry as recently sent, or the replacement connection
+// would wait out the retry timeout before retransmitting.
+func TestDelivery_StaleOnSentDoesNotMarkSent(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+
+	s, _, err := b.CreateSession("c", 5, session.Options{CleanStart: true, ReceiveMaximum: 4})
+	require.NoError(t, err)
+	oldConn := newDeferConn()
+	_, err = s.Connect(oldConn)
+	require.NoError(t, err)
+
+	msg := &storage.Message{Topic: "t", QoS: 1}
+	msg.SetPayloadFromBytes([]byte("x"))
+	pid, err := b.DeliverToSession(context.Background(), s, msg)
+	require.NoError(t, err)
+	require.NotZero(t, pid)
+
+	// Takeover: the inflight entry now belongs to the new generation.
+	newConn := newDeferConn()
+	_, _ = s.ConnectWithOptions(newConn, session.ConnectOptions{Version: 5, ReceiveMaximum: 4})
+
+	// The old connection flushes the queued PUBLISH after the takeover.
+	oldConn.fireOnSent()
+
+	inf, ok := s.Inflight().Get(pid)
+	require.True(t, ok)
+	require.True(t, inf.SentAt.IsZero(),
+		"a stale-generation onSent must not mark the inflight entry as sent")
+
+	oldConn.Close()
+	newConn.Close()
+}

--- a/mqtt/broker/topic_alias_test.go
+++ b/mqtt/broker/topic_alias_test.go
@@ -46,7 +46,7 @@ func TestTopicAlias_RegisterAndResolve(t *testing.T) {
 		},
 	}
 
-	if err := handler.HandlePublish(s, pub1); err != nil {
+	if err := handler.HandlePublish(bindConn(s), pub1); err != nil {
 		t.Fatalf("Failed to handle PUBLISH with alias registration: %v", err)
 	}
 
@@ -69,7 +69,7 @@ func TestTopicAlias_RegisterAndResolve(t *testing.T) {
 		},
 	}
 
-	if err := handler.HandlePublish(s, pub2); err != nil {
+	if err := handler.HandlePublish(bindConn(s), pub2); err != nil {
 		t.Fatalf("Failed to handle PUBLISH with alias resolution: %v", err)
 	}
 
@@ -85,7 +85,7 @@ func TestTopicAlias_RegisterAndResolve(t *testing.T) {
 		},
 	}
 
-	err = handler.HandlePublish(s, pub3)
+	err = handler.HandlePublish(bindConn(s), pub3)
 	if err == nil {
 		t.Fatal("Expected error when alias exceeds TopicAliasMax, got nil")
 	}
@@ -102,7 +102,7 @@ func TestTopicAlias_RegisterAndResolve(t *testing.T) {
 		},
 	}
 
-	err = handler.HandlePublish(s, pub4)
+	err = handler.HandlePublish(bindConn(s), pub4)
 	if err == nil {
 		t.Fatal("Expected error when using unregistered alias, got nil")
 	}
@@ -141,7 +141,7 @@ func TestTopicAlias_MultipleAliases(t *testing.T) {
 			},
 		}
 
-		if err := handler.HandlePublish(s, pub); err != nil {
+		if err := handler.HandlePublish(bindConn(s), pub); err != nil {
 			t.Fatalf("Failed to register alias %d: %v", alias, err)
 		}
 	}
@@ -169,7 +169,7 @@ func TestTopicAlias_MultipleAliases(t *testing.T) {
 			},
 		}
 
-		if err := handler.HandlePublish(s, pub); err != nil {
+		if err := handler.HandlePublish(bindConn(s), pub); err != nil {
 			t.Fatalf("Failed to use alias %d: %v", alias, err)
 		}
 	}
@@ -201,7 +201,7 @@ func TestTopicAlias_UpdateExisting(t *testing.T) {
 		},
 	}
 
-	if err := handler.HandlePublish(s, pub1); err != nil {
+	if err := handler.HandlePublish(bindConn(s), pub1); err != nil {
 		t.Fatalf("Failed to register alias: %v", err)
 	}
 
@@ -215,7 +215,7 @@ func TestTopicAlias_UpdateExisting(t *testing.T) {
 		},
 	}
 
-	if err := handler.HandlePublish(s, pub2); err != nil {
+	if err := handler.HandlePublish(bindConn(s), pub2); err != nil {
 		t.Fatalf("Failed to update alias: %v", err)
 	}
 
@@ -253,7 +253,7 @@ func TestTopicAlias_SessionIsolation(t *testing.T) {
 			TopicAlias: &alias,
 		},
 	}
-	handler.HandlePublish(s1, pub1) //nolint:errcheck // best-effort
+	handler.HandlePublish(bindConn(s1), pub1) //nolint:errcheck // best-effort
 
 	// Register alias 1 in session 2 with different topic
 	pub2 := &v5.Publish{
@@ -264,7 +264,7 @@ func TestTopicAlias_SessionIsolation(t *testing.T) {
 			TopicAlias: &alias,
 		},
 	}
-	handler.HandlePublish(s2, pub2) //nolint:errcheck // best-effort
+	handler.HandlePublish(bindConn(s2), pub2) //nolint:errcheck // best-effort
 
 	// Verify aliases are isolated
 	topic1, _ := s1.ResolveInboundAlias(1)

--- a/mqtt/broker/topic_alias_test.go
+++ b/mqtt/broker/topic_alias_test.go
@@ -33,7 +33,7 @@ func TestTopicAlias_RegisterAndResolve(t *testing.T) {
 	}
 	s.TopicAliasMax = 10
 
-	handler := NewV5Handler(b)
+	handler := newV5Handler(b)
 
 	// Test 1: Register alias with first PUBLISH (topic + alias)
 	alias1 := uint16(1)
@@ -121,7 +121,7 @@ func TestTopicAlias_MultipleAliases(t *testing.T) {
 	}
 	s.TopicAliasMax = 100
 
-	handler := NewV5Handler(b)
+	handler := newV5Handler(b)
 
 	// Register multiple aliases
 	aliases := map[uint16]string{
@@ -188,7 +188,7 @@ func TestTopicAlias_UpdateExisting(t *testing.T) {
 	}
 	s.TopicAliasMax = 10
 
-	handler := NewV5Handler(b)
+	handler := newV5Handler(b)
 
 	// Register alias 1 with topic A
 	alias := uint16(1)
@@ -241,7 +241,7 @@ func TestTopicAlias_SessionIsolation(t *testing.T) {
 	s2, _, _ := b.CreateSession("client2", 5, session.Options{CleanStart: true})
 	s2.TopicAliasMax = 10
 
-	handler := NewV5Handler(b)
+	handler := newV5Handler(b)
 
 	// Register alias 1 in session 1
 	alias := uint16(1)

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -19,20 +19,20 @@ import (
 	"github.com/absmach/fluxmq/topics"
 )
 
-var _ Handler = (*V3Handler)(nil)
+var _ protocolHandler = (*v3Handler)(nil)
 
-// V3Handler is a stateless adapter that translates MQTT v3/v4 packets to broker domain operations.
-type V3Handler struct {
+// v3Handler is a stateless adapter that translates MQTT v3/v4 packets to broker domain operations.
+type v3Handler struct {
 	broker *Broker
 }
 
-// NewV3Handler creates a new V3 protocol handler.
-func NewV3Handler(broker *Broker) *V3Handler {
-	return &V3Handler{broker: broker}
+// newV3Handler creates a new V3 protocol handler.
+func newV3Handler(broker *Broker) *v3Handler {
+	return &v3Handler{broker: broker}
 }
 
 // HandleConnect handles CONNECT packets.
-func (h *V3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacket) error {
+func (h *v3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacket) error {
 	start := time.Now()
 	p, ok := pkt.(*v3.Connect)
 	if !ok {
@@ -157,7 +157,7 @@ func (h *V3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 }
 
 // HandlePublish handles PUBLISH packets.
-func (h *V3Handler) HandlePublish(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v3Handler) HandlePublish(s *connCtx, pkt packets.ControlPacket) error {
 	start := time.Now()
 	p, ok := pkt.(*v3.Publish)
 	if !ok {
@@ -288,7 +288,7 @@ func (h *V3Handler) HandlePublish(s *connCtx, pkt packets.ControlPacket) error {
 }
 
 // HandlePubAck handles PUBACK packets.
-func (h *V3Handler) HandlePubAck(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v3Handler) HandlePubAck(s *connCtx, pkt packets.ControlPacket) error {
 	p, ok := pkt.(*v3.PubAck)
 	if !ok {
 		return ErrInvalidPacketType
@@ -299,7 +299,7 @@ func (h *V3Handler) HandlePubAck(s *connCtx, pkt packets.ControlPacket) error {
 }
 
 // HandlePubRec handles PUBREC packets.
-func (h *V3Handler) HandlePubRec(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v3Handler) HandlePubRec(s *connCtx, pkt packets.ControlPacket) error {
 	p, ok := pkt.(*v3.PubRec)
 	if !ok {
 		return ErrInvalidPacketType
@@ -315,7 +315,7 @@ func (h *V3Handler) HandlePubRec(s *connCtx, pkt packets.ControlPacket) error {
 }
 
 // HandlePubRel handles PUBREL packets.
-func (h *V3Handler) HandlePubRel(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v3Handler) HandlePubRel(s *connCtx, pkt packets.ControlPacket) error {
 	p, ok := pkt.(*v3.PubRel)
 	if !ok {
 		return ErrInvalidPacketType
@@ -374,7 +374,7 @@ func (h *V3Handler) HandlePubRel(s *connCtx, pkt packets.ControlPacket) error {
 }
 
 // HandlePubComp handles PUBCOMP packets.
-func (h *V3Handler) HandlePubComp(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v3Handler) HandlePubComp(s *connCtx, pkt packets.ControlPacket) error {
 	p, ok := pkt.(*v3.PubComp)
 	if !ok {
 		return ErrInvalidPacketType
@@ -385,7 +385,7 @@ func (h *V3Handler) HandlePubComp(s *connCtx, pkt packets.ControlPacket) error {
 }
 
 // HandleSubscribe handles SUBSCRIBE packets.
-func (h *V3Handler) HandleSubscribe(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v3Handler) HandleSubscribe(s *connCtx, pkt packets.ControlPacket) error {
 	start := time.Now()
 	p, ok := pkt.(*v3.Subscribe)
 	if !ok {
@@ -474,7 +474,7 @@ func (h *V3Handler) HandleSubscribe(s *connCtx, pkt packets.ControlPacket) error
 }
 
 // HandleUnsubscribe handles UNSUBSCRIBE packets.
-func (h *V3Handler) HandleUnsubscribe(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v3Handler) HandleUnsubscribe(s *connCtx, pkt packets.ControlPacket) error {
 	start := time.Now()
 	p, ok := pkt.(*v3.Unsubscribe)
 	if !ok {
@@ -500,7 +500,7 @@ func (h *V3Handler) HandleUnsubscribe(s *connCtx, pkt packets.ControlPacket) err
 }
 
 // HandlePingReq handles PINGREQ packets.
-func (h *V3Handler) HandlePingReq(s *connCtx) error {
+func (h *v3Handler) HandlePingReq(s *connCtx) error {
 	h.broker.telemetry.logger.Debug("v3_pingreq", slog.String("client_id", s.ID))
 
 	// Update heartbeat for queue consumers
@@ -515,7 +515,7 @@ func (h *V3Handler) HandlePingReq(s *connCtx) error {
 }
 
 // HandleDisconnect handles DISCONNECT packets.
-func (h *V3Handler) HandleDisconnect(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v3Handler) HandleDisconnect(s *connCtx, pkt packets.ControlPacket) error {
 	_, ok := pkt.(*v3.Disconnect)
 	if !ok {
 		return ErrInvalidPacketType
@@ -527,12 +527,12 @@ func (h *V3Handler) HandleDisconnect(s *connCtx, pkt packets.ControlPacket) erro
 }
 
 // HandleAuth - not supported in V3.
-func (h *V3Handler) HandleAuth(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v3Handler) HandleAuth(s *connCtx, pkt packets.ControlPacket) error {
 	return ErrInvalidPacketType
 }
 
 // deliverOfflineMessages sends queued messages to reconnected client.
-func (h *V3Handler) deliverOfflineMessages(s *session.Session) {
+func (h *v3Handler) deliverOfflineMessages(s *session.Session) {
 	msgs := s.OfflineQueue().Drain()
 	for _, msg := range msgs {
 		h.broker.DeliverToSession(context.Background(), s, msg) //nolint:errcheck // offline message delivery; errors are non-fatal

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -331,7 +331,7 @@ func (h *v3Handler) HandlePubRel(s *connCtx, pkt packets.ControlPacket) error {
 	packetID := p.ID
 
 	// Distribute stored message now that publisher has committed with PUBREL.
-	msg, err := s.Inflight().Ack(packetID, messages.Inbound)
+	msg, err := s.Inflight().AckInbound(packetID)
 	if err != nil {
 		h.broker.telemetry.logger.Warn("v3_pubrel_unknown_packet",
 			slog.String("client_id", s.ID),

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -331,7 +331,7 @@ func (h *v3Handler) HandlePubRel(s *connCtx, pkt packets.ControlPacket) error {
 	packetID := p.ID
 
 	// Distribute stored message now that publisher has committed with PUBREL.
-	msg, err := s.Inflight().Ack(packetID)
+	msg, err := s.Inflight().Ack(packetID, messages.Inbound)
 	if err != nil {
 		h.broker.telemetry.logger.Warn("v3_pubrel_unknown_packet",
 			slog.String("client_id", s.ID),

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -157,7 +157,7 @@ func (h *V3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 }
 
 // HandlePublish handles PUBLISH packets.
-func (h *V3Handler) HandlePublish(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V3Handler) HandlePublish(s *connCtx, pkt packets.ControlPacket) error {
 	start := time.Now()
 	p, ok := pkt.(*v3.Publish)
 	if !ok {
@@ -288,18 +288,18 @@ func (h *V3Handler) HandlePublish(s *session.Session, pkt packets.ControlPacket)
 }
 
 // HandlePubAck handles PUBACK packets.
-func (h *V3Handler) HandlePubAck(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V3Handler) HandlePubAck(s *connCtx, pkt packets.ControlPacket) error {
 	p, ok := pkt.(*v3.PubAck)
 	if !ok {
 		return ErrInvalidPacketType
 	}
 
 	h.broker.telemetry.logger.Debug("v3_puback", slog.String("client_id", s.ID), slog.Int("packet_id", int(p.ID)))
-	return h.broker.AckMessage(s, p.ID)
+	return h.broker.AckMessage(s.Session, p.ID)
 }
 
 // HandlePubRec handles PUBREC packets.
-func (h *V3Handler) HandlePubRec(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V3Handler) HandlePubRec(s *connCtx, pkt packets.ControlPacket) error {
 	p, ok := pkt.(*v3.PubRec)
 	if !ok {
 		return ErrInvalidPacketType
@@ -315,7 +315,7 @@ func (h *V3Handler) HandlePubRec(s *session.Session, pkt packets.ControlPacket) 
 }
 
 // HandlePubRel handles PUBREL packets.
-func (h *V3Handler) HandlePubRel(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V3Handler) HandlePubRel(s *connCtx, pkt packets.ControlPacket) error {
 	p, ok := pkt.(*v3.PubRel)
 	if !ok {
 		return ErrInvalidPacketType
@@ -374,18 +374,18 @@ func (h *V3Handler) HandlePubRel(s *session.Session, pkt packets.ControlPacket) 
 }
 
 // HandlePubComp handles PUBCOMP packets.
-func (h *V3Handler) HandlePubComp(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V3Handler) HandlePubComp(s *connCtx, pkt packets.ControlPacket) error {
 	p, ok := pkt.(*v3.PubComp)
 	if !ok {
 		return ErrInvalidPacketType
 	}
 
 	h.broker.telemetry.logger.Debug("v3_pubcomp", slog.String("client_id", s.ID), slog.Int("packet_id", int(p.ID)))
-	return h.broker.AckMessage(s, p.ID)
+	return h.broker.AckMessage(s.Session, p.ID)
 }
 
 // HandleSubscribe handles SUBSCRIBE packets.
-func (h *V3Handler) HandleSubscribe(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V3Handler) HandleSubscribe(s *connCtx, pkt packets.ControlPacket) error {
 	start := time.Now()
 	p, ok := pkt.(*v3.Subscribe)
 	if !ok {
@@ -428,7 +428,7 @@ func (h *V3Handler) HandleSubscribe(s *session.Session, pkt packets.ControlPacke
 			grantedQoS = maxQoS
 		}
 
-		if err := h.broker.subscribe(s, t.Name, grantedQoS, opts); err != nil {
+		if err := h.broker.subscribe(s.Session, t.Name, grantedQoS, opts); err != nil {
 			reasonCodes[i] = v3.SubAckFailure
 			continue
 		}
@@ -456,7 +456,7 @@ func (h *V3Handler) HandleSubscribe(s *session.Session, pkt packets.ControlPacke
 					// Legacy fallback for messages without PayloadBuf
 					deliverMsg.SetPayloadFromBytes(msg.Payload)
 				}
-				h.broker.DeliverToSession(context.Background(), s, deliverMsg) //nolint:errcheck // retained message delivery; errors are non-fatal
+				h.broker.DeliverToSession(context.Background(), s.Session, deliverMsg) //nolint:errcheck // retained message delivery; errors are non-fatal
 			}
 		}
 	}
@@ -474,7 +474,7 @@ func (h *V3Handler) HandleSubscribe(s *session.Session, pkt packets.ControlPacke
 }
 
 // HandleUnsubscribe handles UNSUBSCRIBE packets.
-func (h *V3Handler) HandleUnsubscribe(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V3Handler) HandleUnsubscribe(s *connCtx, pkt packets.ControlPacket) error {
 	start := time.Now()
 	p, ok := pkt.(*v3.Unsubscribe)
 	if !ok {
@@ -484,7 +484,7 @@ func (h *V3Handler) HandleUnsubscribe(s *session.Session, pkt packets.ControlPac
 	h.broker.telemetry.logger.Info("v3_unsubscribe", slog.String("client_id", s.ID), slog.Int("topics", len(p.Topics)))
 
 	for _, filter := range p.Topics {
-		h.broker.unsubscribeInternal(s, filter) //nolint:errcheck // best-effort unsubscribe; errors are non-fatal
+		h.broker.unsubscribeInternal(s.Session, filter) //nolint:errcheck // best-effort unsubscribe; errors are non-fatal
 	}
 
 	h.broker.telemetry.logger.Info("v3_unsubscribe_complete",
@@ -500,13 +500,13 @@ func (h *V3Handler) HandleUnsubscribe(s *session.Session, pkt packets.ControlPac
 }
 
 // HandlePingReq handles PINGREQ packets.
-func (h *V3Handler) HandlePingReq(s *session.Session) error {
+func (h *V3Handler) HandlePingReq(s *connCtx) error {
 	h.broker.telemetry.logger.Debug("v3_pingreq", slog.String("client_id", s.ID))
 
 	// Update heartbeat for queue consumers
 	// Fire and forget - don't block PINGRESP on this.
 	// Updates are interval-limited to avoid goroutine storms under ping floods.
-	maybeUpdateQueueHeartbeat(h.broker, s)
+	maybeUpdateQueueHeartbeat(h.broker, s.Session)
 
 	resp := &v3.PingResp{
 		FixedHeader: packets.FixedHeader{PacketType: packets.PingRespType},
@@ -515,7 +515,7 @@ func (h *V3Handler) HandlePingReq(s *session.Session) error {
 }
 
 // HandleDisconnect handles DISCONNECT packets.
-func (h *V3Handler) HandleDisconnect(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V3Handler) HandleDisconnect(s *connCtx, pkt packets.ControlPacket) error {
 	_, ok := pkt.(*v3.Disconnect)
 	if !ok {
 		return ErrInvalidPacketType
@@ -527,7 +527,7 @@ func (h *V3Handler) HandleDisconnect(s *session.Session, pkt packets.ControlPack
 }
 
 // HandleAuth - not supported in V3.
-func (h *V3Handler) HandleAuth(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V3Handler) HandleAuth(s *connCtx, pkt packets.ControlPacket) error {
 	return ErrInvalidPacketType
 }
 
@@ -539,7 +539,7 @@ func (h *V3Handler) deliverOfflineMessages(s *session.Session) {
 	}
 }
 
-func sendV3PubRec(s *session.Session, packetID uint16) error {
+func sendV3PubRec(s *connCtx, packetID uint16) error {
 	rec := &v3.PubRec{
 		FixedHeader: packets.FixedHeader{PacketType: packets.PubRecType},
 		ID:          packetID,

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -158,7 +158,7 @@ func (h *v3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	h.deliverOfflineMessages(s)
 
-	return h.broker.runSession(h, s, conn, epoch)
+	return h.broker.runSession(h, s, conn, epoch, time.Duration(p.KeepAlive)*time.Second)
 }
 
 // HandlePublish handles PUBLISH packets.

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -331,7 +331,7 @@ func (h *v3Handler) HandlePubRel(s *connCtx, pkt packets.ControlPacket) error {
 	packetID := p.ID
 
 	// Distribute stored message now that publisher has committed with PUBREL.
-	msg, err := s.Inflight().AckInbound(packetID)
+	msg, err := s.AckInbound(packetID)
 	if err != nil {
 		h.broker.telemetry.logger.Warn("v3_pubrel_unknown_packet",
 			slog.String("client_id", s.ID),

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -128,7 +128,8 @@ func (h *V3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	s.ExternalID = externalID
 
-	if err := s.Connect(conn); err != nil {
+	epoch, err := s.Connect(conn)
+	if err != nil {
 		h.broker.telemetry.stats.IncrementProtocolErrors()
 		conn.Close()
 		return err
@@ -137,7 +138,7 @@ func (h *V3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	sessionPresent := !isNew && !cleanStart
 	if err := sendV3ConnAck(conn, sessionPresent, v3.ConnAckAccepted); err != nil {
-		s.Disconnect(false) //nolint:errcheck // disconnect on failed CONNACK; connection is already broken
+		s.DisconnectIf(false, epoch) //nolint:errcheck // disconnect on failed CONNACK; connection is already broken
 		return err
 	}
 
@@ -152,7 +153,7 @@ func (h *V3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	h.deliverOfflineMessages(s)
 
-	return h.broker.runSession(h, s)
+	return h.broker.runSession(h, s, epoch)
 }
 
 // HandlePublish handles PUBLISH packets.

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -128,11 +128,15 @@ func (h *v3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	s.ExternalID = externalID
 
-	epoch, err := s.Connect(conn)
-	if err != nil {
-		h.broker.telemetry.stats.IncrementProtocolErrors()
-		conn.Close()
-		return err
+	// Apply the negotiated options and take over any existing connection. v3
+	// has no session expiry or topic aliases.
+	epoch, superseded := s.ConnectWithOptions(conn, session.ConnectOptions{
+		Version:   p.ProtocolVersion,
+		KeepAlive: time.Duration(p.KeepAlive) * time.Second,
+		Will:      will,
+	})
+	if superseded != nil {
+		go h.broker.drainSuperseded(context.WithoutCancel(context.Background()), superseded)
 	}
 	h.broker.persistSessionInfo(s)
 

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -129,11 +129,12 @@ func (h *v3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 	s.ExternalID = externalID
 
 	// Apply the negotiated options and take over any existing connection. v3
-	// has no session expiry or topic aliases.
+	// has no session expiry, Receive Maximum, or topic aliases.
 	epoch, superseded := s.ConnectWithOptions(conn, session.ConnectOptions{
-		Version:   p.ProtocolVersion,
-		KeepAlive: time.Duration(p.KeepAlive) * time.Second,
-		Will:      will,
+		Version:        p.ProtocolVersion,
+		KeepAlive:      time.Duration(p.KeepAlive) * time.Second,
+		Will:           will,
+		ReceiveMaximum: maxReceived,
 	})
 	if superseded != nil {
 		go h.broker.drainSuperseded(context.WithoutCancel(context.Background()), superseded)

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -153,7 +153,7 @@ func (h *V3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	h.deliverOfflineMessages(s)
 
-	return h.broker.runSession(h, s, epoch)
+	return h.broker.runSession(h, s, conn, epoch)
 }
 
 // HandlePublish handles PUBLISH packets.

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -192,7 +192,6 @@ func (h *v3Handler) HandlePublish(s *connCtx, pkt packets.ControlPacket) error {
 	qos := p.FixedHeader.QoS
 	retain := p.FixedHeader.Retain
 	packetID := p.ID
-	dup := p.FixedHeader.Dup
 
 	if err := topics.ValidateTopicName(topic); err != nil {
 		h.broker.telemetry.logger.Warn("v3_publish_invalid_topic",
@@ -260,12 +259,6 @@ func (h *v3Handler) HandlePublish(s *connCtx, pkt packets.ControlPacket) error {
 		return s.WritePacket(ack)
 
 	case 2:
-		if dup && s.Inflight().WasReceived(packetID) {
-			return sendV3PubRec(s, packetID)
-		}
-
-		s.Inflight().MarkReceived(packetID)
-
 		buf := core.GetBufferWithData(payload)
 		storeMsg := storage.AcquireMessage()
 		storeMsg.Topic = topic
@@ -275,9 +268,11 @@ func (h *v3Handler) HandlePublish(s *connCtx, pkt packets.ControlPacket) error {
 		storeMsg.PacketID = packetID
 		storeMsg.Properties = setOriginProperties(storeMsg.Properties, s.ExternalID)
 		storeMsg.SetPayloadFromBuffer(buf)
-		if err := s.Inflight().Add(packetID, storeMsg, messages.Inbound); err != nil {
-			storeMsg.ReleasePayload()
+		accepted, err := s.AddInbound(packetID, storeMsg)
+		if !accepted {
 			storage.ReleaseMessage(storeMsg)
+		}
+		if err != nil {
 			return err
 		}
 

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -332,7 +332,6 @@ func (h *v3Handler) HandlePubRel(s *connCtx, pkt packets.ControlPacket) error {
 			slog.String("client_id", s.ID),
 			slog.Int("packet_id", int(packetID)))
 	}
-	s.Inflight().ClearReceived(packetID)
 
 	comp := &v3.PubComp{
 		FixedHeader: packets.FixedHeader{PacketType: packets.PubCompType},

--- a/mqtt/broker/v5_compliance_test.go
+++ b/mqtt/broker/v5_compliance_test.go
@@ -163,7 +163,7 @@ func TestV5RetainHandlingRespected(t *testing.T) {
 			{Topic: testRetainTopic, MaxQoS: 1, RetainHandling: &rh0},
 		},
 	}
-	require.NoError(t, handler.HandleSubscribe(s, sub1))
+	require.NoError(t, handler.HandleSubscribe(bindConn(s), sub1))
 	require.Len(t, conn.packets, 2)
 
 	_, ok := conn.packets[0].(*v5.Publish)
@@ -181,7 +181,7 @@ func TestV5RetainHandlingRespected(t *testing.T) {
 			{Topic: testRetainTopic, MaxQoS: 1, RetainHandling: &rh1},
 		},
 	}
-	require.NoError(t, handler.HandleSubscribe(s, sub2))
+	require.NoError(t, handler.HandleSubscribe(bindConn(s), sub2))
 	require.Len(t, conn.packets, 1)
 	_, ok = conn.packets[0].(*v5.SubAck)
 	require.True(t, ok)
@@ -209,7 +209,7 @@ func TestV5PublishErrorResponseMatchesQoS(t *testing.T) {
 			TopicAlias: &alias2,
 		},
 	}
-	err = handler.HandlePublish(s, pub0)
+	err = handler.HandlePublish(bindConn(s), pub0)
 	require.ErrorIs(t, err, ErrTopicInvalid)
 	require.Len(t, conn.packets, 0)
 
@@ -222,7 +222,7 @@ func TestV5PublishErrorResponseMatchesQoS(t *testing.T) {
 			TopicAlias: &alias2,
 		},
 	}
-	require.NoError(t, handler.HandlePublish(s, pub2))
+	require.NoError(t, handler.HandlePublish(bindConn(s), pub2))
 	require.Len(t, conn.packets, 1)
 	_, ok := conn.packets[0].(*v5.PubRec)
 	require.True(t, ok)

--- a/mqtt/broker/v5_compliance_test.go
+++ b/mqtt/broker/v5_compliance_test.go
@@ -153,7 +153,7 @@ func TestV5RetainHandlingRespected(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, matchedRetained, 1)
 
-	handler := NewV5Handler(b)
+	handler := newV5Handler(b)
 
 	rh0 := byte(0)
 	sub1 := &v5.Subscribe{
@@ -198,7 +198,7 @@ func TestV5PublishErrorResponseMatchesQoS(t *testing.T) {
 	_, errConn := s.Connect(conn)
 	require.NoError(t, errConn)
 
-	handler := NewV5Handler(b)
+	handler := newV5Handler(b)
 
 	alias2 := uint16(2)
 	pub0 := &v5.Publish{

--- a/mqtt/broker/v5_compliance_test.go
+++ b/mqtt/broker/v5_compliance_test.go
@@ -78,7 +78,8 @@ func TestV5NoLocalPreventsSelfDelivery(t *testing.T) {
 	require.NoError(t, err)
 
 	conn := &captureConnection{}
-	require.NoError(t, s.Connect(conn))
+	_, errConn := s.Connect(conn)
+	require.NoError(t, errConn)
 	require.NoError(t, b.subscribe(s, "devices/one", 1, storage.SubscribeOptions{NoLocal: true}))
 
 	msg := &storage.Message{
@@ -102,8 +103,10 @@ func TestV5RetainAsPublishedAffectsDeliveryFlag(t *testing.T) {
 
 	conn1 := &captureConnection{}
 	conn2 := &captureConnection{}
-	require.NoError(t, s1.Connect(conn1))
-	require.NoError(t, s2.Connect(conn2))
+	_, errConn1 := s1.Connect(conn1)
+	require.NoError(t, errConn1)
+	_, errConn2 := s2.Connect(conn2)
+	require.NoError(t, errConn2)
 
 	require.NoError(t, b.subscribe(s1, "devices/two", 1, storage.SubscribeOptions{RetainAsPublished: false}))
 	require.NoError(t, b.subscribe(s2, "devices/two", 1, storage.SubscribeOptions{RetainAsPublished: true}))
@@ -135,7 +138,8 @@ func TestV5RetainHandlingRespected(t *testing.T) {
 	require.NoError(t, err)
 
 	conn := &captureConnection{}
-	require.NoError(t, s.Connect(conn))
+	_, errConn := s.Connect(conn)
+	require.NoError(t, errConn)
 
 	retained := &storage.Message{
 		Topic:    testRetainTopic,
@@ -191,7 +195,8 @@ func TestV5PublishErrorResponseMatchesQoS(t *testing.T) {
 	s.TopicAliasMax = 1
 
 	conn := &captureConnection{}
-	require.NoError(t, s.Connect(conn))
+	_, errConn := s.Connect(conn)
+	require.NoError(t, errConn)
 
 	handler := NewV5Handler(b)
 

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -178,7 +178,7 @@ func (h *V5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	h.deliverOfflineMessages(s)
 
-	return h.broker.runSession(h, s, epoch)
+	return h.broker.runSession(h, s, conn, epoch)
 }
 
 // HandlePublish handles PUBLISH packets.

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -153,7 +153,8 @@ func (h *V5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	s.ExternalID = externalID
 
-	if err := s.Connect(conn); err != nil {
+	epoch, err := s.Connect(conn)
+	if err != nil {
 		h.broker.telemetry.stats.IncrementProtocolErrors()
 		conn.Close()
 		return err
@@ -162,7 +163,7 @@ func (h *V5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	sessionPresent := !isNew && !cleanStart
 	if err := sendV5ConnAckWithProperties(conn, s, sessionPresent, v5.ConnAckSuccess, h.broker.MaxQoS()); err != nil {
-		s.Disconnect(false) //nolint:errcheck // disconnect on failed CONNACK; connection is already broken
+		s.DisconnectIf(false, epoch) //nolint:errcheck // disconnect on failed CONNACK; connection is already broken
 		return err
 	}
 
@@ -177,7 +178,7 @@ func (h *V5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	h.deliverOfflineMessages(s)
 
-	return h.broker.runSession(h, s)
+	return h.broker.runSession(h, s, epoch)
 }
 
 // HandlePublish handles PUBLISH packets.

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -227,7 +227,6 @@ func (h *v5Handler) HandlePublish(s *connCtx, pkt packets.ControlPacket) error {
 	qos := p.FixedHeader.QoS
 	retain := p.FixedHeader.Retain
 	packetID := p.ID
-	dup := p.FixedHeader.Dup
 
 	// Downgrade QoS if it exceeds server's maximum (MQTT 5.0 spec 3.3.2-4)
 	if maxQoS := h.broker.MaxQoS(); qos > maxQoS {
@@ -342,12 +341,6 @@ func (h *v5Handler) HandlePublish(s *connCtx, pkt packets.ControlPacket) error {
 		return sendV5PubAck(s, packetID, v5.PubAckSuccess, "")
 
 	case 2:
-		if dup && s.Inflight().WasReceived(packetID) {
-			return sendV5PubRec(s, packetID, v5.PubRecSuccess, "")
-		}
-
-		s.Inflight().MarkReceived(packetID)
-
 		buf := core.GetBufferWithData(payload)
 		storeMsg := storage.AcquireMessage()
 		storeMsg.Topic = topic
@@ -364,9 +357,11 @@ func (h *v5Handler) HandlePublish(s *connCtx, pkt packets.ControlPacket) error {
 		storeMsg.ResponseTopic = responseTopic
 		storeMsg.CorrelationData = correlationData
 		storeMsg.SetPayloadFromBuffer(buf)
-		if err := s.Inflight().Add(packetID, storeMsg, messages.Inbound); err != nil {
-			storeMsg.ReleasePayload()
+		accepted, err := s.AddInbound(packetID, storeMsg)
+		if !accepted {
 			storage.ReleaseMessage(storeMsg)
+		}
+		if err != nil {
 			return err
 		}
 

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -149,15 +149,20 @@ func (h *v5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 		return err
 	}
 
-	s.TopicAliasMax = topicAliasMax
-
 	s.ExternalID = externalID
 
-	epoch, err := s.Connect(conn)
-	if err != nil {
-		h.broker.telemetry.stats.IncrementProtocolErrors()
-		conn.Close()
-		return err
+	// Apply the negotiated options and take over any existing connection. On a
+	// persistent reconnect this replaces the previous connection's version,
+	// keep-alive, Will, expiry, and topic-alias maximum.
+	epoch, superseded := s.ConnectWithOptions(conn, session.ConnectOptions{
+		Version:        p.ProtocolVersion,
+		KeepAlive:      time.Duration(p.KeepAlive) * time.Second,
+		Will:           will,
+		ExpiryInterval: sessionExpiry,
+		TopicAliasMax:  topicAliasMax,
+	})
+	if superseded != nil {
+		go h.broker.drainSuperseded(context.WithoutCancel(context.Background()), superseded)
 	}
 	h.broker.persistSessionInfo(s)
 

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -182,7 +182,7 @@ func (h *V5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 }
 
 // HandlePublish handles PUBLISH packets.
-func (h *V5Handler) HandlePublish(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V5Handler) HandlePublish(s *connCtx, pkt packets.ControlPacket) error {
 	start := time.Now()
 	p, ok := pkt.(*v5.Publish)
 	if !ok {
@@ -367,18 +367,18 @@ func (h *V5Handler) HandlePublish(s *session.Session, pkt packets.ControlPacket)
 }
 
 // HandlePubAck handles PUBACK packets.
-func (h *V5Handler) HandlePubAck(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V5Handler) HandlePubAck(s *connCtx, pkt packets.ControlPacket) error {
 	p, ok := pkt.(*v5.PubAck)
 	if !ok {
 		return ErrInvalidPacketType
 	}
 
 	h.broker.telemetry.logger.Debug("v5_puback", slog.String("client_id", s.ID), slog.Int("packet_id", int(p.ID)))
-	return h.broker.AckMessage(s, p.ID)
+	return h.broker.AckMessage(s.Session, p.ID)
 }
 
 // HandlePubRec handles PUBREC packets.
-func (h *V5Handler) HandlePubRec(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V5Handler) HandlePubRec(s *connCtx, pkt packets.ControlPacket) error {
 	p, ok := pkt.(*v5.PubRec)
 	if !ok {
 		return ErrInvalidPacketType
@@ -397,7 +397,7 @@ func (h *V5Handler) HandlePubRec(s *session.Session, pkt packets.ControlPacket) 
 }
 
 // HandlePubRel handles PUBREL packets.
-func (h *V5Handler) HandlePubRel(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V5Handler) HandlePubRel(s *connCtx, pkt packets.ControlPacket) error {
 	p, ok := pkt.(*v5.PubRel)
 	if !ok {
 		return ErrInvalidPacketType
@@ -459,18 +459,18 @@ func (h *V5Handler) HandlePubRel(s *session.Session, pkt packets.ControlPacket) 
 }
 
 // HandlePubComp handles PUBCOMP packets.
-func (h *V5Handler) HandlePubComp(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V5Handler) HandlePubComp(s *connCtx, pkt packets.ControlPacket) error {
 	p, ok := pkt.(*v5.PubComp)
 	if !ok {
 		return ErrInvalidPacketType
 	}
 
 	h.broker.telemetry.logger.Debug("v5_pubcomp", slog.String("client_id", s.ID), slog.Int("packet_id", int(p.ID)))
-	return h.broker.AckMessage(s, p.ID)
+	return h.broker.AckMessage(s.Session, p.ID)
 }
 
 // HandleSubscribe handles SUBSCRIBE packets.
-func (h *V5Handler) HandleSubscribe(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V5Handler) HandleSubscribe(s *connCtx, pkt packets.ControlPacket) error {
 	start := time.Now()
 	p, ok := pkt.(*v5.Subscribe)
 	if !ok {
@@ -536,7 +536,7 @@ func (h *V5Handler) HandleSubscribe(s *session.Session, pkt packets.ControlPacke
 			grantedQoS = maxQoS
 		}
 
-		if err := h.broker.subscribe(s, t.Topic, grantedQoS, opts); err != nil {
+		if err := h.broker.subscribe(s.Session, t.Topic, grantedQoS, opts); err != nil {
 			reasonCodes[i] = v5.SubAckImplementationSpecificError
 			continue
 		}
@@ -571,7 +571,7 @@ func (h *V5Handler) HandleSubscribe(s *session.Session, pkt packets.ControlPacke
 						// Legacy fallback for messages without PayloadBuf
 						deliverMsg.SetPayloadFromBytes(msg.Payload)
 					}
-					h.broker.DeliverToSession(context.Background(), s, deliverMsg) //nolint:errcheck // retained message delivery; errors are non-fatal
+					h.broker.DeliverToSession(context.Background(), s.Session, deliverMsg) //nolint:errcheck // retained message delivery; errors are non-fatal
 				}
 			}
 		}
@@ -591,7 +591,7 @@ func (h *V5Handler) HandleSubscribe(s *session.Session, pkt packets.ControlPacke
 }
 
 // HandleUnsubscribe handles UNSUBSCRIBE packets.
-func (h *V5Handler) HandleUnsubscribe(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V5Handler) HandleUnsubscribe(s *connCtx, pkt packets.ControlPacket) error {
 	start := time.Now()
 	p, ok := pkt.(*v5.Unsubscribe)
 	if !ok {
@@ -602,7 +602,7 @@ func (h *V5Handler) HandleUnsubscribe(s *session.Session, pkt packets.ControlPac
 
 	reasonCodes := make([]byte, len(p.Topics))
 	for i, filter := range p.Topics {
-		if err := h.broker.unsubscribeInternal(s, filter); err != nil {
+		if err := h.broker.unsubscribeInternal(s.Session, filter); err != nil {
 			reasonCodes[i] = v5.ConnAckUnspecifiedError
 		} else {
 			reasonCodes[i] = v5.ConnAckSuccess
@@ -623,13 +623,13 @@ func (h *V5Handler) HandleUnsubscribe(s *session.Session, pkt packets.ControlPac
 }
 
 // HandlePingReq handles PINGREQ packets.
-func (h *V5Handler) HandlePingReq(s *session.Session) error {
+func (h *V5Handler) HandlePingReq(s *connCtx) error {
 	h.broker.telemetry.logger.Debug("v5_pingreq", slog.String("client_id", s.ID))
 
 	// Update heartbeat for queue consumers
 	// Fire and forget - don't block PINGRESP on this.
 	// Updates are interval-limited to avoid goroutine storms under ping floods.
-	maybeUpdateQueueHeartbeat(h.broker, s)
+	maybeUpdateQueueHeartbeat(h.broker, s.Session)
 
 	resp := &v5.PingResp{
 		FixedHeader: packets.FixedHeader{PacketType: packets.PingRespType},
@@ -638,7 +638,7 @@ func (h *V5Handler) HandlePingReq(s *session.Session) error {
 }
 
 // HandleDisconnect handles DISCONNECT packets.
-func (h *V5Handler) HandleDisconnect(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V5Handler) HandleDisconnect(s *connCtx, pkt packets.ControlPacket) error {
 	_, ok := pkt.(*v5.Disconnect)
 	if !ok {
 		return ErrInvalidPacketType
@@ -650,7 +650,7 @@ func (h *V5Handler) HandleDisconnect(s *session.Session, pkt packets.ControlPack
 }
 
 // HandleAuth handles AUTH packets.
-func (h *V5Handler) HandleAuth(s *session.Session, pkt packets.ControlPacket) error {
+func (h *V5Handler) HandleAuth(s *connCtx, pkt packets.ControlPacket) error {
 	_, ok := pkt.(*v5.Auth)
 	if !ok {
 		return ErrInvalidPacketType
@@ -712,7 +712,7 @@ func mapV5ConnectValidationReason(code byte) byte {
 	}
 }
 
-func sendV5PublishError(s *session.Session, qos byte, packetID uint16, reasonCode byte, reasonString string, qos0Err error) error {
+func sendV5PublishError(s *connCtx, qos byte, packetID uint16, reasonCode byte, reasonString string, qos0Err error) error {
 	switch qos {
 	case 1:
 		return sendV5PubAck(s, packetID, reasonCode, reasonString)
@@ -726,7 +726,7 @@ func sendV5PublishError(s *session.Session, qos byte, packetID uint16, reasonCod
 	}
 }
 
-func sendV5PubAck(s *session.Session, packetID uint16, reasonCode byte, reasonString string) error {
+func sendV5PubAck(s *connCtx, packetID uint16, reasonCode byte, reasonString string) error {
 	rc := reasonCode
 	ack := &v5.PubAck{
 		FixedHeader: packets.FixedHeader{PacketType: packets.PubAckType},
@@ -737,7 +737,7 @@ func sendV5PubAck(s *session.Session, packetID uint16, reasonCode byte, reasonSt
 	return s.WritePacket(ack)
 }
 
-func sendV5PubRec(s *session.Session, packetID uint16, reasonCode byte, reasonString string) error {
+func sendV5PubRec(s *connCtx, packetID uint16, reasonCode byte, reasonString string) error {
 	rc := reasonCode
 	rec := &v5.PubRec{
 		FixedHeader: packets.FixedHeader{PacketType: packets.PubRecType},

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -25,20 +25,20 @@ const (
 	noSessionExpiry = uint32(0)
 )
 
-var _ Handler = (*V5Handler)(nil)
+var _ protocolHandler = (*v5Handler)(nil)
 
-// V5Handler is a stateless adapter that translates MQTT v5 packets to broker domain operations.
-type V5Handler struct {
+// v5Handler is a stateless adapter that translates MQTT v5 packets to broker domain operations.
+type v5Handler struct {
 	broker *Broker
 }
 
-// NewV5Handler creates a new V5 protocol handler.
-func NewV5Handler(broker *Broker) *V5Handler {
-	return &V5Handler{broker: broker}
+// newV5Handler creates a new V5 protocol handler.
+func newV5Handler(broker *Broker) *v5Handler {
+	return &v5Handler{broker: broker}
 }
 
 // HandleConnect handles CONNECT packets.
-func (h *V5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacket) error {
+func (h *v5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacket) error {
 	start := time.Now()
 	p, ok := pkt.(*v5.Connect)
 	if !ok {
@@ -182,7 +182,7 @@ func (h *V5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 }
 
 // HandlePublish handles PUBLISH packets.
-func (h *V5Handler) HandlePublish(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v5Handler) HandlePublish(s *connCtx, pkt packets.ControlPacket) error {
 	start := time.Now()
 	p, ok := pkt.(*v5.Publish)
 	if !ok {
@@ -367,7 +367,7 @@ func (h *V5Handler) HandlePublish(s *connCtx, pkt packets.ControlPacket) error {
 }
 
 // HandlePubAck handles PUBACK packets.
-func (h *V5Handler) HandlePubAck(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v5Handler) HandlePubAck(s *connCtx, pkt packets.ControlPacket) error {
 	p, ok := pkt.(*v5.PubAck)
 	if !ok {
 		return ErrInvalidPacketType
@@ -378,7 +378,7 @@ func (h *V5Handler) HandlePubAck(s *connCtx, pkt packets.ControlPacket) error {
 }
 
 // HandlePubRec handles PUBREC packets.
-func (h *V5Handler) HandlePubRec(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v5Handler) HandlePubRec(s *connCtx, pkt packets.ControlPacket) error {
 	p, ok := pkt.(*v5.PubRec)
 	if !ok {
 		return ErrInvalidPacketType
@@ -397,7 +397,7 @@ func (h *V5Handler) HandlePubRec(s *connCtx, pkt packets.ControlPacket) error {
 }
 
 // HandlePubRel handles PUBREL packets.
-func (h *V5Handler) HandlePubRel(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v5Handler) HandlePubRel(s *connCtx, pkt packets.ControlPacket) error {
 	p, ok := pkt.(*v5.PubRel)
 	if !ok {
 		return ErrInvalidPacketType
@@ -459,7 +459,7 @@ func (h *V5Handler) HandlePubRel(s *connCtx, pkt packets.ControlPacket) error {
 }
 
 // HandlePubComp handles PUBCOMP packets.
-func (h *V5Handler) HandlePubComp(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v5Handler) HandlePubComp(s *connCtx, pkt packets.ControlPacket) error {
 	p, ok := pkt.(*v5.PubComp)
 	if !ok {
 		return ErrInvalidPacketType
@@ -470,7 +470,7 @@ func (h *V5Handler) HandlePubComp(s *connCtx, pkt packets.ControlPacket) error {
 }
 
 // HandleSubscribe handles SUBSCRIBE packets.
-func (h *V5Handler) HandleSubscribe(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v5Handler) HandleSubscribe(s *connCtx, pkt packets.ControlPacket) error {
 	start := time.Now()
 	p, ok := pkt.(*v5.Subscribe)
 	if !ok {
@@ -591,7 +591,7 @@ func (h *V5Handler) HandleSubscribe(s *connCtx, pkt packets.ControlPacket) error
 }
 
 // HandleUnsubscribe handles UNSUBSCRIBE packets.
-func (h *V5Handler) HandleUnsubscribe(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v5Handler) HandleUnsubscribe(s *connCtx, pkt packets.ControlPacket) error {
 	start := time.Now()
 	p, ok := pkt.(*v5.Unsubscribe)
 	if !ok {
@@ -623,7 +623,7 @@ func (h *V5Handler) HandleUnsubscribe(s *connCtx, pkt packets.ControlPacket) err
 }
 
 // HandlePingReq handles PINGREQ packets.
-func (h *V5Handler) HandlePingReq(s *connCtx) error {
+func (h *v5Handler) HandlePingReq(s *connCtx) error {
 	h.broker.telemetry.logger.Debug("v5_pingreq", slog.String("client_id", s.ID))
 
 	// Update heartbeat for queue consumers
@@ -638,7 +638,7 @@ func (h *V5Handler) HandlePingReq(s *connCtx) error {
 }
 
 // HandleDisconnect handles DISCONNECT packets.
-func (h *V5Handler) HandleDisconnect(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v5Handler) HandleDisconnect(s *connCtx, pkt packets.ControlPacket) error {
 	_, ok := pkt.(*v5.Disconnect)
 	if !ok {
 		return ErrInvalidPacketType
@@ -650,7 +650,7 @@ func (h *V5Handler) HandleDisconnect(s *connCtx, pkt packets.ControlPacket) erro
 }
 
 // HandleAuth handles AUTH packets.
-func (h *V5Handler) HandleAuth(s *connCtx, pkt packets.ControlPacket) error {
+func (h *v5Handler) HandleAuth(s *connCtx, pkt packets.ControlPacket) error {
 	_, ok := pkt.(*v5.Auth)
 	if !ok {
 		return ErrInvalidPacketType
@@ -661,7 +661,7 @@ func (h *V5Handler) HandleAuth(s *connCtx, pkt packets.ControlPacket) error {
 }
 
 // deliverOfflineMessages sends queued messages to reconnected client.
-func (h *V5Handler) deliverOfflineMessages(s *session.Session) {
+func (h *v5Handler) deliverOfflineMessages(s *session.Session) {
 	msgs := s.OfflineQueue().Drain()
 	for _, msg := range msgs {
 		h.broker.DeliverToSession(context.Background(), s, msg) //nolint:errcheck // offline message delivery; errors are non-fatal

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -423,7 +423,7 @@ func (h *v5Handler) HandlePubRel(s *connCtx, pkt packets.ControlPacket) error {
 	packetID := p.ID
 
 	// Distribute stored message now that publisher has committed with PUBREL.
-	msg, err := s.Inflight().AckInbound(packetID)
+	msg, err := s.AckInbound(packetID)
 	if err != nil {
 		h.broker.telemetry.logger.Warn("v5_pubrel_unknown_packet",
 			slog.String("client_id", s.ID),

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -193,7 +193,7 @@ func (h *v5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	h.deliverOfflineMessages(s)
 
-	return h.broker.runSession(h, s, conn, epoch)
+	return h.broker.runSession(h, s, conn, epoch, time.Duration(p.KeepAlive)*time.Second)
 }
 
 // HandlePublish handles PUBLISH packets.

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -423,7 +423,7 @@ func (h *v5Handler) HandlePubRel(s *connCtx, pkt packets.ControlPacket) error {
 	packetID := p.ID
 
 	// Distribute stored message now that publisher has committed with PUBREL.
-	msg, err := s.Inflight().Ack(packetID)
+	msg, err := s.Inflight().Ack(packetID, messages.Inbound)
 	if err != nil {
 		h.broker.telemetry.logger.Warn("v5_pubrel_unknown_packet",
 			slog.String("client_id", s.ID),

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -424,7 +424,6 @@ func (h *v5Handler) HandlePubRel(s *connCtx, pkt packets.ControlPacket) error {
 			slog.String("client_id", s.ID),
 			slog.Int("packet_id", int(packetID)))
 	}
-	s.Inflight().ClearReceived(packetID)
 
 	rc := byte(0x00)
 	comp := &v5.PubComp{

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -684,7 +684,10 @@ func (h *v5Handler) deliverOfflineMessages(s *session.Session) {
 }
 
 func sendV5ConnAckWithProperties(conn core.Connection, s *session.Session, sessionPresent bool, reasonCode byte, maxQoS byte) error {
-	receiveMax := maxReceived
+	// Advertise the server's actual inbound Receive Maximum (the bidirectional
+	// inflight store capacity), not the protocol default, so the client does not
+	// send more concurrent QoS 1/2 PUBLISH packets than the broker accepts.
+	receiveMax := uint16(s.ServerMaxInflight())
 	topicAliasMax := s.TopicAliasMax
 	retainAvailable := byte(1)
 	wildcardSubAvailable := byte(1)

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -111,6 +111,9 @@ func (h *v5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 			Retain:     p.WillRetain,
 			Properties: setOriginProperties(nil, externalID),
 		}
+		if p.WillProperties != nil && p.WillProperties.WillDelayInterval != nil {
+			will.Delay = *p.WillProperties.WillDelayInterval
+		}
 	}
 
 	receiveMax := maxReceived
@@ -153,14 +156,21 @@ func (h *v5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	// Apply the negotiated options and take over any existing connection. On a
 	// persistent reconnect this replaces the previous connection's version,
-	// keep-alive, Will, expiry, and topic-alias maximum.
+	// keep-alive, Will, Receive Maximum, and topic-alias maximum.
 	epoch, superseded := s.ConnectWithOptions(conn, session.ConnectOptions{
 		Version:        p.ProtocolVersion,
 		KeepAlive:      time.Duration(p.KeepAlive) * time.Second,
 		Will:           will,
-		ExpiryInterval: sessionExpiry,
+		ReceiveMaximum: receiveMax,
 		TopicAliasMax:  topicAliasMax,
 	})
+	// Session expiry is applied verbatim on reconnect so a new value of 0
+	// (expire on disconnect) replaces a previous positive one. A new session's
+	// expiry, including the server default policy, was already set in
+	// CreateSession.
+	if !isNew {
+		s.SetExpiryInterval(sessionExpiry)
+	}
 	if superseded != nil {
 		go h.broker.drainSuperseded(context.WithoutCancel(context.Background()), superseded)
 	}

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -423,7 +423,7 @@ func (h *v5Handler) HandlePubRel(s *connCtx, pkt packets.ControlPacket) error {
 	packetID := p.ID
 
 	// Distribute stored message now that publisher has committed with PUBREL.
-	msg, err := s.Inflight().Ack(packetID, messages.Inbound)
+	msg, err := s.Inflight().AckInbound(packetID)
 	if err != nil {
 		h.broker.telemetry.logger.Warn("v5_pubrel_unknown_packet",
 			slog.String("client_id", s.ID),

--- a/mqtt/session/encode.go
+++ b/mqtt/session/encode.go
@@ -1,0 +1,135 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"encoding/base64"
+	"strconv"
+	"time"
+
+	"github.com/absmach/fluxmq/mqtt/packets"
+	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
+	"github.com/absmach/fluxmq/storage"
+)
+
+// EncodePublish builds a PUBLISH control packet for the given protocol version
+// from msg. The packet is taken from the version's pool and the caller must
+// return it via pkt.Release() once written. dup sets the DUP flag (true for a
+// retransmission). For v5 it applies the message's PUBLISH properties and the
+// remaining message-expiry interval, so a retransmission carries the same
+// properties as the original send.
+//
+// This is the single encoder shared by the first-send path (broker delivery)
+// and the retransmission path (ProcessRetries), so the two cannot diverge.
+func EncodePublish(msg *storage.Message, packetID uint16, version byte, dup bool) packets.ControlPacket {
+	if version == packets.V5 {
+		p := v5.AcquirePublish()
+		p.FixedHeader = packets.FixedHeader{
+			PacketType: packets.PublishType,
+			QoS:        msg.QoS,
+			Retain:     msg.Retain,
+			Dup:        dup,
+		}
+		p.TopicName = msg.Topic
+		p.Payload = msg.GetPayload()
+		p.ID = packetID
+
+		// Send the remaining message-expiry interval, not the original.
+		if msg.MessageExpiry != nil && !msg.Expiry.IsZero() {
+			if remaining := time.Until(msg.Expiry); remaining > 0 {
+				remainingSec := uint32(remaining.Seconds())
+				p.Properties.MessageExpiry = &remainingSec
+			}
+		}
+		applyPublishProperties(p.Properties, msg)
+		return p
+	}
+
+	p := v3.AcquirePublish()
+	p.FixedHeader = packets.FixedHeader{
+		PacketType: packets.PublishType,
+		QoS:        msg.QoS,
+		Retain:     msg.Retain,
+		Dup:        dup,
+	}
+	p.TopicName = msg.Topic
+	p.Payload = msg.GetPayload()
+	p.ID = packetID
+	return p
+}
+
+func applyPublishProperties(props *v5.PublishProperties, msg *storage.Message) {
+	if props == nil || msg == nil {
+		return
+	}
+
+	// Prefer explicit fields; fall back to mapped properties.
+	if msg.ContentType != "" {
+		props.ContentType = msg.ContentType
+	} else if v := msg.Properties["content-type"]; v != "" {
+		props.ContentType = v
+	}
+
+	if msg.ResponseTopic != "" {
+		props.ResponseTopic = msg.ResponseTopic
+	} else if v := msg.Properties["response-topic"]; v != "" {
+		props.ResponseTopic = v
+	}
+
+	if len(msg.CorrelationData) > 0 {
+		props.CorrelationData = msg.CorrelationData
+	} else if v := msg.Properties["correlation-id"]; v != "" {
+		if decoded, err := base64.StdEncoding.DecodeString(v); err == nil {
+			props.CorrelationData = decoded
+		} else {
+			props.CorrelationData = []byte(v)
+		}
+	}
+
+	if msg.PayloadFormat != nil {
+		props.PayloadFormat = msg.PayloadFormat
+	} else if v := msg.Properties["payload-format"]; v != "" {
+		if n, err := strconv.ParseUint(v, 10, 8); err == nil {
+			pf := byte(n)
+			props.PayloadFormat = &pf
+		}
+	}
+
+	// Build User properties slice directly without intermediate map.
+	// Skip entirely when no properties exist (common case).
+	var userCount int
+	if msg.Properties != nil {
+		for k := range msg.Properties {
+			if !isReservedUserPropertyKey(k) {
+				userCount++
+			}
+		}
+	}
+	userCount += len(msg.UserProperties)
+
+	if userCount > 0 {
+		props.User = make([]v5.User, 0, userCount)
+		if msg.Properties != nil {
+			for k, v := range msg.Properties {
+				if isReservedUserPropertyKey(k) {
+					continue
+				}
+				props.User = append(props.User, v5.User{Key: k, Value: v})
+			}
+		}
+		for k, v := range msg.UserProperties {
+			props.User = append(props.User, v5.User{Key: k, Value: v})
+		}
+	}
+}
+
+func isReservedUserPropertyKey(key string) bool {
+	switch key {
+	case "content-type", "response-topic", "correlation-id", "payload-format":
+		return true
+	default:
+		return false
+	}
+}

--- a/mqtt/session/encode_test.go
+++ b/mqtt/session/encode_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/absmach/fluxmq/mqtt/packets"
+	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
+	"github.com/absmach/fluxmq/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEncodePublish_V5RetransmitCarriesProperties guards against the
+// retransmission path stripping v5 PUBLISH properties: a resent message
+// (dup=true) must carry the same ContentType, ResponseTopic, CorrelationData,
+// UserProperties, PayloadFormat, and a positive remaining MessageExpiry as the
+// first send.
+func TestEncodePublish_V5RetransmitCarriesProperties(t *testing.T) {
+	pf := byte(1)
+	expiry := uint32(120)
+	msg := &storage.Message{
+		Topic:           "sensors/temp",
+		QoS:             1,
+		Retain:          true,
+		ContentType:     "application/json",
+		ResponseTopic:   "responses/123",
+		CorrelationData: []byte("corr-1"),
+		PayloadFormat:   &pf,
+		MessageExpiry:   &expiry,
+		Expiry:          time.Now().Add(60 * time.Second),
+		UserProperties:  map[string]string{"trace": "abc"},
+	}
+	msg.SetPayloadFromBytes([]byte("payload"))
+
+	pkt := EncodePublish(msg, 42, packets.V5, true)
+	pub, ok := pkt.(*v5.Publish)
+	require.True(t, ok, "v5 version must produce a *v5.Publish")
+	defer pub.Release()
+
+	require.Equal(t, uint16(42), pub.ID)
+	require.Equal(t, "sensors/temp", pub.TopicName)
+	require.True(t, pub.FixedHeader.Dup, "retransmission must set the DUP flag")
+	require.Equal(t, byte(1), pub.FixedHeader.QoS)
+	require.True(t, pub.FixedHeader.Retain)
+
+	require.NotNil(t, pub.Properties)
+	require.Equal(t, "application/json", pub.Properties.ContentType)
+	require.Equal(t, "responses/123", pub.Properties.ResponseTopic)
+	require.Equal(t, []byte("corr-1"), pub.Properties.CorrelationData)
+	require.NotNil(t, pub.Properties.PayloadFormat)
+	require.Equal(t, byte(1), *pub.Properties.PayloadFormat)
+	require.NotNil(t, pub.Properties.MessageExpiry, "remaining message expiry must be set")
+	require.Greater(t, *pub.Properties.MessageExpiry, uint32(0))
+	require.LessOrEqual(t, *pub.Properties.MessageExpiry, uint32(60))
+	require.Contains(t, pub.Properties.User, v5.User{Key: "trace", Value: "abc"})
+}
+
+// TestEncodePublish_V3FirstSendNoDup verifies the v3 path encodes a *v3.Publish
+// and honours the dup flag.
+func TestEncodePublish_V3FirstSendNoDup(t *testing.T) {
+	msg := &storage.Message{Topic: "t", QoS: 2}
+	msg.SetPayloadFromBytes([]byte("p"))
+
+	pkt := EncodePublish(msg, 7, packets.V311, false)
+	pub, ok := pkt.(*v3.Publish)
+	require.True(t, ok, "v3 version must produce a *v3.Publish")
+
+	require.Equal(t, uint16(7), pub.ID)
+	require.Equal(t, "t", pub.TopicName)
+	require.False(t, pub.FixedHeader.Dup, "first send must not set the DUP flag")
+	require.Equal(t, byte(2), pub.FixedHeader.QoS)
+}

--- a/mqtt/session/messages.go
+++ b/mqtt/session/messages.go
@@ -14,7 +14,6 @@ import (
 	"github.com/absmach/fluxmq/mqtt/packets"
 	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
 	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
-	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/storage/messages"
 )
 
@@ -155,7 +154,9 @@ func (h *msgHandler) resendMessage(writer core.PacketWriter, inflight *messages.
 		return writer.WriteControlPacket(rel, onSent)
 	}
 
-	pub := h.acquirePublishPacket(msg, inflight.PacketID, version)
+	// dup=true: this is a retransmission. EncodePublish carries the v5 PUBLISH
+	// properties so a resent message is not stripped of them.
+	pub := EncodePublish(msg, inflight.PacketID, version, true)
 	err := writer.TryWriteDataPacket(pub, onSent)
 	if errors.Is(err, core.ErrSendQueueFull) {
 		pub.Release()
@@ -166,34 +167,6 @@ func (h *msgHandler) resendMessage(writer core.PacketWriter, inflight *messages.
 		pub.Release()
 	}
 	return err
-}
-
-func (h *msgHandler) acquirePublishPacket(msg *storage.Message, packetID uint16, version byte) packets.ControlPacket {
-	payload := msg.GetPayload()
-	if version == packets.V5 {
-		p := v5.AcquirePublish()
-		p.FixedHeader = packets.FixedHeader{
-			PacketType: packets.PublishType,
-			QoS:        msg.QoS,
-			Retain:     msg.Retain,
-			Dup:        true,
-		}
-		p.TopicName = msg.Topic
-		p.Payload = payload
-		p.ID = packetID
-		return p
-	}
-	p := v3.AcquirePublish()
-	p.FixedHeader = packets.FixedHeader{
-		PacketType: packets.PublishType,
-		QoS:        msg.QoS,
-		Retain:     msg.Retain,
-		Dup:        true,
-	}
-	p.TopicName = msg.Topic
-	p.Payload = payload
-	p.ID = packetID
-	return p
 }
 
 func (h *msgHandler) newPubRelPacket(packetID uint16, version byte) packets.ControlPacket {

--- a/mqtt/session/messages.go
+++ b/mqtt/session/messages.go
@@ -65,8 +65,6 @@ func (h *msgHandler) ProcessRetries(writer core.PacketWriter, acquire func(packe
 			slog.Debug("Failed to resend message", "packet_id", inflight.PacketID, "error", err)
 		}
 	}
-
-	h.inflight.CleanupExpiredReceived(30 * time.Minute)
 }
 
 // Inflight returns the inflight tracker.

--- a/mqtt/session/messages.go
+++ b/mqtt/session/messages.go
@@ -52,7 +52,18 @@ const RetryTimeout = 20 * time.Second
 // token is consumed; when none is available the retransmission is deferred to a
 // later cycle. This stops a reconnect from retransmitting more unacknowledged
 // PUBLISH packets at once than the new connection advertised.
-func (h *msgHandler) ProcessRetries(writer core.PacketWriter, acquire func(packetID uint16) bool) {
+func (h *msgHandler) ProcessRetries(writer core.PacketWriter, version byte, acquire func(packetID uint16) bool, markRetry func(packetID uint16)) {
+	if version == 0 {
+		version = h.version
+	}
+	if markRetry == nil {
+		markRetry = func(packetID uint16) {
+			if err := h.inflight.MarkRetry(packetID); err != nil {
+				slog.Debug("Failed to mark retry", "packet_id", packetID, "error", err)
+			}
+		}
+	}
+
 	expired := h.inflight.GetExpired(RetryTimeout)
 	for _, inflight := range expired {
 		if inflight.Direction != messages.Outbound {
@@ -61,7 +72,7 @@ func (h *msgHandler) ProcessRetries(writer core.PacketWriter, acquire func(packe
 		if acquire != nil && !acquire(inflight.PacketID) {
 			continue // no send quota available this cycle; retry later
 		}
-		if err := h.resendMessage(writer, inflight); err != nil {
+		if err := h.resendMessage(writer, inflight, version, markRetry); err != nil {
 			slog.Debug("Failed to resend message", "packet_id", inflight.PacketID, "error", err)
 		}
 	}
@@ -129,24 +140,22 @@ func (h *msgHandler) ClearAliases() {
 	h.inboundAliases = make(map[uint16]string)
 }
 
-func (h *msgHandler) resendMessage(writer core.PacketWriter, inflight *messages.InflightMessage) error {
+func (h *msgHandler) resendMessage(writer core.PacketWriter, inflight *messages.InflightMessage, version byte, markRetry func(packetID uint16)) error {
 	msg := inflight.Message
 	if msg == nil {
 		return nil
 	}
 
 	onSent := func() {
-		if err := h.inflight.MarkRetry(inflight.PacketID); err != nil {
-			slog.Debug("Failed to mark retry", "packet_id", inflight.PacketID, "error", err)
-		}
+		markRetry(inflight.PacketID)
 	}
 
 	if msg.QoS == 2 && inflight.State == messages.StatePubRecReceived {
-		rel := h.newPubRelPacket(inflight.PacketID)
+		rel := h.newPubRelPacket(inflight.PacketID, version)
 		return writer.WriteControlPacket(rel, onSent)
 	}
 
-	pub := h.acquirePublishPacket(msg, inflight.PacketID)
+	pub := h.acquirePublishPacket(msg, inflight.PacketID, version)
 	err := writer.TryWriteDataPacket(pub, onSent)
 	if errors.Is(err, core.ErrSendQueueFull) {
 		pub.Release()
@@ -159,9 +168,9 @@ func (h *msgHandler) resendMessage(writer core.PacketWriter, inflight *messages.
 	return err
 }
 
-func (h *msgHandler) acquirePublishPacket(msg *storage.Message, packetID uint16) packets.ControlPacket {
+func (h *msgHandler) acquirePublishPacket(msg *storage.Message, packetID uint16, version byte) packets.ControlPacket {
 	payload := msg.GetPayload()
-	if h.version == packets.V5 {
+	if version == packets.V5 {
 		p := v5.AcquirePublish()
 		p.FixedHeader = packets.FixedHeader{
 			PacketType: packets.PublishType,
@@ -187,8 +196,8 @@ func (h *msgHandler) acquirePublishPacket(msg *storage.Message, packetID uint16)
 	return p
 }
 
-func (h *msgHandler) newPubRelPacket(packetID uint16) packets.ControlPacket {
-	if h.version == packets.V5 {
+func (h *msgHandler) newPubRelPacket(packetID uint16, version byte) packets.ControlPacket {
+	if version == packets.V5 {
 		return &v5.PubRel{
 			FixedHeader: packets.FixedHeader{PacketType: packets.PubRelType, QoS: 1},
 			ID:          packetID,

--- a/mqtt/session/messages.go
+++ b/mqtt/session/messages.go
@@ -44,12 +44,22 @@ func newMessageHandler(inflight messages.Inflight, offlineQueue messages.Queue, 
 const RetryTimeout = 20 * time.Second
 
 // ProcessRetries checks for expired inflight messages and resends them.
-// This is called synchronously from the read loop instead of running in a separate goroutine.
-func (h *msgHandler) ProcessRetries(writer core.PacketWriter) {
+// This is called synchronously from the read loop instead of running in a
+// separate goroutine.
+//
+// acquire gates each outbound retransmission against the connection's send quota
+// (Receive Maximum): a message already holding a token resends, otherwise a
+// token is consumed; when none is available the retransmission is deferred to a
+// later cycle. This stops a reconnect from retransmitting more unacknowledged
+// PUBLISH packets at once than the new connection advertised.
+func (h *msgHandler) ProcessRetries(writer core.PacketWriter, acquire func(packetID uint16) bool) {
 	expired := h.inflight.GetExpired(RetryTimeout)
 	for _, inflight := range expired {
 		if inflight.Direction != messages.Outbound {
 			continue
+		}
+		if acquire != nil && !acquire(inflight.PacketID) {
+			continue // no send quota available this cycle; retry later
 		}
 		if err := h.resendMessage(writer, inflight); err != nil {
 			slog.Debug("Failed to resend message", "packet_id", inflight.PacketID, "error", err)

--- a/mqtt/session/messages_test.go
+++ b/mqtt/session/messages_test.go
@@ -30,7 +30,7 @@ func TestProcessRetriesSkipsInbound(t *testing.T) {
 	h := newMessageHandler(f, nil, 4)
 	w := &mockWriter{}
 
-	h.ProcessRetries(w)
+	h.ProcessRetries(w, nil)
 
 	require.Empty(t, w.data)
 	require.Empty(t, w.control)
@@ -51,7 +51,7 @@ func TestProcessRetriesOutboundQoS1UsesPublish(t *testing.T) {
 	h := newMessageHandler(f, nil, 4)
 	w := &mockWriter{}
 
-	h.ProcessRetries(w)
+	h.ProcessRetries(w, nil)
 
 	require.Len(t, w.data, 1)
 	require.IsType(t, &v3.Publish{}, w.data[0])
@@ -73,7 +73,7 @@ func TestProcessRetriesOutboundQoS2PublishSentUsesPublish(t *testing.T) {
 	h := newMessageHandler(f, nil, 4)
 	w := &mockWriter{}
 
-	h.ProcessRetries(w)
+	h.ProcessRetries(w, nil)
 
 	require.Len(t, w.data, 1)
 	require.IsType(t, &v3.Publish{}, w.data[0])
@@ -95,7 +95,7 @@ func TestProcessRetriesOutboundQoS2PubRecReceivedUsesPubRelV3(t *testing.T) {
 	h := newMessageHandler(f, nil, 4)
 	w := &mockWriter{}
 
-	h.ProcessRetries(w)
+	h.ProcessRetries(w, nil)
 
 	require.Empty(t, w.data)
 	require.Len(t, w.control, 1)
@@ -117,7 +117,7 @@ func TestProcessRetriesOutboundQoS2PubRecReceivedUsesPubRelV5(t *testing.T) {
 	h := newMessageHandler(f, nil, packets.V5)
 	w := &mockWriter{}
 
-	h.ProcessRetries(w)
+	h.ProcessRetries(w, nil)
 
 	require.Empty(t, w.data)
 	require.Len(t, w.control, 1)
@@ -163,8 +163,6 @@ type fakeInflight struct {
 func (f *fakeInflight) Add(packetID uint16, msg *storage.Message, direction messages.Direction) error {
 	return nil
 }
-
-func (f *fakeInflight) SetMaxSize(maxSize int) {}
 
 func (f *fakeInflight) Ack(packetID uint16) (*storage.Message, error) { return nil, nil }
 
@@ -237,7 +235,7 @@ func TestProcessRetries_ResetsBackoffOnQueueFull(t *testing.T) {
 	}
 	h := newMessageHandler(f, nil, 4)
 
-	h.ProcessRetries(&queueFullWriter{})
+	h.ProcessRetries(&queueFullWriter{}, nil)
 
 	// MarkRetry must NOT be called — the message never reached the wire.
 	require.Empty(t, f.retryCalls)

--- a/mqtt/session/messages_test.go
+++ b/mqtt/session/messages_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/absmach/fluxmq/config"
 	core "github.com/absmach/fluxmq/mqtt"
 	"github.com/absmach/fluxmq/mqtt/packets"
 	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
@@ -158,13 +159,20 @@ type fakeInflight struct {
 	expired                []*messages.InflightMessage
 	retryCalls             []uint16
 	deliveryAttemptedCalls []uint16
+	addCalls               []uint16
+	ackCalls               []uint16
+	ackResult              *storage.Message
 }
 
 func (f *fakeInflight) Add(packetID uint16, msg *storage.Message, direction messages.Direction) error {
+	f.addCalls = append(f.addCalls, packetID)
 	return nil
 }
 
-func (f *fakeInflight) Ack(packetID uint16) (*storage.Message, error) { return nil, nil }
+func (f *fakeInflight) Ack(packetID uint16) (*storage.Message, error) {
+	f.ackCalls = append(f.ackCalls, packetID)
+	return f.ackResult, nil
+}
 
 func (f *fakeInflight) Get(packetID uint16) (*messages.InflightMessage, bool) { return nil, false }
 
@@ -202,6 +210,21 @@ func (f *fakeInflight) MarkRetry(packetID uint16) error {
 func (f *fakeInflight) GetAll() []*messages.InflightMessage { return nil }
 
 func (f *fakeInflight) CleanupExpiredReceived(olderThan time.Duration) {}
+
+func TestInboundOperationsRequireDirectionalExtensions(t *testing.T) {
+	f := &fakeInflight{ackResult: &storage.Message{Topic: "outbound"}}
+	s := New("client", packets.V5, Options{}, f, nil, config.SessionConfig{})
+
+	accepted, err := s.AddInbound(7, &storage.Message{Topic: "inbound"})
+	require.ErrorIs(t, err, messages.ErrInboundUnsupported)
+	require.False(t, accepted)
+	require.Empty(t, f.addCalls, "unsupported inbound admission must not call base Add")
+
+	got, err := s.AckInbound(7)
+	require.ErrorIs(t, err, messages.ErrInboundUnsupported)
+	require.Nil(t, got)
+	require.Empty(t, f.ackCalls, "unsupported PUBREL must not acknowledge an outbound entry")
+}
 
 // queueFullWriter returns ErrSendQueueFull for every TryWriteDataPacket call.
 type queueFullWriter struct{}

--- a/mqtt/session/messages_test.go
+++ b/mqtt/session/messages_test.go
@@ -164,9 +164,8 @@ func (f *fakeInflight) Add(packetID uint16, msg *storage.Message, direction mess
 	return nil
 }
 
-func (f *fakeInflight) Ack(packetID uint16, direction messages.Direction) (*storage.Message, error) {
-	return nil, nil
-}
+func (f *fakeInflight) Ack(packetID uint16) (*storage.Message, error)        { return nil, nil }
+func (f *fakeInflight) AckInbound(packetID uint16) (*storage.Message, error) { return nil, nil }
 
 func (f *fakeInflight) Get(packetID uint16) (*messages.InflightMessage, bool) { return nil, false }
 

--- a/mqtt/session/messages_test.go
+++ b/mqtt/session/messages_test.go
@@ -164,6 +164,8 @@ func (f *fakeInflight) Add(packetID uint16, msg *storage.Message, direction mess
 	return nil
 }
 
+func (f *fakeInflight) SetMaxSize(maxSize int) {}
+
 func (f *fakeInflight) Ack(packetID uint16) (*storage.Message, error) { return nil, nil }
 
 func (f *fakeInflight) Get(packetID uint16) (*messages.InflightMessage, bool) { return nil, false }

--- a/mqtt/session/messages_test.go
+++ b/mqtt/session/messages_test.go
@@ -164,8 +164,7 @@ func (f *fakeInflight) Add(packetID uint16, msg *storage.Message, direction mess
 	return nil
 }
 
-func (f *fakeInflight) Ack(packetID uint16) (*storage.Message, error)        { return nil, nil }
-func (f *fakeInflight) AckInbound(packetID uint16) (*storage.Message, error) { return nil, nil }
+func (f *fakeInflight) Ack(packetID uint16) (*storage.Message, error) { return nil, nil }
 
 func (f *fakeInflight) Get(packetID uint16) (*messages.InflightMessage, bool) { return nil, false }
 

--- a/mqtt/session/messages_test.go
+++ b/mqtt/session/messages_test.go
@@ -31,7 +31,7 @@ func TestProcessRetriesSkipsInbound(t *testing.T) {
 	h := newMessageHandler(f, nil, 4)
 	w := &mockWriter{}
 
-	h.ProcessRetries(w, nil)
+	h.ProcessRetries(w, 0, nil, nil)
 
 	require.Empty(t, w.data)
 	require.Empty(t, w.control)
@@ -52,7 +52,7 @@ func TestProcessRetriesOutboundQoS1UsesPublish(t *testing.T) {
 	h := newMessageHandler(f, nil, 4)
 	w := &mockWriter{}
 
-	h.ProcessRetries(w, nil)
+	h.ProcessRetries(w, 0, nil, nil)
 
 	require.Len(t, w.data, 1)
 	require.IsType(t, &v3.Publish{}, w.data[0])
@@ -74,7 +74,7 @@ func TestProcessRetriesOutboundQoS2PublishSentUsesPublish(t *testing.T) {
 	h := newMessageHandler(f, nil, 4)
 	w := &mockWriter{}
 
-	h.ProcessRetries(w, nil)
+	h.ProcessRetries(w, 0, nil, nil)
 
 	require.Len(t, w.data, 1)
 	require.IsType(t, &v3.Publish{}, w.data[0])
@@ -96,7 +96,7 @@ func TestProcessRetriesOutboundQoS2PubRecReceivedUsesPubRelV3(t *testing.T) {
 	h := newMessageHandler(f, nil, 4)
 	w := &mockWriter{}
 
-	h.ProcessRetries(w, nil)
+	h.ProcessRetries(w, 0, nil, nil)
 
 	require.Empty(t, w.data)
 	require.Len(t, w.control, 1)
@@ -118,12 +118,66 @@ func TestProcessRetriesOutboundQoS2PubRecReceivedUsesPubRelV5(t *testing.T) {
 	h := newMessageHandler(f, nil, packets.V5)
 	w := &mockWriter{}
 
-	h.ProcessRetries(w, nil)
+	h.ProcessRetries(w, 0, nil, nil)
 
 	require.Empty(t, w.data)
 	require.Len(t, w.control, 1)
 	require.IsType(t, &v5.PubRel{}, w.control[0])
 	require.Equal(t, []uint16{40}, f.retryCalls)
+}
+
+func TestProcessRetriesTo_EncodesForConnectionVersionAfterReconnect(t *testing.T) {
+	f := &fakeInflight{
+		expired: []*messages.InflightMessage{
+			{
+				PacketID:  50,
+				Direction: messages.Outbound,
+				State:     messages.StatePublishSent,
+				Message:   &storage.Message{Topic: "t", QoS: 1, Payload: []byte("a")},
+			},
+		},
+	}
+	s := New("client", packets.V311, Options{ReceiveMaximum: 8}, f, nil, config.SessionConfig{MaxInflightMessages: 8})
+
+	gen, _ := s.ConnectWithOptions(&testConn{}, ConnectOptions{Version: packets.V5, ReceiveMaximum: 8})
+	w := &mockWriter{}
+
+	s.ProcessRetriesTo(w, gen)
+
+	require.Len(t, w.data, 1)
+	require.IsType(t, &v5.Publish{}, w.data[0])
+	require.Equal(t, []uint16{50}, f.retryCalls)
+}
+
+func TestProcessRetriesTo_StaleOnSentDoesNotMarkRetry(t *testing.T) {
+	f := &fakeInflight{
+		expired: []*messages.InflightMessage{
+			{
+				PacketID:  60,
+				Direction: messages.Outbound,
+				State:     messages.StatePublishSent,
+				Message:   &storage.Message{Topic: "t", QoS: 1, Payload: []byte("a")},
+			},
+		},
+	}
+	s := New("client", packets.V5, Options{ReceiveMaximum: 8}, f, nil, config.SessionConfig{MaxInflightMessages: 8})
+	gen0, err := s.Connect(&testConn{})
+	require.NoError(t, err)
+
+	oldWriter := &captureOnSentWriter{}
+	s.ProcessRetriesTo(oldWriter, gen0)
+	require.Len(t, oldWriter.data, 1)
+	require.Empty(t, f.retryCalls)
+
+	_, _ = s.ConnectWithOptions(&testConn{}, ConnectOptions{Version: packets.V5, ReceiveMaximum: 8})
+	oldWriter.fire()
+	require.Empty(t, f.retryCalls, "stale retry callback must not update current-generation retry state")
+
+	currentWriter := &captureOnSentWriter{}
+	s.ProcessRetriesTo(currentWriter, s.Epoch())
+	require.Len(t, currentWriter.data, 1)
+	currentWriter.fire()
+	require.Equal(t, []uint16{60}, f.retryCalls)
 }
 
 type mockWriter struct {
@@ -153,6 +207,38 @@ func (w *mockWriter) WriteDataPacket(pkt packets.ControlPacket, onSent func()) e
 
 func (w *mockWriter) TryWriteDataPacket(pkt packets.ControlPacket, onSent func()) error {
 	return w.WriteDataPacket(pkt, onSent)
+}
+
+type captureOnSentWriter struct {
+	control []packets.ControlPacket
+	data    []packets.ControlPacket
+	onSent  func()
+}
+
+func (w *captureOnSentWriter) WritePacket(pkt packets.ControlPacket) error {
+	return w.WriteControlPacket(pkt, nil)
+}
+
+func (w *captureOnSentWriter) WriteControlPacket(pkt packets.ControlPacket, onSent func()) error {
+	w.control = append(w.control, pkt)
+	w.onSent = onSent
+	return nil
+}
+
+func (w *captureOnSentWriter) WriteDataPacket(pkt packets.ControlPacket, onSent func()) error {
+	w.data = append(w.data, pkt)
+	w.onSent = onSent
+	return nil
+}
+
+func (w *captureOnSentWriter) TryWriteDataPacket(pkt packets.ControlPacket, onSent func()) error {
+	return w.WriteDataPacket(pkt, onSent)
+}
+
+func (w *captureOnSentWriter) fire() {
+	if w.onSent != nil {
+		w.onSent()
+	}
 }
 
 type fakeInflight struct {
@@ -250,7 +336,7 @@ func TestProcessRetries_ResetsBackoffOnQueueFull(t *testing.T) {
 	}
 	h := newMessageHandler(f, nil, 4)
 
-	h.ProcessRetries(&queueFullWriter{}, nil)
+	h.ProcessRetries(&queueFullWriter{}, 0, nil, nil)
 
 	// MarkRetry must NOT be called — the message never reached the wire.
 	require.Empty(t, f.retryCalls)

--- a/mqtt/session/messages_test.go
+++ b/mqtt/session/messages_test.go
@@ -178,13 +178,7 @@ func (f *fakeInflight) Get(packetID uint16) (*messages.InflightMessage, bool) { 
 
 func (f *fakeInflight) Has(packetID uint16) bool { return false }
 
-func (f *fakeInflight) WasReceived(packetID uint16) bool { return false }
-
-func (f *fakeInflight) MarkReceived(packetID uint16) {}
-
 func (f *fakeInflight) UpdateState(packetID uint16, state messages.InflightState) error { return nil }
-
-func (f *fakeInflight) ClearReceived(packetID uint16) {}
 
 func (f *fakeInflight) GetExpired(expiry time.Duration) []*messages.InflightMessage {
 	return f.expired
@@ -208,8 +202,6 @@ func (f *fakeInflight) MarkRetry(packetID uint16) error {
 }
 
 func (f *fakeInflight) GetAll() []*messages.InflightMessage { return nil }
-
-func (f *fakeInflight) CleanupExpiredReceived(olderThan time.Duration) {}
 
 func TestInboundOperationsRequireDirectionalExtensions(t *testing.T) {
 	f := &fakeInflight{ackResult: &storage.Message{Topic: "outbound"}}

--- a/mqtt/session/messages_test.go
+++ b/mqtt/session/messages_test.go
@@ -164,7 +164,9 @@ func (f *fakeInflight) Add(packetID uint16, msg *storage.Message, direction mess
 	return nil
 }
 
-func (f *fakeInflight) Ack(packetID uint16) (*storage.Message, error) { return nil, nil }
+func (f *fakeInflight) Ack(packetID uint16, direction messages.Direction) (*storage.Message, error) {
+	return nil, nil
+}
 
 func (f *fakeInflight) Get(packetID uint16) (*messages.InflightMessage, bool) { return nil, false }
 

--- a/mqtt/session/sendwindow.go
+++ b/mqtt/session/sendwindow.go
@@ -9,9 +9,14 @@ import "sync"
 // packets. Its capacity is the negotiated Receive Maximum, already bounded by
 // the configured server limit. A token is consumed for every outbound
 // transmission of a packet ID — a new send or a retransmission — that does not
-// already hold one on the current connection, and released when the packet is
-// acknowledged (PUBACK/PUBCOMP). The window is reset on each (re)connect, which
-// clears the per-connection holds and refills the quota. [MQTT-4.9]
+// already hold one for the current generation, and released when the packet is
+// acknowledged (PUBACK/PUBCOMP). [MQTT-4.9]
+//
+// Tokens are bound to a generation (the connection epoch). reset, called on each
+// (re)connect, advances the generation, drops the previous generation's holds,
+// and refills the quota. Acquire and release carry the caller's generation, so a
+// delivery or retry left over from a superseded connection can neither consume
+// nor free the replacement generation's quota.
 //
 // It is independent of the persistent, bidirectional inflight store: Receive
 // Maximum bounds only outbound QoS 1/2 flow, so inbound QoS 2 traffic must not
@@ -21,18 +26,20 @@ import "sync"
 type sendWindow struct {
 	mu       sync.Mutex
 	capacity int
-	held     map[uint16]struct{} // packet IDs holding a token on this connection
+	gen      uint64              // current generation (connection epoch)
+	held     map[uint16]struct{} // packet IDs holding a token in the current generation
 	waiters  int                 // senders currently blocked in acquire
 	ready    chan struct{}       // closed to wake blocked senders; recreated per broadcast
 	blocking bool                // backpressure mode: acquire blocks until a token frees
 }
 
-func newSendWindow(capacity int, blocking bool) *sendWindow {
+func newSendWindow(capacity int, gen uint64, blocking bool) *sendWindow {
 	if capacity < 1 {
 		capacity = 1
 	}
 	return &sendWindow{
 		capacity: capacity,
+		gen:      gen,
 		held:     make(map[uint16]struct{}),
 		ready:    make(chan struct{}),
 		blocking: blocking,
@@ -47,14 +54,15 @@ func (w *sendWindow) broadcastLocked() {
 	w.ready = make(chan struct{})
 }
 
-// reset reinitialises the window to capacity, clearing the per-connection holds.
-// Called on (re)connect so the quota is the new connection's Receive Maximum.
-func (w *sendWindow) reset(capacity int) {
+// reset reinitialises the window to capacity for the given generation, dropping
+// the previous generation's holds. Called on (re)connect.
+func (w *sendWindow) reset(capacity int, gen uint64) {
 	if capacity < 1 {
 		capacity = 1
 	}
 	w.mu.Lock()
 	w.capacity = capacity
+	w.gen = gen
 	w.held = make(map[uint16]struct{})
 	if w.waiters > 0 {
 		w.broadcastLocked()
@@ -62,12 +70,20 @@ func (w *sendWindow) reset(capacity int) {
 	w.mu.Unlock()
 }
 
-// tryAcquire consumes a token for packetID without blocking. A packet that
-// already holds a token (a retransmission on this connection) succeeds without
-// consuming another. Returns false if no token is available.
-func (w *sendWindow) tryAcquire(packetID uint16) bool {
+// tryAcquire consumes a token for packetID in generation gen without blocking.
+// It returns false if gen is no longer current (the connection was superseded)
+// or no token is available. A packet that already holds a token in the current
+// generation (a retransmission) succeeds without consuming another.
+func (w *sendWindow) tryAcquire(packetID uint16, gen uint64) bool {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	return w.tryAcquireLocked(packetID, gen)
+}
+
+func (w *sendWindow) tryAcquireLocked(packetID uint16, gen uint64) bool {
+	if gen != w.gen {
+		return false
+	}
 	if _, ok := w.held[packetID]; ok {
 		return true
 	}
@@ -78,17 +94,17 @@ func (w *sendWindow) tryAcquire(packetID uint16) bool {
 	return true
 }
 
-// acquire blocks until a token is available for packetID or stop is closed.
-// Returns false only if stop fired first.
-func (w *sendWindow) acquire(packetID uint16, stop <-chan struct{}) bool {
+// acquire blocks until a token is available for packetID in generation gen, the
+// generation is superseded, or stop is closed. Returns false if gen is no longer
+// current or stop fired first.
+func (w *sendWindow) acquire(packetID uint16, gen uint64, stop <-chan struct{}) bool {
 	for {
 		w.mu.Lock()
-		if _, ok := w.held[packetID]; ok {
+		if gen != w.gen {
 			w.mu.Unlock()
-			return true
+			return false
 		}
-		if len(w.held) < w.capacity {
-			w.held[packetID] = struct{}{}
+		if w.tryAcquireLocked(packetID, gen) {
 			w.mu.Unlock()
 			return true
 		}
@@ -111,15 +127,19 @@ func (w *sendWindow) acquire(packetID uint16, stop <-chan struct{}) bool {
 	}
 }
 
-// release returns the token held for packetID, if any, waking a blocked sender.
-// It only allocates (to wake waiters) when a sender is actually blocked, so the
-// uncontended PUBACK/PUBCOMP path stays allocation-free.
-func (w *sendWindow) release(packetID uint16) {
+// release returns the token held for packetID in generation gen, if any, waking
+// a blocked sender. A release carrying a superseded generation is a no-op, so a
+// leftover delivery cannot free the replacement generation's quota. It only
+// allocates (to wake waiters) when a sender is actually blocked, keeping the
+// uncontended PUBACK/PUBCOMP path allocation-free.
+func (w *sendWindow) release(packetID uint16, gen uint64) {
 	w.mu.Lock()
-	if _, ok := w.held[packetID]; ok {
-		delete(w.held, packetID)
-		if w.waiters > 0 {
-			w.broadcastLocked()
+	if gen == w.gen {
+		if _, ok := w.held[packetID]; ok {
+			delete(w.held, packetID)
+			if w.waiters > 0 {
+				w.broadcastLocked()
+			}
 		}
 	}
 	w.mu.Unlock()

--- a/mqtt/session/sendwindow.go
+++ b/mqtt/session/sendwindow.go
@@ -1,0 +1,126 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import "sync"
+
+// sendWindow is a connection-generation send quota for outbound QoS 1/2 PUBLISH
+// packets. Its capacity is the negotiated Receive Maximum, already bounded by
+// the configured server limit. A token is consumed for every outbound
+// transmission of a packet ID — a new send or a retransmission — that does not
+// already hold one on the current connection, and released when the packet is
+// acknowledged (PUBACK/PUBCOMP). The window is reset on each (re)connect, which
+// clears the per-connection holds and refills the quota. [MQTT-4.9]
+//
+// It is independent of the persistent, bidirectional inflight store: Receive
+// Maximum bounds only outbound QoS 1/2 flow, so inbound QoS 2 traffic must not
+// consume it.
+//
+// Safe for concurrent use.
+type sendWindow struct {
+	mu       sync.Mutex
+	capacity int
+	held     map[uint16]struct{} // packet IDs holding a token on this connection
+	waiters  int                 // senders currently blocked in acquire
+	ready    chan struct{}       // closed to wake blocked senders; recreated per broadcast
+	blocking bool                // backpressure mode: acquire blocks until a token frees
+}
+
+func newSendWindow(capacity int, blocking bool) *sendWindow {
+	if capacity < 1 {
+		capacity = 1
+	}
+	return &sendWindow{
+		capacity: capacity,
+		held:     make(map[uint16]struct{}),
+		ready:    make(chan struct{}),
+		blocking: blocking,
+	}
+}
+
+// broadcastLocked wakes blocked senders. It allocates a channel, so callers only
+// invoke it when waiters > 0, keeping the uncontended acquire/release path
+// allocation-free. Caller must hold w.mu.
+func (w *sendWindow) broadcastLocked() {
+	close(w.ready)
+	w.ready = make(chan struct{})
+}
+
+// reset reinitialises the window to capacity, clearing the per-connection holds.
+// Called on (re)connect so the quota is the new connection's Receive Maximum.
+func (w *sendWindow) reset(capacity int) {
+	if capacity < 1 {
+		capacity = 1
+	}
+	w.mu.Lock()
+	w.capacity = capacity
+	w.held = make(map[uint16]struct{})
+	if w.waiters > 0 {
+		w.broadcastLocked()
+	}
+	w.mu.Unlock()
+}
+
+// tryAcquire consumes a token for packetID without blocking. A packet that
+// already holds a token (a retransmission on this connection) succeeds without
+// consuming another. Returns false if no token is available.
+func (w *sendWindow) tryAcquire(packetID uint16) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if _, ok := w.held[packetID]; ok {
+		return true
+	}
+	if len(w.held) >= w.capacity {
+		return false
+	}
+	w.held[packetID] = struct{}{}
+	return true
+}
+
+// acquire blocks until a token is available for packetID or stop is closed.
+// Returns false only if stop fired first.
+func (w *sendWindow) acquire(packetID uint16, stop <-chan struct{}) bool {
+	for {
+		w.mu.Lock()
+		if _, ok := w.held[packetID]; ok {
+			w.mu.Unlock()
+			return true
+		}
+		if len(w.held) < w.capacity {
+			w.held[packetID] = struct{}{}
+			w.mu.Unlock()
+			return true
+		}
+		w.waiters++
+		ready := w.ready
+		w.mu.Unlock()
+
+		select {
+		case <-ready:
+		case <-stop:
+			w.mu.Lock()
+			w.waiters--
+			w.mu.Unlock()
+			return false
+		}
+
+		w.mu.Lock()
+		w.waiters--
+		w.mu.Unlock()
+	}
+}
+
+// release returns the token held for packetID, if any, waking a blocked sender.
+// It only allocates (to wake waiters) when a sender is actually blocked, so the
+// uncontended PUBACK/PUBCOMP path stays allocation-free.
+func (w *sendWindow) release(packetID uint16) {
+	w.mu.Lock()
+	if _, ok := w.held[packetID]; ok {
+		delete(w.held, packetID)
+		if w.waiters > 0 {
+			w.broadcastLocked()
+		}
+	}
+	w.mu.Unlock()
+}

--- a/mqtt/session/sendwindow_test.go
+++ b/mqtt/session/sendwindow_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/absmach/fluxmq/config"
+	"github.com/absmach/fluxmq/mqtt/packets"
+	"github.com/absmach/fluxmq/storage"
+	"github.com/absmach/fluxmq/storage/messages"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSendWindow_TryAcquireRespectsCapacity(t *testing.T) {
+	w := newSendWindow(2, false)
+
+	require.True(t, w.tryAcquire(1))
+	require.True(t, w.tryAcquire(2))
+	require.False(t, w.tryAcquire(3), "capacity 2 exhausted")
+
+	// A retransmission of an already-held packet ID does not consume another.
+	require.True(t, w.tryAcquire(1))
+
+	// Releasing frees a token for a new packet ID.
+	w.release(1)
+	require.True(t, w.tryAcquire(3))
+	require.False(t, w.tryAcquire(4))
+}
+
+func TestSendWindow_ResetClearsHoldsAndRefills(t *testing.T) {
+	w := newSendWindow(1, false)
+	require.True(t, w.tryAcquire(1))
+	require.False(t, w.tryAcquire(2))
+
+	// Reset to a larger capacity drops per-connection holds and refills quota.
+	w.reset(3)
+	require.True(t, w.tryAcquire(1)) // no longer held, re-acquired fresh
+	require.True(t, w.tryAcquire(2))
+	require.True(t, w.tryAcquire(3))
+	require.False(t, w.tryAcquire(4))
+}
+
+func TestSendWindow_AcquireUnblocksOnRelease(t *testing.T) {
+	w := newSendWindow(1, true)
+	stop := make(chan struct{})
+	require.True(t, w.acquire(1, stop))
+
+	got := make(chan bool, 1)
+	go func() { got <- w.acquire(2, stop) }()
+
+	time.Sleep(20 * time.Millisecond)
+	w.release(1) // frees a token; the blocked acquire must proceed
+
+	select {
+	case ok := <-got:
+		require.True(t, ok)
+	case <-time.After(time.Second):
+		t.Fatal("acquire did not unblock after release")
+	}
+}
+
+// TestProcessRetries_GatedBySendQuota guards finding #1: a reconnect with a low
+// Receive Maximum must not retransmit more unacknowledged PUBLISH packets at
+// once than the quota allows. With three expired outbound messages and a quota
+// of one, only one is retransmitted per cycle.
+func TestProcessRetries_GatedBySendQuota(t *testing.T) {
+	f := &fakeInflight{
+		expired: []*messages.InflightMessage{
+			{PacketID: 1, Direction: messages.Outbound, State: messages.StatePublishSent, Message: &storage.Message{Topic: "t", QoS: 1, Payload: []byte("a")}},
+			{PacketID: 2, Direction: messages.Outbound, State: messages.StatePublishSent, Message: &storage.Message{Topic: "t", QoS: 1, Payload: []byte("a")}},
+			{PacketID: 3, Direction: messages.Outbound, State: messages.StatePublishSent, Message: &storage.Message{Topic: "t", QoS: 1, Payload: []byte("a")}},
+		},
+	}
+	h := newMessageHandler(f, nil, packets.V5)
+	w := &mockWriter{}
+	quota := newSendWindow(1, false)
+
+	h.ProcessRetries(w, quota.tryAcquire)
+	require.Len(t, w.data, 1, "only one of three expired messages fits the quota of one")
+
+	// Even on a later cycle the quota of one still admits a single PUBLISH
+	// (the one holding the token); packets 2 and 3 stay gated.
+	w2 := &mockWriter{}
+	h.ProcessRetries(w2, quota.tryAcquire)
+	require.Len(t, w2.data, 1, "quota of one limits each retry cycle to one PUBLISH")
+}
+
+func TestNew_SendWindowClampedByServerMaxInflight(t *testing.T) {
+	s := New(
+		"client-cap",
+		packets.V5,
+		Options{CleanStart: true, ReceiveMaximum: 65535},
+		messages.NewInflightTracker(16),
+		messages.NewMessageQueue(16, true),
+		config.SessionConfig{
+			MaxInflightMessages: 256,
+			InflightOverflow:    config.InflightOverflowBackpressure,
+		},
+	)
+	require.Equal(t, 256, s.serverMaxInflight)
+
+	// A reconnect advertising a huge Receive Maximum is clamped to the server cap.
+	_, _ = s.ConnectWithOptions(&testConn{}, ConnectOptions{Version: 5, ReceiveMaximum: 65535})
+	require.Equal(t, uint16(256), s.ReceiveMaximum)
+	require.Equal(t, 256, s.sendWindow.capacity)
+}

--- a/mqtt/session/sendwindow_test.go
+++ b/mqtt/session/sendwindow_test.go
@@ -195,3 +195,27 @@ func TestNew_SendWindowClampedByServerMaxInflight(t *testing.T) {
 	require.Equal(t, uint16(256), s.ReceiveMaximum)
 	require.Equal(t, 256, s.sendWindow.capacity)
 }
+
+// TestMarkSentIfEpoch_StaleGenerationNoOp guards finding #2: marking sent is
+// scoped to the connection generation under the session lock, so a stale onSent
+// from a displaced connection cannot mark the shared inflight entry as sent.
+func TestMarkSentIfEpoch_StaleGenerationNoOp(t *testing.T) {
+	s := newTakeoverSession(t)
+	_, err := s.Connect(&testConn{})
+	require.NoError(t, err)
+	gen := s.Epoch()
+
+	require.NoError(t, s.Inflight().Add(1, &storage.Message{Topic: "t", QoS: 1}, messages.Outbound))
+
+	// Stale generation: must not mark sent.
+	s.MarkSentIfEpoch(1, gen-1)
+	inf, ok := s.Inflight().Get(1)
+	require.True(t, ok)
+	require.True(t, inf.SentAt.IsZero(), "stale generation must not mark sent")
+
+	// Current generation: marks sent.
+	s.MarkSentIfEpoch(1, gen)
+	inf, ok = s.Inflight().Get(1)
+	require.True(t, ok)
+	require.False(t, inf.SentAt.IsZero(), "current generation marks sent")
+}

--- a/mqtt/session/sendwindow_test.go
+++ b/mqtt/session/sendwindow_test.go
@@ -15,50 +15,90 @@ import (
 )
 
 func TestSendWindow_TryAcquireRespectsCapacity(t *testing.T) {
-	w := newSendWindow(2, false)
+	const gen = 1
+	w := newSendWindow(2, gen, false)
 
-	require.True(t, w.tryAcquire(1))
-	require.True(t, w.tryAcquire(2))
-	require.False(t, w.tryAcquire(3), "capacity 2 exhausted")
+	require.True(t, w.tryAcquire(1, gen))
+	require.True(t, w.tryAcquire(2, gen))
+	require.False(t, w.tryAcquire(3, gen), "capacity 2 exhausted")
 
 	// A retransmission of an already-held packet ID does not consume another.
-	require.True(t, w.tryAcquire(1))
+	require.True(t, w.tryAcquire(1, gen))
 
 	// Releasing frees a token for a new packet ID.
-	w.release(1)
-	require.True(t, w.tryAcquire(3))
-	require.False(t, w.tryAcquire(4))
+	w.release(1, gen)
+	require.True(t, w.tryAcquire(3, gen))
+	require.False(t, w.tryAcquire(4, gen))
 }
 
 func TestSendWindow_ResetClearsHoldsAndRefills(t *testing.T) {
-	w := newSendWindow(1, false)
-	require.True(t, w.tryAcquire(1))
-	require.False(t, w.tryAcquire(2))
+	w := newSendWindow(1, 1, false)
+	require.True(t, w.tryAcquire(1, 1))
+	require.False(t, w.tryAcquire(2, 1))
 
-	// Reset to a larger capacity drops per-connection holds and refills quota.
-	w.reset(3)
-	require.True(t, w.tryAcquire(1)) // no longer held, re-acquired fresh
-	require.True(t, w.tryAcquire(2))
-	require.True(t, w.tryAcquire(3))
-	require.False(t, w.tryAcquire(4))
+	// Reset advances the generation, drops holds, and refills quota.
+	w.reset(3, 2)
+	require.False(t, w.tryAcquire(1, 1), "stale generation cannot acquire")
+	require.True(t, w.tryAcquire(1, 2)) // re-acquired fresh in new generation
+	require.True(t, w.tryAcquire(2, 2))
+	require.True(t, w.tryAcquire(3, 2))
+	require.False(t, w.tryAcquire(4, 2))
+}
+
+func TestSendWindow_StaleGenerationCannotAcquireOrRelease(t *testing.T) {
+	w := newSendWindow(1, 1, false)
+	require.True(t, w.tryAcquire(1, 1))
+
+	// Takeover: new generation 2.
+	w.reset(1, 2)
+	require.True(t, w.tryAcquire(10, 2)) // gen 2 holds its one token
+
+	// A leftover gen-1 release must not free gen-2's token.
+	w.release(10, 1)
+	require.False(t, w.tryAcquire(11, 2), "stale release must not free current-generation quota")
+
+	// The current-generation release does free it.
+	w.release(10, 2)
+	require.True(t, w.tryAcquire(11, 2))
 }
 
 func TestSendWindow_AcquireUnblocksOnRelease(t *testing.T) {
-	w := newSendWindow(1, true)
+	const gen = 1
+	w := newSendWindow(1, gen, true)
 	stop := make(chan struct{})
-	require.True(t, w.acquire(1, stop))
+	require.True(t, w.acquire(1, gen, stop))
 
 	got := make(chan bool, 1)
-	go func() { got <- w.acquire(2, stop) }()
+	go func() { got <- w.acquire(2, gen, stop) }()
 
 	time.Sleep(20 * time.Millisecond)
-	w.release(1) // frees a token; the blocked acquire must proceed
+	w.release(1, gen) // frees a token; the blocked acquire must proceed
 
 	select {
 	case ok := <-got:
 		require.True(t, ok)
 	case <-time.After(time.Second):
 		t.Fatal("acquire did not unblock after release")
+	}
+}
+
+func TestSendWindow_AcquireUnblocksWhenSuperseded(t *testing.T) {
+	const gen = 1
+	w := newSendWindow(1, gen, true)
+	stop := make(chan struct{})
+	require.True(t, w.acquire(1, gen, stop))
+
+	got := make(chan bool, 1)
+	go func() { got <- w.acquire(2, gen, stop) }()
+
+	time.Sleep(20 * time.Millisecond)
+	w.reset(1, 2) // takeover: the blocked gen-1 acquire must return false
+
+	select {
+	case ok := <-got:
+		require.False(t, ok, "a superseded acquire must not succeed")
+	case <-time.After(time.Second):
+		t.Fatal("acquire did not unblock after takeover")
 	}
 }
 
@@ -76,16 +116,63 @@ func TestProcessRetries_GatedBySendQuota(t *testing.T) {
 	}
 	h := newMessageHandler(f, nil, packets.V5)
 	w := &mockWriter{}
-	quota := newSendWindow(1, false)
+	const gen = 1
+	quota := newSendWindow(1, gen, false)
+	acquire := func(packetID uint16) bool { return quota.tryAcquire(packetID, gen) }
 
-	h.ProcessRetries(w, quota.tryAcquire)
+	h.ProcessRetries(w, acquire)
 	require.Len(t, w.data, 1, "only one of three expired messages fits the quota of one")
 
 	// Even on a later cycle the quota of one still admits a single PUBLISH
 	// (the one holding the token); packets 2 and 3 stay gated.
 	w2 := &mockWriter{}
-	h.ProcessRetries(w2, quota.tryAcquire)
+	h.ProcessRetries(w2, acquire)
 	require.Len(t, w2.data, 1, "quota of one limits each retry cycle to one PUBLISH")
+}
+
+// TestSendQuota_LeaseIsGenerationBound guards finding #1: a delivery that
+// acquired quota under one connection generation cannot, after a takeover,
+// consume or free the replacement generation's quota. The session API carries
+// the generation through acquire and release.
+func TestSendQuota_LeaseIsGenerationBound(t *testing.T) {
+	s := newTakeoverSession(t)
+
+	_, err := s.Connect(&testConn{})
+	require.NoError(t, err)
+	gen0 := s.Epoch()
+
+	conn0, capturedGen := s.ConnEpoch()
+	require.NotNil(t, conn0)
+	require.Equal(t, gen0, capturedGen)
+	require.True(t, s.TryAcquireSendQuota(1, gen0))
+
+	// Takeover advances the generation and refills the quota.
+	_, _ = s.ConnectWithOptions(&testConn{}, ConnectOptions{Version: 4, ReceiveMaximum: 1})
+	gen1 := s.Epoch()
+	require.Greater(t, gen1, gen0)
+
+	// The old-generation delivery can neither acquire nor free new-generation
+	// quota.
+	require.False(t, s.TryAcquireSendQuota(2, gen0), "stale generation cannot acquire")
+	s.ReleaseSendQuota(1, gen0) // stale release: no-op
+
+	// The new generation has its full quota of one available.
+	require.True(t, s.TryAcquireSendQuota(3, gen1))
+	require.False(t, s.TryAcquireSendQuota(4, gen1), "new-generation quota of one is now exhausted")
+}
+
+// TestNew_ServerMaxInflightDefaultMatchesBroker guards finding #4: an unset
+// MaxInflightMessages must default to the shared value, not 65535.
+func TestNew_ServerMaxInflightDefaultMatchesBroker(t *testing.T) {
+	s := New(
+		"client-default",
+		packets.V5,
+		Options{CleanStart: true},
+		messages.NewInflightTracker(16),
+		messages.NewMessageQueue(16, true),
+		config.SessionConfig{InflightOverflow: config.InflightOverflowBackpressure},
+	)
+	require.Equal(t, config.DefaultMaxInflightMessages, s.serverMaxInflight)
 }
 
 func TestNew_SendWindowClampedByServerMaxInflight(t *testing.T) {

--- a/mqtt/session/sendwindow_test.go
+++ b/mqtt/session/sendwindow_test.go
@@ -141,8 +141,9 @@ func TestSendQuota_LeaseIsGenerationBound(t *testing.T) {
 	require.NoError(t, err)
 	gen0 := s.Epoch()
 
-	conn0, capturedGen := s.ConnEpoch()
+	conn0, version0, capturedGen := s.DeliveryLease()
 	require.NotNil(t, conn0)
+	require.Equal(t, byte(4), version0)
 	require.Equal(t, gen0, capturedGen)
 	require.True(t, s.TryAcquireSendQuota(1, gen0))
 

--- a/mqtt/session/sendwindow_test.go
+++ b/mqtt/session/sendwindow_test.go
@@ -135,13 +135,13 @@ func TestProcessRetries_GatedBySendQuota(t *testing.T) {
 	quota := newSendWindow(1, gen, false)
 	acquire := func(packetID uint16) bool { return quota.tryAcquire(packetID, gen) }
 
-	h.ProcessRetries(w, acquire)
+	h.ProcessRetries(w, 0, acquire, nil)
 	require.Len(t, w.data, 1, "only one of three expired messages fits the quota of one")
 
 	// Even on a later cycle the quota of one still admits a single PUBLISH
 	// (the one holding the token); packets 2 and 3 stay gated.
 	w2 := &mockWriter{}
-	h.ProcessRetries(w2, acquire)
+	h.ProcessRetries(w2, 0, acquire, nil)
 	require.Len(t, w2.data, 1, "quota of one limits each retry cycle to one PUBLISH")
 }
 

--- a/mqtt/session/sendwindow_test.go
+++ b/mqtt/session/sendwindow_test.go
@@ -14,6 +14,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// waitForBlockedWaiter blocks until a goroutine has registered as a blocked
+// sender in w (waiters incremented under the lock before it parks on the ready
+// channel). This is a deterministic replacement for sleeping to "let the
+// goroutine reach acquire": once waiters > 0 the goroutine has already captured
+// the current ready channel, so a subsequent release/reset broadcast cannot be
+// missed.
+func waitForBlockedWaiter(t *testing.T, w *sendWindow) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		return w.waiters > 0
+	}, time.Second, time.Millisecond, "sender did not block in acquire")
+}
+
 func TestSendWindow_TryAcquireRespectsCapacity(t *testing.T) {
 	const gen = 1
 	w := newSendWindow(2, gen, false)
@@ -71,7 +86,7 @@ func TestSendWindow_AcquireUnblocksOnRelease(t *testing.T) {
 	got := make(chan bool, 1)
 	go func() { got <- w.acquire(2, gen, stop) }()
 
-	time.Sleep(20 * time.Millisecond)
+	waitForBlockedWaiter(t, w)
 	w.release(1, gen) // frees a token; the blocked acquire must proceed
 
 	select {
@@ -91,7 +106,7 @@ func TestSendWindow_AcquireUnblocksWhenSuperseded(t *testing.T) {
 	got := make(chan bool, 1)
 	go func() { got <- w.acquire(2, gen, stop) }()
 
-	time.Sleep(20 * time.Millisecond)
+	waitForBlockedWaiter(t, w)
 	w.reset(1, 2) // takeover: the blocked gen-1 acquire must return false
 
 	select {

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -395,6 +395,19 @@ func (s *Session) ReleaseSendQuota(packetID uint16, gen uint64) {
 	s.sendWindow.release(packetID, gen)
 }
 
+// MarkSentIfEpoch marks the outbound packet as sent only while gen is still the
+// current connection generation, atomically under the session lock. This closes
+// the window where a takeover between an epoch check and MarkSent would let a
+// stale onSent (a packet flushed on a displaced connection) postpone
+// retransmission to the replacement connection.
+func (s *Session) MarkSentIfEpoch(packetID uint16, gen uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.epoch == gen {
+		s.msgHandler.Inflight().MarkSent(packetID)
+	}
+}
+
 // TryEnqueuePending attempts to push an overflow item into the pending queue.
 // Returns true on success, false if the pending queue is also full (caller drops).
 // Only meaningful when pendingCh is non-nil (pending queue mode).

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -594,21 +594,43 @@ func (s *Session) NextPacketID() uint16 {
 	return s.msgHandler.NextPacketID()
 }
 
-// ProcessRetriesTo resends due inflight messages on the provided writer, gated
-// by the send quota for generation gen. runSession uses this via connCtx so a
-// superseded goroutine can neither redeliver onto the replacement connection nor
-// consume the replacement generation's quota.
+// ProcessRetriesTo resends due inflight messages on the provided writer,
+// encoded for generation gen's protocol version and gated by that generation's
+// send quota. runSession uses this via connCtx so a superseded goroutine can
+// neither redeliver onto the replacement connection nor consume or update the
+// replacement generation's retry state.
 func (s *Session) ProcessRetriesTo(w core.PacketWriter, gen uint64) {
 	if w == nil {
 		return
 	}
-	s.msgHandler.ProcessRetries(w, s.sendQuotaAcquirer(gen))
+	s.mu.RLock()
+	if s.epoch != gen {
+		s.mu.RUnlock()
+		return
+	}
+	version := s.Version
+	s.mu.RUnlock()
+
+	s.msgHandler.ProcessRetries(w, version, s.sendQuotaAcquirer(gen), s.markRetryIfEpoch(gen))
 }
 
 // sendQuotaAcquirer returns a retry-gate bound to generation gen.
 func (s *Session) sendQuotaAcquirer(gen uint64) func(packetID uint16) bool {
 	return func(packetID uint16) bool {
 		return s.sendWindow.tryAcquire(packetID, gen)
+	}
+}
+
+// markRetryIfEpoch marks a retransmission as sent only while gen is still the
+// current connection generation. A retry flushed by a superseded connection must
+// not postpone redelivery on the replacement connection.
+func (s *Session) markRetryIfEpoch(gen uint64) func(packetID uint16) {
+	return func(packetID uint16) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if s.epoch == gen {
+			_ = s.msgHandler.Inflight().MarkRetry(packetID)
+		}
 	}
 }
 

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -351,14 +351,23 @@ func (s *Session) SendBackpressure() bool {
 	return s.sendWindow.blocking
 }
 
-// ConnEpoch atomically captures the current connection and its generation. A
-// delivery uses these as a lease: it acquires send quota for the generation and
-// writes to the captured connection, so a takeover landing mid-delivery cannot
-// make it write to, or consume the quota of, the replacement connection.
-func (s *Session) ConnEpoch() (core.Connection, uint64) {
+// DeliveryLease atomically captures the current connection, its protocol
+// version, and its generation. A delivery uses these together: it acquires send
+// quota for the generation, encodes the PUBLISH for the captured version, and
+// writes it to the captured connection. Capturing the version with the
+// connection prevents a cross-version takeover (v3<->v5) from encoding a packet
+// for one protocol and writing it to a connection of the other.
+func (s *Session) DeliveryLease() (conn core.Connection, version byte, gen uint64) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.conn, s.epoch
+	return s.conn, s.Version, s.epoch
+}
+
+// ServerMaxInflight returns the configured upper bound on concurrent inflight
+// messages. It is the server's inbound Receive Maximum advertised in CONNACK and
+// the capacity of the bidirectional inflight store.
+func (s *Session) ServerMaxInflight() int {
+	return s.serverMaxInflight
 }
 
 // AcquireSendQuota consumes a send-quota token for packetID in generation gen,

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -186,17 +186,17 @@ func New(clientID string, version byte, opts Options, inflight messages.Inflight
 
 // ConnectOptions carries the per-connection settings negotiated by a CONNECT.
 // They are applied to the session on (re)connect so a persistent session does
-// not retain the previous connection's protocol version, keep-alive, Will, or
-// expiry. [MQTT-3.1.0-2]
+// not retain the previous connection's protocol version, keep-alive, Will,
+// Receive Maximum, or topic-alias maximum. [MQTT-3.1.0-2]
 //
-// ReceiveMaximum is intentionally not included: the inflight window is fixed at
-// session creation (the inflight tracker is sized then), so it is not resized on
-// reconnect.
+// Session expiry is applied separately (see SetExpiryInterval): zero is a valid
+// value that must replace a previous positive one, which a struct field with an
+// "apply when non-zero" rule cannot express.
 type ConnectOptions struct {
 	Version        byte
 	KeepAlive      time.Duration
 	Will           *storage.WillMessage
-	ExpiryInterval uint32
+	ReceiveMaximum uint16
 	TopicAliasMax  uint16
 }
 
@@ -247,15 +247,37 @@ func (s *Session) attach(c core.Connection, opts ConnectOptions, applyOpts bool)
 		s.Version = opts.Version
 		s.KeepAlive = opts.KeepAlive
 		s.Will = opts.Will
-		if opts.ExpiryInterval > 0 {
-			s.ExpiryInterval = opts.ExpiryInterval
-		}
 		s.TopicAliasMax = opts.TopicAliasMax
 	}
 
 	// Topic alias mappings are scoped to a single network connection and must
 	// not survive a takeover. [MQTT-3.3.2-7]
 	s.msgHandler.ClearAliases()
+
+	// Reset the delivery stop channel for the new connection. If it is already
+	// closed (a prior disconnect) recreate it; on a live takeover, close it
+	// first to release any sender still blocked on the previous connection's
+	// delivery slots so it does not hang on an orphaned channel.
+	stopClosed := false
+	select {
+	case <-s.deliverStop:
+		stopClosed = true
+	default:
+	}
+	if superseded != nil && !stopClosed {
+		close(s.deliverStop)
+		stopClosed = true
+	}
+	if stopClosed {
+		s.deliverStop = make(chan struct{})
+	}
+
+	// Receive Maximum is connection-scoped: reinitialise the send quota to the
+	// newly negotiated value so a reconnect with a lower value cannot exceed it.
+	// [MQTT-3.3.4]
+	if applyOpts {
+		s.reinitSendWindowLocked(opts.ReceiveMaximum)
+	}
 
 	s.epoch++
 	epoch := s.epoch
@@ -264,11 +286,6 @@ func (s *Session) attach(c core.Connection, opts ConnectOptions, applyOpts bool)
 	s.conn = c
 	s.state = StateConnected
 	s.connectedAt = time.Now()
-	select {
-	case <-s.deliverStop:
-		s.deliverStop = make(chan struct{})
-	default:
-	}
 
 	s.mu.Unlock()
 
@@ -281,6 +298,41 @@ func (s *Session) attach(c core.Connection, opts ConnectOptions, applyOpts bool)
 	})
 
 	return epoch, superseded
+}
+
+// reinitSendWindowLocked resizes the session's send window to newMax (the
+// negotiated Receive Maximum). It updates the inflight tracker's capacity and,
+// in backpressure mode, rebuilds the delivery-slot semaphore with the available
+// quota (newMax minus messages already in flight). Caller must hold s.mu.
+func (s *Session) reinitSendWindowLocked(newMax uint16) {
+	capacity := int(newMax)
+	if capacity <= 0 {
+		capacity = 65535
+	}
+	s.ReceiveMaximum = uint16(capacity)
+	s.msgHandler.Inflight().SetMaxSize(capacity)
+
+	if s.deliverSlots == nil {
+		return // not backpressure mode; the tracker capacity is the limit
+	}
+	used := len(s.msgHandler.Inflight().GetAll())
+	if used > capacity {
+		used = capacity
+	}
+	slots := make(chan struct{}, capacity)
+	for range capacity - used {
+		slots <- struct{}{}
+	}
+	s.deliverSlots = slots
+}
+
+// SetExpiryInterval sets the session expiry interval. Unlike the option struct,
+// this applies the value verbatim, so a reconnect carrying expiry 0 (expire on
+// disconnect) replaces a previous positive value. [MQTT-3.1.2.11].
+func (s *Session) SetExpiryInterval(interval uint32) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ExpiryInterval = interval
 }
 
 // Epoch returns the current connection generation. A runSession goroutine

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -56,18 +56,23 @@ type Session struct {
 	connectedAt    time.Time
 	disconnectedAt time.Time
 
-	ID                   string
-	ExternalID           string
-	authMethod           string
-	authState            any
-	conn                 core.Connection
-	msgHandler           *msgHandler
-	Will                 *storage.WillMessage
-	subscriptions        map[string]storage.SubscribeOptions
-	subscriptionIDs      map[string][]uint32
-	onDisconnect         func(s *Session, graceful bool)
-	KeepAlive            time.Duration
-	state                State
+	ID              string
+	ExternalID      string
+	authMethod      string
+	authState       any
+	conn            core.Connection
+	msgHandler      *msgHandler
+	Will            *storage.WillMessage
+	subscriptions   map[string]storage.SubscribeOptions
+	subscriptionIDs map[string][]uint32
+	onDisconnect    func(s *Session, graceful bool)
+	KeepAlive       time.Duration
+	state           State
+	// epoch is bumped on every Connect. It identifies the current connection
+	// generation so a stale runSession goroutine (from a superseded connection)
+	// can detect that the session has moved on and avoid tearing down the new
+	// connection. Guarded by mu.
+	epoch                uint64
 	ExpiryInterval       uint32
 	MaxPacketSize        uint32
 	ReceiveMaximum       uint16
@@ -179,10 +184,28 @@ func New(clientID string, version byte, opts Options, inflight messages.Inflight
 	return s
 }
 
-// Connect attaches a connection to the session.
-func (s *Session) Connect(c core.Connection) error {
+// Connect attaches a connection to the session and returns the connection's
+// epoch. The caller must pass this epoch to runSession so that teardown is
+// scoped to this specific connection generation.
+//
+// If a previous connection is still attached — which happens when a client
+// reconnects with the same client ID before the old socket's FIN has been
+// processed (common on high-latency links) — the old connection is closed
+// here. This honors [MQTT-3.1.4-2] (the server must disconnect the existing
+// connection) and performs a local same-node session takeover.
+func (s *Session) Connect(c core.Connection) (uint64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// Local takeover: kick any connection still attached to this session.
+	// The superseded runSession goroutine will observe the closed socket and
+	// tear down via DisconnectIf, which no-ops because the epoch has advanced.
+	if s.conn != nil {
+		s.conn.Close() //nolint:errcheck // best-effort close of superseded connection
+	}
+
+	s.epoch++
+	epoch := s.epoch
 
 	s.conn = c
 	s.state = StateConnected
@@ -195,12 +218,13 @@ func (s *Session) Connect(c core.Connection) error {
 
 	c.SetKeepAlive(s.KeepAlive) //nolint:errcheck // keepalive timer setup; connection already validated at this point
 
-	// Set callback to handle connection loss/keepalive expiry
+	// Set callback to handle connection loss/keepalive expiry. Scoped to this
+	// epoch so a stale callback cannot disconnect a newer connection.
 	c.SetOnDisconnect(func(graceful bool) {
-		s.Disconnect(graceful) //nolint:errcheck // disconnect callback; session cleanup is best-effort
+		s.DisconnectIf(graceful, epoch) //nolint:errcheck // disconnect callback; session cleanup is best-effort
 	})
 
-	return nil
+	return epoch, nil
 }
 
 // AcquireDeliverSlot blocks until an inflight slot is available.
@@ -297,11 +321,28 @@ func (s *Session) drainPendingToOffline() {
 	}
 }
 
-// Disconnect disconnects the session.
+// Disconnect disconnects the session unconditionally.
 func (s *Session) Disconnect(graceful bool) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.disconnectLocked(graceful)
+}
 
+// DisconnectIf disconnects the session only if epoch still matches the current
+// connection generation. A stale runSession goroutine (whose connection has
+// been superseded by a local takeover) passes its own epoch here and becomes a
+// no-op, so it cannot tear down the connection that replaced it.
+func (s *Session) DisconnectIf(graceful bool, epoch uint64) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.epoch != epoch {
+		return nil
+	}
+	return s.disconnectLocked(graceful)
+}
+
+// disconnectLocked performs the disconnect. Caller must hold s.mu.
+func (s *Session) disconnectLocked(graceful bool) error {
 	if s.state != StateConnected {
 		return nil
 	}

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -72,7 +72,13 @@ type Session struct {
 	// generation so a stale runSession goroutine (from a superseded connection)
 	// can detect that the session has moved on and avoid tearing down the new
 	// connection. Guarded by mu.
-	epoch                uint64
+	epoch uint64
+	// procMu serializes packet processing (dispatch and retry) for the active
+	// connection against a takeover (Connect). A superseded runSession
+	// goroutine can never run a handler concurrently with, or after, the swap
+	// to a new connection, so it cannot write to or disconnect the replacement.
+	// Lock order: procMu before mu.
+	procMu               sync.Mutex
 	ExpiryInterval       uint32
 	MaxPacketSize        uint32
 	ReceiveMaximum       uint16
@@ -194,15 +200,15 @@ func New(clientID string, version byte, opts Options, inflight messages.Inflight
 // here. This honors [MQTT-3.1.4-2] (the server must disconnect the existing
 // connection) and performs a local same-node session takeover.
 func (s *Session) Connect(c core.Connection) (uint64, error) {
+	// Hold procMu across the swap so a superseded runSession goroutine that is
+	// mid-dispatch finishes (against the old connection) before the swap, and
+	// any dispatch it attempts after the swap fails its epoch check. This makes
+	// takeover atomic with respect to packet processing.
+	s.procMu.Lock()
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
-	// Local takeover: kick any connection still attached to this session.
-	// The superseded runSession goroutine will observe the closed socket and
-	// tear down via DisconnectIf, which no-ops because the epoch has advanced.
-	if s.conn != nil {
-		s.conn.Close() //nolint:errcheck // best-effort close of superseded connection
-	}
+	// Local takeover: detach any connection still attached to this session.
+	old := s.conn
 
 	s.epoch++
 	epoch := s.epoch
@@ -216,6 +222,19 @@ func (s *Session) Connect(c core.Connection) (uint64, error) {
 	default:
 	}
 
+	s.mu.Unlock()
+	s.procMu.Unlock()
+
+	// Close the superseded connection OUTSIDE the locks. Some transports
+	// (WebSocket) invoke onDisconnect synchronously from Close(), which calls
+	// back into DisconnectIf and would deadlock if we still held s.mu. The
+	// superseded runSession goroutine observes the closed socket and tears down
+	// via DisconnectIf, which no-ops because the epoch has advanced.
+	// [MQTT-3.1.4-2]
+	if old != nil {
+		old.Close() //nolint:errcheck // best-effort close of superseded connection
+	}
+
 	c.SetKeepAlive(s.KeepAlive) //nolint:errcheck // keepalive timer setup; connection already validated at this point
 
 	// Set callback to handle connection loss/keepalive expiry. Scoped to this
@@ -225,6 +244,28 @@ func (s *Session) Connect(c core.Connection) (uint64, error) {
 	})
 
 	return epoch, nil
+}
+
+// BeginProcessing acquires the processing lock for the connection generation
+// identified by epoch. It returns true if epoch is still current — in which
+// case the caller owns the lock and MUST call EndProcessing — or false if the
+// connection has been superseded by a takeover, in which case no lock is held
+// and the caller must stop processing.
+func (s *Session) BeginProcessing(epoch uint64) bool {
+	s.procMu.Lock()
+	s.mu.RLock()
+	current := s.epoch
+	s.mu.RUnlock()
+	if current != epoch {
+		s.procMu.Unlock()
+		return false
+	}
+	return true
+}
+
+// EndProcessing releases the processing lock acquired by BeginProcessing.
+func (s *Session) EndProcessing() {
+	s.procMu.Unlock()
 }
 
 // AcquireDeliverSlot blocks until an inflight slot is available.

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -594,20 +594,6 @@ func (s *Session) NextPacketID() uint16 {
 	return s.msgHandler.NextPacketID()
 }
 
-// ProcessRetries checks for expired inflight messages and resends them on the
-// current connection, gated by the current generation's send quota.
-func (s *Session) ProcessRetries() {
-	s.mu.RLock()
-	conn := s.conn
-	gen := s.epoch
-	s.mu.RUnlock()
-
-	if conn == nil {
-		return
-	}
-	s.msgHandler.ProcessRetries(conn, s.sendQuotaAcquirer(gen))
-}
-
 // ProcessRetriesTo resends due inflight messages on the provided writer, gated
 // by the send quota for generation gen. runSession uses this via connCtx so a
 // superseded goroutine can neither redeliver onto the replacement connection nor

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -395,6 +395,16 @@ func (s *Session) ReleaseSendQuota(packetID uint16, gen uint64) {
 	s.sendWindow.release(packetID, gen)
 }
 
+// AckInbound acknowledges and removes an inbound message (PUBREL). It uses the
+// tracker's optional directional acknowledgement when available, falling back to
+// Ack for trackers that do not separate directions.
+func (s *Session) AckInbound(packetID uint16) (*storage.Message, error) {
+	if ib, ok := s.msgHandler.Inflight().(messages.InboundAcker); ok {
+		return ib.AckInbound(packetID)
+	}
+	return s.msgHandler.Inflight().Ack(packetID)
+}
+
 // MarkSentIfEpoch marks the outbound packet as sent only while gen is still the
 // current connection generation, atomically under the session lock. This closes
 // the window where a takeover between an epoch check and MarkSent would let a

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -395,14 +395,25 @@ func (s *Session) ReleaseSendQuota(packetID uint16, gen uint64) {
 	s.sendWindow.release(packetID, gen)
 }
 
-// AckInbound acknowledges and removes an inbound message (PUBREL). It uses the
-// tracker's optional directional acknowledgement when available, falling back to
-// Ack for trackers that do not separate directions.
+// AddInbound atomically admits an inbound QoS 2 transaction. accepted reports
+// whether the tracker took ownership of msg. Trackers that do not implement the
+// optional directional extension are rejected explicitly because their base
+// Add implementation may not isolate inbound and outbound packet-ID spaces.
+func (s *Session) AddInbound(packetID uint16, msg *storage.Message) (bool, error) {
+	if ia, ok := s.msgHandler.Inflight().(messages.InboundAdder); ok {
+		return ia.AddInbound(packetID, msg)
+	}
+	return false, messages.ErrInboundUnsupported
+}
+
+// AckInbound acknowledges and removes an inbound message (PUBREL). Trackers
+// that do not implement the optional directional extension are rejected
+// explicitly so an inbound acknowledgement cannot remove an outbound entry.
 func (s *Session) AckInbound(packetID uint16) (*storage.Message, error) {
 	if ib, ok := s.msgHandler.Inflight().(messages.InboundAcker); ok {
 		return ib.AckInbound(packetID)
 	}
-	return s.msgHandler.Inflight().Ack(packetID)
+	return nil, messages.ErrInboundUnsupported
 }
 
 // MarkSentIfEpoch marks the outbound packet as sent only while gen is still the

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -131,6 +131,19 @@ func DefaultOptions() Options {
 	}
 }
 
+// clampServerMaxInflight normalises a configured MaxInflightMessages value:
+// values <= 0 fall back to the shared default, and the result is capped at the
+// 16-bit packet-ID space.
+func clampServerMaxInflight(maxInflight int) int {
+	if maxInflight <= 0 {
+		maxInflight = config.DefaultMaxInflightMessages
+	}
+	if maxInflight > 65535 {
+		maxInflight = 65535
+	}
+	return maxInflight
+}
+
 // New creates a new session with injected dependencies.
 // The inflight tracker and offline queue should be created and restored by the Manager.
 func New(clientID string, version byte, opts Options, inflight messages.Inflight, offlineQueue messages.Queue, sessionCfg config.SessionConfig) *Session {
@@ -165,17 +178,14 @@ func New(clientID string, version byte, opts Options, inflight messages.Inflight
 
 	// serverMaxInflight is the configured cap the send quota is clamped to. The
 	// negotiated receiveMax is already clamped to it by the broker, but the
-	// session re-clamps on reconnect.
-	s.serverMaxInflight = sessionCfg.MaxInflightMessages
-	if s.serverMaxInflight <= 0 {
-		s.serverMaxInflight = 65535
-	}
-	if s.serverMaxInflight > 65535 {
-		s.serverMaxInflight = 65535
-	}
+	// session re-clamps on reconnect. Uses the same default as the broker so the
+	// clamp is consistent across the first CONNECT.
+	s.serverMaxInflight = clampServerMaxInflight(sessionCfg.MaxInflightMessages)
 
 	backpressure := sessionCfg.InflightOverflow == config.InflightOverflowBackpressure
-	s.sendWindow = newSendWindow(int(receiveMax), backpressure)
+	// gen 0: no connection yet. attach sets the generation to the connection
+	// epoch on (re)connect.
+	s.sendWindow = newSendWindow(int(receiveMax), 0, backpressure)
 
 	switch sessionCfg.InflightOverflow {
 	case config.InflightOverflowBackpressure:
@@ -261,15 +271,6 @@ func (s *Session) attach(c core.Connection, opts ConnectOptions, applyOpts bool)
 	// not survive a takeover. [MQTT-3.3.2-7]
 	s.msgHandler.ClearAliases()
 
-	if applyOpts {
-		// Receive Maximum is connection-scoped: reinitialise the send quota to
-		// the newly negotiated value (clamped by the server limit), so a
-		// reconnect with a lower value cannot exceed it. reset broadcasts to
-		// any sender blocked on the previous connection's quota, which then
-		// re-evaluates against the new capacity. [MQTT-4.9]
-		s.resetSendWindowLocked(opts.ReceiveMaximum)
-	}
-
 	select {
 	case <-s.deliverStop:
 		s.deliverStop = make(chan struct{})
@@ -278,6 +279,15 @@ func (s *Session) attach(c core.Connection, opts ConnectOptions, applyOpts bool)
 
 	s.epoch++
 	epoch := s.epoch
+
+	// Bind the send quota to this connection generation. Receive Maximum is
+	// connection-scoped, so on a reconnect (applyOpts) the capacity is the newly
+	// negotiated value (clamped by the server limit); otherwise the existing
+	// capacity is kept. Advancing the generation invalidates any lease held by a
+	// superseded delivery or retry, so it can neither consume nor free this
+	// generation's quota. [MQTT-4.9]
+	s.resetSendWindowLocked(opts.ReceiveMaximum, applyOpts)
+
 	keepAlive := s.KeepAlive
 
 	s.conn = c
@@ -297,16 +307,24 @@ func (s *Session) attach(c core.Connection, opts ConnectOptions, applyOpts bool)
 	return epoch, superseded
 }
 
-// resetSendWindowLocked reinitialises the outbound send quota to the negotiated
-// Receive Maximum, clamped by the configured server limit. Caller must hold
-// s.mu. The persistent bidirectional inflight store is left untouched.
-func (s *Session) resetSendWindowLocked(clientReceiveMax uint16) {
-	capacity := int(clientReceiveMax)
-	if capacity <= 0 || capacity > s.serverMaxInflight {
-		capacity = s.serverMaxInflight
+// resetSendWindowLocked rebinds the outbound send quota to the current
+// connection generation (s.epoch). When applyCapacity is set it also resizes the
+// quota to the negotiated Receive Maximum, clamped by the configured server
+// limit; otherwise the existing capacity is kept. Caller must hold s.mu. The
+// persistent bidirectional inflight store is left untouched.
+func (s *Session) resetSendWindowLocked(clientReceiveMax uint16, applyCapacity bool) {
+	capacity := int(s.ReceiveMaximum)
+	if applyCapacity {
+		capacity = int(clientReceiveMax)
+		if capacity <= 0 || capacity > s.serverMaxInflight {
+			capacity = s.serverMaxInflight
+		}
+	}
+	if capacity < 1 {
+		capacity = 1
 	}
 	s.ReceiveMaximum = uint16(capacity)
-	s.sendWindow.reset(capacity)
+	s.sendWindow.reset(capacity, s.epoch)
 }
 
 // SetExpiryInterval sets the session expiry interval. Unlike the option struct,
@@ -333,27 +351,39 @@ func (s *Session) SendBackpressure() bool {
 	return s.sendWindow.blocking
 }
 
-// AcquireSendQuota consumes a send-quota token for packetID, blocking until one
-// is available or the session disconnects. A retransmission that already holds a
-// token succeeds immediately. Returns false if the session disconnected while
-// waiting. Used in backpressure mode.
-func (s *Session) AcquireSendQuota(packetID uint16) bool {
+// ConnEpoch atomically captures the current connection and its generation. A
+// delivery uses these as a lease: it acquires send quota for the generation and
+// writes to the captured connection, so a takeover landing mid-delivery cannot
+// make it write to, or consume the quota of, the replacement connection.
+func (s *Session) ConnEpoch() (core.Connection, uint64) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.conn, s.epoch
+}
+
+// AcquireSendQuota consumes a send-quota token for packetID in generation gen,
+// blocking until one is available, the generation is superseded by a takeover,
+// or the session disconnects. A retransmission that already holds a token in the
+// generation succeeds immediately. Returns false if gen is no longer current or
+// the session disconnected while waiting. Used in backpressure mode.
+func (s *Session) AcquireSendQuota(packetID uint16, gen uint64) bool {
 	s.mu.RLock()
 	stop := s.deliverStop
 	s.mu.RUnlock()
-	return s.sendWindow.acquire(packetID, stop)
+	return s.sendWindow.acquire(packetID, gen, stop)
 }
 
-// TryAcquireSendQuota consumes a send-quota token for packetID without blocking.
-// A retransmission that already holds a token succeeds without consuming another.
-// Returns false if no token is available.
-func (s *Session) TryAcquireSendQuota(packetID uint16) bool {
-	return s.sendWindow.tryAcquire(packetID)
+// TryAcquireSendQuota consumes a send-quota token for packetID in generation gen
+// without blocking. Returns false if gen is superseded or no token is available.
+func (s *Session) TryAcquireSendQuota(packetID uint16, gen uint64) bool {
+	return s.sendWindow.tryAcquire(packetID, gen)
 }
 
-// ReleaseSendQuota returns the token held for packetID (on PUBACK/PUBCOMP).
-func (s *Session) ReleaseSendQuota(packetID uint16) {
-	s.sendWindow.release(packetID)
+// ReleaseSendQuota returns the token held for packetID in generation gen (on
+// PUBACK/PUBCOMP, or to roll back a failed delivery). A release carrying a
+// superseded generation is a no-op.
+func (s *Session) ReleaseSendQuota(packetID uint16, gen uint64) {
+	s.sendWindow.release(packetID, gen)
 }
 
 // TryEnqueuePending attempts to push an overflow item into the pending queue.
@@ -521,28 +551,36 @@ func (s *Session) NextPacketID() uint16 {
 	return s.msgHandler.NextPacketID()
 }
 
-// ProcessRetries checks for expired inflight messages and resends them.
-// This should be called periodically from the read loop.
+// ProcessRetries checks for expired inflight messages and resends them on the
+// current connection, gated by the current generation's send quota.
 func (s *Session) ProcessRetries() {
 	s.mu.RLock()
 	conn := s.conn
+	gen := s.epoch
 	s.mu.RUnlock()
 
 	if conn == nil {
 		return
 	}
-	s.msgHandler.ProcessRetries(conn, s.sendWindow.tryAcquire)
+	s.msgHandler.ProcessRetries(conn, s.sendQuotaAcquirer(gen))
 }
 
-// ProcessRetriesTo resends due inflight messages on the provided writer rather
-// than the session's current connection. Used to bind retry delivery to a
-// specific connection generation. [[runSession]] uses this via connCtx so a
-// superseded goroutine cannot redeliver onto a replacement connection.
-func (s *Session) ProcessRetriesTo(w core.PacketWriter) {
+// ProcessRetriesTo resends due inflight messages on the provided writer, gated
+// by the send quota for generation gen. runSession uses this via connCtx so a
+// superseded goroutine can neither redeliver onto the replacement connection nor
+// consume the replacement generation's quota.
+func (s *Session) ProcessRetriesTo(w core.PacketWriter, gen uint64) {
 	if w == nil {
 		return
 	}
-	s.msgHandler.ProcessRetries(w, s.sendWindow.tryAcquire)
+	s.msgHandler.ProcessRetries(w, s.sendQuotaAcquirer(gen))
+}
+
+// sendQuotaAcquirer returns a retry-gate bound to generation gen.
+func (s *Session) sendQuotaAcquirer(gen uint64) func(packetID uint16) bool {
+	return func(packetID uint16) bool {
+		return s.sendWindow.tryAcquire(packetID, gen)
+	}
 }
 
 // WritePacket writes a packet to the connection.

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -72,13 +72,7 @@ type Session struct {
 	// generation so a stale runSession goroutine (from a superseded connection)
 	// can detect that the session has moved on and avoid tearing down the new
 	// connection. Guarded by mu.
-	epoch uint64
-	// procMu serializes packet processing (dispatch and retry) for the active
-	// connection against a takeover (Connect). A superseded runSession
-	// goroutine can never run a handler concurrently with, or after, the swap
-	// to a new connection, so it cannot write to or disconnect the replacement.
-	// Lock order: procMu before mu.
-	procMu               sync.Mutex
+	epoch                uint64
 	ExpiryInterval       uint32
 	MaxPacketSize        uint32
 	ReceiveMaximum       uint16
@@ -200,11 +194,6 @@ func New(clientID string, version byte, opts Options, inflight messages.Inflight
 // here. This honors [MQTT-3.1.4-2] (the server must disconnect the existing
 // connection) and performs a local same-node session takeover.
 func (s *Session) Connect(c core.Connection) (uint64, error) {
-	// Hold procMu across the swap so a superseded runSession goroutine that is
-	// mid-dispatch finishes (against the old connection) before the swap, and
-	// any dispatch it attempts after the swap fails its epoch check. This makes
-	// takeover atomic with respect to packet processing.
-	s.procMu.Lock()
 	s.mu.Lock()
 
 	// Local takeover: detach any connection still attached to this session.
@@ -223,9 +212,8 @@ func (s *Session) Connect(c core.Connection) (uint64, error) {
 	}
 
 	s.mu.Unlock()
-	s.procMu.Unlock()
 
-	// Close the superseded connection OUTSIDE the locks. Some transports
+	// Close the superseded connection OUTSIDE the lock. Some transports
 	// (WebSocket) invoke onDisconnect synchronously from Close(), which calls
 	// back into DisconnectIf and would deadlock if we still held s.mu. The
 	// superseded runSession goroutine observes the closed socket and tears down
@@ -246,26 +234,13 @@ func (s *Session) Connect(c core.Connection) (uint64, error) {
 	return epoch, nil
 }
 
-// BeginProcessing acquires the processing lock for the connection generation
-// identified by epoch. It returns true if epoch is still current — in which
-// case the caller owns the lock and MUST call EndProcessing — or false if the
-// connection has been superseded by a takeover, in which case no lock is held
-// and the caller must stop processing.
-func (s *Session) BeginProcessing(epoch uint64) bool {
-	s.procMu.Lock()
+// Epoch returns the current connection generation. A runSession goroutine
+// captures this at connect time and uses it to bind writes and teardown to its
+// own connection, so a superseded goroutine cannot affect the replacement.
+func (s *Session) Epoch() uint64 {
 	s.mu.RLock()
-	current := s.epoch
-	s.mu.RUnlock()
-	if current != epoch {
-		s.procMu.Unlock()
-		return false
-	}
-	return true
-}
-
-// EndProcessing releases the processing lock acquired by BeginProcessing.
-func (s *Session) EndProcessing() {
-	s.procMu.Unlock()
+	defer s.mu.RUnlock()
+	return s.epoch
 }
 
 // AcquireDeliverSlot blocks until an inflight slot is available.
@@ -479,6 +454,17 @@ func (s *Session) ProcessRetries() {
 		return
 	}
 	s.msgHandler.ProcessRetries(conn)
+}
+
+// ProcessRetriesTo resends due inflight messages on the provided writer rather
+// than the session's current connection. Used to bind retry delivery to a
+// specific connection generation. [[runSession]] uses this via connCtx so a
+// superseded goroutine cannot redeliver onto a replacement connection.
+func (s *Session) ProcessRetriesTo(w core.PacketWriter) {
+	if w == nil {
+		return
+	}
+	s.msgHandler.ProcessRetries(w)
 }
 
 // WritePacket writes a packet to the connection.

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -86,18 +86,21 @@ type Session struct {
 	wildcardSubAvailable bool
 	sharedSubAvailable   bool
 
-	// deliverSlots is a semaphore with capacity == inflight window size.
-	// Non-nil only when InflightOverflow == InflightOverflowBackpressure.
-	// Callers acquire a slot before adding to inflight; release on ACK.
-	deliverSlots chan struct{}
+	// sendWindow is the outbound QoS 1/2 send quota (Receive Maximum), bounded
+	// by serverMaxInflight. Independent of the bidirectional inflight store.
+	sendWindow *sendWindow
 
-	// pendingCh buffers messages that exceeded the inflight window.
+	// serverMaxInflight is the configured upper bound on the send quota; the
+	// negotiated Receive Maximum is clamped to it on every (re)connect.
+	serverMaxInflight int
+
+	// pendingCh buffers messages that exceeded the send quota.
 	// Non-nil only when InflightOverflow == InflightOverflowQueue.
 	// Drained into inflight as ACKs arrive; spilled to offline on disconnect.
 	pendingCh chan pendingItem
 
 	// deliverStop is closed when the session disconnects to unblock goroutines
-	// waiting in AcquireDeliverSlot.
+	// waiting on the send window.
 	deliverStop chan struct{}
 
 	// lastHeartbeatUpdate tracks the last queue heartbeat update emitted
@@ -160,19 +163,23 @@ func New(clientID string, version byte, opts Options, inflight messages.Inflight
 		deliverStop:          make(chan struct{}),
 	}
 
-	inflightCap := int(receiveMax)
+	// serverMaxInflight is the configured cap the send quota is clamped to. The
+	// negotiated receiveMax is already clamped to it by the broker, but the
+	// session re-clamps on reconnect.
+	s.serverMaxInflight = sessionCfg.MaxInflightMessages
+	if s.serverMaxInflight <= 0 {
+		s.serverMaxInflight = 65535
+	}
+	if s.serverMaxInflight > 65535 {
+		s.serverMaxInflight = 65535
+	}
+
+	backpressure := sessionCfg.InflightOverflow == config.InflightOverflowBackpressure
+	s.sendWindow = newSendWindow(int(receiveMax), backpressure)
 
 	switch sessionCfg.InflightOverflow {
 	case config.InflightOverflowBackpressure:
-		slots := make(chan struct{}, inflightCap)
-		used := len(inflight.GetAll())
-		if used > inflightCap {
-			used = inflightCap
-		}
-		for range inflightCap - used {
-			slots <- struct{}{}
-		}
-		s.deliverSlots = slots
+		// Send quota provides the backpressure; no pending queue.
 	case config.InflightOverflowQueue:
 		pendingCap := sessionCfg.PendingQueueSize
 		if pendingCap <= 0 {
@@ -254,29 +261,19 @@ func (s *Session) attach(c core.Connection, opts ConnectOptions, applyOpts bool)
 	// not survive a takeover. [MQTT-3.3.2-7]
 	s.msgHandler.ClearAliases()
 
-	// Reset the delivery stop channel for the new connection. If it is already
-	// closed (a prior disconnect) recreate it; on a live takeover, close it
-	// first to release any sender still blocked on the previous connection's
-	// delivery slots so it does not hang on an orphaned channel.
-	stopClosed := false
-	select {
-	case <-s.deliverStop:
-		stopClosed = true
-	default:
-	}
-	if superseded != nil && !stopClosed {
-		close(s.deliverStop)
-		stopClosed = true
-	}
-	if stopClosed {
-		s.deliverStop = make(chan struct{})
+	if applyOpts {
+		// Receive Maximum is connection-scoped: reinitialise the send quota to
+		// the newly negotiated value (clamped by the server limit), so a
+		// reconnect with a lower value cannot exceed it. reset broadcasts to
+		// any sender blocked on the previous connection's quota, which then
+		// re-evaluates against the new capacity. [MQTT-4.9]
+		s.resetSendWindowLocked(opts.ReceiveMaximum)
 	}
 
-	// Receive Maximum is connection-scoped: reinitialise the send quota to the
-	// newly negotiated value so a reconnect with a lower value cannot exceed it.
-	// [MQTT-3.3.4]
-	if applyOpts {
-		s.reinitSendWindowLocked(opts.ReceiveMaximum)
+	select {
+	case <-s.deliverStop:
+		s.deliverStop = make(chan struct{})
+	default:
 	}
 
 	s.epoch++
@@ -300,30 +297,16 @@ func (s *Session) attach(c core.Connection, opts ConnectOptions, applyOpts bool)
 	return epoch, superseded
 }
 
-// reinitSendWindowLocked resizes the session's send window to newMax (the
-// negotiated Receive Maximum). It updates the inflight tracker's capacity and,
-// in backpressure mode, rebuilds the delivery-slot semaphore with the available
-// quota (newMax minus messages already in flight). Caller must hold s.mu.
-func (s *Session) reinitSendWindowLocked(newMax uint16) {
-	capacity := int(newMax)
-	if capacity <= 0 {
-		capacity = 65535
+// resetSendWindowLocked reinitialises the outbound send quota to the negotiated
+// Receive Maximum, clamped by the configured server limit. Caller must hold
+// s.mu. The persistent bidirectional inflight store is left untouched.
+func (s *Session) resetSendWindowLocked(clientReceiveMax uint16) {
+	capacity := int(clientReceiveMax)
+	if capacity <= 0 || capacity > s.serverMaxInflight {
+		capacity = s.serverMaxInflight
 	}
 	s.ReceiveMaximum = uint16(capacity)
-	s.msgHandler.Inflight().SetMaxSize(capacity)
-
-	if s.deliverSlots == nil {
-		return // not backpressure mode; the tracker capacity is the limit
-	}
-	used := len(s.msgHandler.Inflight().GetAll())
-	if used > capacity {
-		used = capacity
-	}
-	slots := make(chan struct{}, capacity)
-	for range capacity - used {
-		slots <- struct{}{}
-	}
-	s.deliverSlots = slots
+	s.sendWindow.reset(capacity)
 }
 
 // SetExpiryInterval sets the session expiry interval. Unlike the option struct,
@@ -344,39 +327,33 @@ func (s *Session) Epoch() uint64 {
 	return s.epoch
 }
 
-// AcquireDeliverSlot blocks until an inflight slot is available.
-// Returns false if the session disconnects while waiting.
-// Only meaningful when deliverSlots is non-nil (backpressure mode).
-func (s *Session) AcquireDeliverSlot() bool {
-	s.mu.RLock()
-	slots := s.deliverSlots
-	stop := s.deliverStop
-	s.mu.RUnlock()
-
-	if slots == nil {
-		return true
-	}
-
-	select {
-	case <-slots:
-		return true
-	case <-stop:
-		return false
-	}
+// SendBackpressure reports whether outbound delivery blocks on the send quota
+// (vs. falling back to the pending queue) when the quota is exhausted.
+func (s *Session) SendBackpressure() bool {
+	return s.sendWindow.blocking
 }
 
-// ReleaseDeliverSlot returns an inflight slot, potentially unblocking a waiting sender.
-// Only meaningful when deliverSlots is non-nil (backpressure mode).
-func (s *Session) ReleaseDeliverSlot() {
-	if s.deliverSlots == nil {
-		return
-	}
-	select {
-	case s.deliverSlots <- struct{}{}:
-	default:
-		// Channel is full — this can happen if ReleaseDeliverSlot is called
-		// more times than AcquireDeliverSlot (e.g. on session reset). Safe to ignore.
-	}
+// AcquireSendQuota consumes a send-quota token for packetID, blocking until one
+// is available or the session disconnects. A retransmission that already holds a
+// token succeeds immediately. Returns false if the session disconnected while
+// waiting. Used in backpressure mode.
+func (s *Session) AcquireSendQuota(packetID uint16) bool {
+	s.mu.RLock()
+	stop := s.deliverStop
+	s.mu.RUnlock()
+	return s.sendWindow.acquire(packetID, stop)
+}
+
+// TryAcquireSendQuota consumes a send-quota token for packetID without blocking.
+// A retransmission that already holds a token succeeds without consuming another.
+// Returns false if no token is available.
+func (s *Session) TryAcquireSendQuota(packetID uint16) bool {
+	return s.sendWindow.tryAcquire(packetID)
+}
+
+// ReleaseSendQuota returns the token held for packetID (on PUBACK/PUBCOMP).
+func (s *Session) ReleaseSendQuota(packetID uint16) {
+	s.sendWindow.release(packetID)
 }
 
 // TryEnqueuePending attempts to push an overflow item into the pending queue.
@@ -554,7 +531,7 @@ func (s *Session) ProcessRetries() {
 	if conn == nil {
 		return
 	}
-	s.msgHandler.ProcessRetries(conn)
+	s.msgHandler.ProcessRetries(conn, s.sendWindow.tryAcquire)
 }
 
 // ProcessRetriesTo resends due inflight messages on the provided writer rather
@@ -565,7 +542,7 @@ func (s *Session) ProcessRetriesTo(w core.PacketWriter) {
 	if w == nil {
 		return
 	}
-	s.msgHandler.ProcessRetries(w)
+	s.msgHandler.ProcessRetries(w, s.sendWindow.tryAcquire)
 }
 
 // WritePacket writes a packet to the connection.

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -184,23 +184,82 @@ func New(clientID string, version byte, opts Options, inflight messages.Inflight
 	return s
 }
 
-// Connect attaches a connection to the session and returns the connection's
-// epoch. The caller must pass this epoch to runSession so that teardown is
-// scoped to this specific connection generation.
+// ConnectOptions carries the per-connection settings negotiated by a CONNECT.
+// They are applied to the session on (re)connect so a persistent session does
+// not retain the previous connection's protocol version, keep-alive, Will, or
+// expiry. [MQTT-3.1.0-2]
 //
-// If a previous connection is still attached — which happens when a client
-// reconnects with the same client ID before the old socket's FIN has been
-// processed (common on high-latency links) — the old connection is closed
-// here. This honors [MQTT-3.1.4-2] (the server must disconnect the existing
-// connection) and performs a local same-node session takeover.
+// ReceiveMaximum is intentionally not included: the inflight window is fixed at
+// session creation (the inflight tracker is sized then), so it is not resized on
+// reconnect.
+type ConnectOptions struct {
+	Version        byte
+	KeepAlive      time.Duration
+	Will           *storage.WillMessage
+	ExpiryInterval uint32
+	TopicAliasMax  uint16
+}
+
+// Superseded describes a connection displaced by a takeover, so the broker can
+// drain it outside the session lock: notify the displaced MQTT 5 client with a
+// DISCONNECT (0x8E), close the socket, and publish its Will if required.
+type Superseded struct {
+	Conn    core.Connection
+	Version byte
+	Will    *storage.WillMessage
+}
+
+// Connect attaches a connection using the session's existing options. The
+// superseded connection, if any, is closed here. Intended for callers that are
+// not (re)negotiating connection parameters (e.g. tests); the broker uses
+// ConnectWithOptions.
 func (s *Session) Connect(c core.Connection) (uint64, error) {
+	epoch, superseded := s.attach(c, ConnectOptions{}, false)
+	if superseded != nil && superseded.Conn != nil {
+		superseded.Conn.Close() //nolint:errcheck // best-effort close of superseded connection
+	}
+	return epoch, nil
+}
+
+// ConnectWithOptions attaches a connection and applies the negotiated options,
+// performing a local same-node takeover of any existing connection. It returns
+// the connection epoch and the superseded connection (if any). The caller MUST
+// drain the superseded connection (notify, close, Will). [MQTT-3.1.4-2].
+func (s *Session) ConnectWithOptions(c core.Connection, opts ConnectOptions) (uint64, *Superseded) {
+	return s.attach(c, opts, true)
+}
+
+// attach swaps in connection c under the lock: it bumps the epoch, applies
+// options when applyOpts is set, and clears per-connection topic aliases (they
+// never carry across connections, MQTT-3.3.2-7). It returns the new epoch and
+// any superseded connection. The superseded connection is NOT closed here —
+// closing while holding the lock can deadlock transports (e.g. WebSocket) whose
+// Close synchronously invokes onDisconnect.
+func (s *Session) attach(c core.Connection, opts ConnectOptions, applyOpts bool) (uint64, *Superseded) {
 	s.mu.Lock()
 
-	// Local takeover: detach any connection still attached to this session.
-	old := s.conn
+	var superseded *Superseded
+	if s.conn != nil {
+		superseded = &Superseded{Conn: s.conn, Version: s.Version, Will: s.Will}
+	}
+
+	if applyOpts {
+		s.Version = opts.Version
+		s.KeepAlive = opts.KeepAlive
+		s.Will = opts.Will
+		if opts.ExpiryInterval > 0 {
+			s.ExpiryInterval = opts.ExpiryInterval
+		}
+		s.TopicAliasMax = opts.TopicAliasMax
+	}
+
+	// Topic alias mappings are scoped to a single network connection and must
+	// not survive a takeover. [MQTT-3.3.2-7]
+	s.msgHandler.ClearAliases()
 
 	s.epoch++
 	epoch := s.epoch
+	keepAlive := s.KeepAlive
 
 	s.conn = c
 	s.state = StateConnected
@@ -213,17 +272,7 @@ func (s *Session) Connect(c core.Connection) (uint64, error) {
 
 	s.mu.Unlock()
 
-	// Close the superseded connection OUTSIDE the lock. Some transports
-	// (WebSocket) invoke onDisconnect synchronously from Close(), which calls
-	// back into DisconnectIf and would deadlock if we still held s.mu. The
-	// superseded runSession goroutine observes the closed socket and tears down
-	// via DisconnectIf, which no-ops because the epoch has advanced.
-	// [MQTT-3.1.4-2]
-	if old != nil {
-		old.Close() //nolint:errcheck // best-effort close of superseded connection
-	}
-
-	c.SetKeepAlive(s.KeepAlive) //nolint:errcheck // keepalive timer setup; connection already validated at this point
+	c.SetKeepAlive(keepAlive) //nolint:errcheck // keepalive timer setup; connection already validated at this point
 
 	// Set callback to handle connection loss/keepalive expiry. Scoped to this
 	// epoch so a stale callback cannot disconnect a newer connection.
@@ -231,7 +280,7 @@ func (s *Session) Connect(c core.Connection) (uint64, error) {
 		s.DisconnectIf(graceful, epoch) //nolint:errcheck // disconnect callback; session cleanup is best-effort
 	})
 
-	return epoch, nil
+	return epoch, superseded
 }
 
 // Epoch returns the current connection generation. A runSession goroutine

--- a/mqtt/session/session_overflow_test.go
+++ b/mqtt/session/session_overflow_test.go
@@ -100,7 +100,7 @@ func TestNew_SendWindowCapacityRespectsReceiveMaximum(t *testing.T) {
 	require.Equal(t, 2, s.sendWindow.capacity)
 	require.Equal(t, 0, len(s.sendWindow.held))
 
-	acked, err := inflight.Ack(1, messages.Outbound)
+	acked, err := inflight.Ack(1)
 	require.NoError(t, err)
 	require.NotNil(t, acked)
 	acked.ReleasePayload()

--- a/mqtt/session/session_overflow_test.go
+++ b/mqtt/session/session_overflow_test.go
@@ -120,13 +120,14 @@ func TestAcquireSendQuota_UnblocksOnDisconnect(t *testing.T) {
 	)
 	_, errConn := s.Connect(&testConn{})
 	require.NoError(t, errConn)
+	gen := s.Epoch()
 
 	// Consume the only token, then a second acquire must block until disconnect.
-	require.True(t, s.AcquireSendQuota(1))
+	require.True(t, s.AcquireSendQuota(1, gen))
 
 	result := make(chan bool, 1)
 	go func() {
-		result <- s.AcquireSendQuota(2)
+		result <- s.AcquireSendQuota(2, gen)
 	}()
 
 	time.Sleep(20 * time.Millisecond)

--- a/mqtt/session/session_overflow_test.go
+++ b/mqtt/session/session_overflow_test.go
@@ -114,7 +114,8 @@ func TestAcquireDeliverSlot_UnblocksOnDisconnect(t *testing.T) {
 			InflightOverflow: config.InflightOverflowBackpressure,
 		},
 	)
-	require.NoError(t, s.Connect(&testConn{}))
+	_, errConn := s.Connect(&testConn{})
+	require.NoError(t, errConn)
 
 	require.True(t, s.AcquireDeliverSlot())
 
@@ -146,7 +147,8 @@ func TestDrainPendingToOffline_ReleasesOriginalMessage(t *testing.T) {
 			PendingQueueSize: 8,
 		},
 	)
-	require.NoError(t, s.Connect(&testConn{}))
+	_, errConn := s.Connect(&testConn{})
+	require.NoError(t, errConn)
 
 	msg := storage.AcquireMessage()
 	msg.Topic = "topic"

--- a/mqtt/session/session_overflow_test.go
+++ b/mqtt/session/session_overflow_test.go
@@ -100,7 +100,7 @@ func TestNew_SendWindowCapacityRespectsReceiveMaximum(t *testing.T) {
 	require.Equal(t, 2, s.sendWindow.capacity)
 	require.Equal(t, 0, len(s.sendWindow.held))
 
-	acked, err := inflight.Ack(1)
+	acked, err := inflight.Ack(1, messages.Outbound)
 	require.NoError(t, err)
 	require.NotNil(t, acked)
 	acked.ReleasePayload()

--- a/mqtt/session/session_overflow_test.go
+++ b/mqtt/session/session_overflow_test.go
@@ -72,7 +72,7 @@ func (c *testConn) Touch() {}
 
 var _ core.Connection = (*testConn)(nil)
 
-func TestNew_BackpressureSlotsRespectReceiveMaximumAndRestoredInflight(t *testing.T) {
+func TestNew_SendWindowCapacityRespectsReceiveMaximum(t *testing.T) {
 	inflight := messages.NewInflightTracker(16)
 	msg := storage.AcquireMessage()
 	msg.Topic = "topic"
@@ -87,14 +87,18 @@ func TestNew_BackpressureSlotsRespectReceiveMaximumAndRestoredInflight(t *testin
 		inflight,
 		messages.NewMessageQueue(16, true),
 		config.SessionConfig{
-			MaxInflightMessages: 128, // must be ignored in favor of negotiated ReceiveMaximum.
+			MaxInflightMessages: 128,
 			InflightOverflow:    config.InflightOverflowBackpressure,
 		},
 	)
 
-	require.NotNil(t, s.deliverSlots)
-	require.Equal(t, 2, cap(s.deliverSlots))
-	require.Equal(t, 1, len(s.deliverSlots))
+	// The send window is the connection send quota, separate from the
+	// persistent inflight store: capacity == negotiated Receive Maximum, and
+	// no token is pre-consumed for restored inflight (those consume on
+	// retransmission).
+	require.NotNil(t, s.sendWindow)
+	require.Equal(t, 2, s.sendWindow.capacity)
+	require.Equal(t, 0, len(s.sendWindow.held))
 
 	acked, err := inflight.Ack(1)
 	require.NoError(t, err)
@@ -103,7 +107,7 @@ func TestNew_BackpressureSlotsRespectReceiveMaximumAndRestoredInflight(t *testin
 	storage.ReleaseMessage(acked)
 }
 
-func TestAcquireDeliverSlot_UnblocksOnDisconnect(t *testing.T) {
+func TestAcquireSendQuota_UnblocksOnDisconnect(t *testing.T) {
 	s := New(
 		"client-2",
 		packets.V5,
@@ -117,11 +121,12 @@ func TestAcquireDeliverSlot_UnblocksOnDisconnect(t *testing.T) {
 	_, errConn := s.Connect(&testConn{})
 	require.NoError(t, errConn)
 
-	require.True(t, s.AcquireDeliverSlot())
+	// Consume the only token, then a second acquire must block until disconnect.
+	require.True(t, s.AcquireSendQuota(1))
 
 	result := make(chan bool, 1)
 	go func() {
-		result <- s.AcquireDeliverSlot()
+		result <- s.AcquireSendQuota(2)
 	}()
 
 	time.Sleep(20 * time.Millisecond)
@@ -131,7 +136,7 @@ func TestAcquireDeliverSlot_UnblocksOnDisconnect(t *testing.T) {
 	case ok := <-result:
 		require.False(t, ok)
 	case <-time.After(500 * time.Millisecond):
-		t.Fatal("AcquireDeliverSlot did not unblock after disconnect")
+		t.Fatal("AcquireSendQuota did not unblock after disconnect")
 	}
 }
 

--- a/mqtt/session/takeover_test.go
+++ b/mqtt/session/takeover_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package session
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/absmach/fluxmq/config"
+	"github.com/absmach/fluxmq/storage/messages"
+	"github.com/stretchr/testify/require"
+)
+
+// recordingConn is a testConn that records whether it was closed and exposes
+// the onDisconnect callback the session installed on it.
+type recordingConn struct {
+	testConn
+	closed atomic.Bool
+}
+
+func (c *recordingConn) Close() error {
+	c.closed.Store(true)
+	return nil
+}
+
+func newTakeoverSession(t *testing.T) *Session {
+	t.Helper()
+	return New(
+		"taker",
+		4,
+		Options{CleanStart: false, ReceiveMaximum: 16},
+		messages.NewInflightTracker(16),
+		messages.NewMessageQueue(16, true),
+		config.SessionConfig{},
+	)
+}
+
+// TestConnect_LocalTakeoverClosesOldConn verifies that attaching a new
+// connection to a session that already has one closes the old connection
+// (MQTT-3.1.4-2) and advances the epoch.
+func TestConnect_LocalTakeoverClosesOldConn(t *testing.T) {
+	s := newTakeoverSession(t)
+
+	oldConn := &recordingConn{}
+	oldEpoch, err := s.Connect(oldConn)
+	require.NoError(t, err)
+	require.False(t, oldConn.closed.Load(), "old conn must be open after first Connect")
+
+	newConn := &recordingConn{}
+	newEpoch, err := s.Connect(newConn)
+	require.NoError(t, err)
+
+	require.True(t, oldConn.closed.Load(), "takeover must close the superseded connection")
+	require.False(t, newConn.closed.Load(), "new conn must remain open")
+	require.Greater(t, newEpoch, oldEpoch, "epoch must advance on takeover")
+	require.True(t, s.IsConnected())
+	got, ok := s.Conn().(*recordingConn)
+	require.True(t, ok)
+	require.Same(t, newConn, got)
+}
+
+// TestDisconnectIf_StaleEpochIsNoOp is the core race guard. After a local
+// takeover, a superseded runSession goroutine calling DisconnectIf with its
+// old epoch must NOT tear down the session — otherwise it would kill the new
+// connection. This reproduces the high-latency reconnect failure from
+// propeller#241.
+func TestDisconnectIf_StaleEpochIsNoOp(t *testing.T) {
+	s := newTakeoverSession(t)
+
+	oldConn := &recordingConn{}
+	oldEpoch, err := s.Connect(oldConn)
+	require.NoError(t, err)
+
+	newConn := &recordingConn{}
+	newEpoch, err := s.Connect(newConn)
+	require.NoError(t, err)
+
+	// Stale goroutine from the old connection tears down with its old epoch.
+	require.NoError(t, s.DisconnectIf(false, oldEpoch))
+
+	// New connection must be untouched and the session still connected.
+	require.True(t, s.IsConnected(), "stale epoch teardown must not disconnect the session")
+	require.False(t, newConn.closed.Load(), "stale epoch teardown must not close the new conn")
+
+	// The current epoch's teardown does disconnect.
+	require.NoError(t, s.DisconnectIf(false, newEpoch))
+	require.False(t, s.IsConnected())
+	require.True(t, newConn.closed.Load())
+}
+
+// TestConnect_OnDisconnectCallbackScopedToEpoch verifies the conn-level
+// onDisconnect callback installed by Connect is scoped to its epoch, so the
+// old socket dying after takeover cannot disconnect the new connection.
+func TestConnect_OnDisconnectCallbackScopedToEpoch(t *testing.T) {
+	s := newTakeoverSession(t)
+
+	oldConn := &recordingConn{}
+	_, err := s.Connect(oldConn)
+	require.NoError(t, err)
+	oldCallback := oldConn.onDisconnect
+	require.NotNil(t, oldCallback)
+
+	newConn := &recordingConn{}
+	_, err = s.Connect(newConn)
+	require.NoError(t, err)
+
+	// Old socket's death fires the old callback. It must be a no-op.
+	oldCallback(false)
+
+	require.True(t, s.IsConnected(), "old conn callback must not disconnect after takeover")
+	require.False(t, newConn.closed.Load())
+}
+
+// TestConnect_ConcurrentReconnectKeepsLatest stress-checks that under many
+// concurrent reconnects exactly one connection survives and the session is
+// left in a consistent connected state.
+func TestConnect_ConcurrentReconnectKeepsLatest(t *testing.T) {
+	s := newTakeoverSession(t)
+
+	const n = 64
+	conns := make([]*recordingConn, n)
+	errs := make([]error, n)
+	var wg sync.WaitGroup
+
+	for i := range n {
+		conns[i] = &recordingConn{}
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = s.Connect(conns[i])
+		}(i)
+	}
+	wg.Wait()
+	require.NoError(t, errors.Join(errs...))
+
+	// Exactly one conn (the highest epoch winner) should be open and current.
+	openCount := 0
+	for _, c := range conns {
+		if !c.closed.Load() {
+			openCount++
+		}
+	}
+	require.Equal(t, 1, openCount, "exactly one connection must survive concurrent takeover")
+	require.True(t, s.IsConnected())
+}

--- a/mqtt/session/takeover_test.go
+++ b/mqtt/session/takeover_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/absmach/fluxmq/config"
 	"github.com/absmach/fluxmq/storage/messages"
@@ -23,6 +24,24 @@ type recordingConn struct {
 
 func (c *recordingConn) Close() error {
 	c.closed.Store(true)
+	return nil
+}
+
+// wsLikeConn models a WebSocket connection whose Close() synchronously invokes
+// the onDisconnect callback (as server/websocket does), which calls back into
+// the session. Used to guard against re-entrant lock deadlock on takeover.
+type wsLikeConn struct {
+	testConn
+	closed atomic.Bool
+}
+
+func (c *wsLikeConn) Close() error {
+	if c.closed.Swap(true) {
+		return nil
+	}
+	if c.onDisconnect != nil {
+		c.onDisconnect(false) // synchronous, like the WebSocket transport
+	}
 	return nil
 }
 
@@ -111,6 +130,35 @@ func TestConnect_OnDisconnectCallbackScopedToEpoch(t *testing.T) {
 	oldCallback(false)
 
 	require.True(t, s.IsConnected(), "old conn callback must not disconnect after takeover")
+	require.False(t, newConn.closed.Load())
+}
+
+// TestConnect_WebSocketStyleSyncOnDisconnectNoDeadlock verifies that a takeover
+// of a connection whose Close() synchronously calls onDisconnect (WebSocket)
+// does not deadlock by re-entering the session lock.
+func TestConnect_WebSocketStyleSyncOnDisconnectNoDeadlock(t *testing.T) {
+	s := newTakeoverSession(t)
+
+	oldConn := &wsLikeConn{}
+	_, err := s.Connect(oldConn)
+	require.NoError(t, err)
+
+	newConn := &wsLikeConn{}
+	done := make(chan struct{})
+	go func() {
+		_, err := s.Connect(newConn) // would deadlock if Close re-entered s.mu
+		require.NoError(t, err)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Connect deadlocked on WebSocket-style synchronous onDisconnect")
+	}
+
+	require.True(t, oldConn.closed.Load(), "old ws conn must be closed by takeover")
+	require.True(t, s.IsConnected())
 	require.False(t, newConn.closed.Load())
 }
 

--- a/mqtt/session/takeover_test.go
+++ b/mqtt/session/takeover_test.go
@@ -181,15 +181,28 @@ func TestConnectWithOptions_AppliesNewOptionsOnReconnect(t *testing.T) {
 		Version:        5,
 		KeepAlive:      45 * time.Second,
 		Will:           newWill,
-		ExpiryInterval: 120,
+		ReceiveMaximum: 8,
 		TopicAliasMax:  10,
 	})
 
 	require.Equal(t, byte(5), s.Version, "reconnect must adopt the new protocol version")
 	require.Equal(t, 45*time.Second, s.KeepAlive)
 	require.Equal(t, newWill, s.GetWill())
+	require.Equal(t, uint16(8), s.ReceiveMaximum, "reconnect must adopt the new Receive Maximum")
 	require.NotNil(t, superseded)
 	require.Equal(t, byte(4), superseded.Version, "superseded carries the old version")
+}
+
+// TestSetExpiryInterval_ZeroReplacesPositive guards finding #3: a reconnect
+// carrying session expiry 0 (expire on disconnect) must replace a previous
+// positive value, not be ignored.
+func TestSetExpiryInterval_ZeroReplacesPositive(t *testing.T) {
+	s := newTakeoverSession(t)
+	s.SetExpiryInterval(300)
+	require.Equal(t, uint32(300), s.ExpiryInterval)
+
+	s.SetExpiryInterval(0)
+	require.Equal(t, uint32(0), s.ExpiryInterval, "expiry 0 must replace the previous positive value")
 }
 
 // TestConnectWithOptions_ClearsTopicAliases guards finding #4: topic alias

--- a/mqtt/session/takeover_test.go
+++ b/mqtt/session/takeover_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/absmach/fluxmq/config"
+	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/storage/messages"
 	"github.com/stretchr/testify/require"
 )
@@ -160,6 +161,57 @@ func TestConnect_WebSocketStyleSyncOnDisconnectNoDeadlock(t *testing.T) {
 	require.True(t, oldConn.closed.Load(), "old ws conn must be closed by takeover")
 	require.True(t, s.IsConnected())
 	require.False(t, newConn.closed.Load())
+}
+
+// TestConnectWithOptions_AppliesNewOptionsOnReconnect guards finding #1: a
+// persistent reconnect must adopt the new connection's options (notably the
+// protocol version, which drives packet encoding) and return the displaced
+// connection's old version and Will.
+func TestConnectWithOptions_AppliesNewOptionsOnReconnect(t *testing.T) {
+	s := newTakeoverSession(t) // version 4
+
+	oldConn := &recordingConn{}
+	_, err := s.Connect(oldConn)
+	require.NoError(t, err)
+	require.Equal(t, byte(4), s.Version)
+
+	newWill := &storage.WillMessage{Topic: "will/new", Payload: []byte("x")}
+	newConn := &recordingConn{}
+	_, superseded := s.ConnectWithOptions(newConn, ConnectOptions{
+		Version:        5,
+		KeepAlive:      45 * time.Second,
+		Will:           newWill,
+		ExpiryInterval: 120,
+		TopicAliasMax:  10,
+	})
+
+	require.Equal(t, byte(5), s.Version, "reconnect must adopt the new protocol version")
+	require.Equal(t, 45*time.Second, s.KeepAlive)
+	require.Equal(t, newWill, s.GetWill())
+	require.NotNil(t, superseded)
+	require.Equal(t, byte(4), superseded.Version, "superseded carries the old version")
+}
+
+// TestConnectWithOptions_ClearsTopicAliases guards finding #4: topic alias
+// mappings are scoped to a single connection and must not survive a takeover.
+// [MQTT-3.3.2-7].
+func TestConnectWithOptions_ClearsTopicAliases(t *testing.T) {
+	s := newTakeoverSession(t)
+
+	c1 := &recordingConn{}
+	_, err := s.Connect(c1)
+	require.NoError(t, err)
+
+	s.SetInboundAlias(1, "devices/a")
+	topic, ok := s.ResolveInboundAlias(1)
+	require.True(t, ok)
+	require.Equal(t, "devices/a", topic)
+
+	c2 := &recordingConn{}
+	s.ConnectWithOptions(c2, ConnectOptions{Version: 5, TopicAliasMax: 10})
+
+	_, ok = s.ResolveInboundAlias(1)
+	require.False(t, ok, "topic aliases must not carry across a takeover")
 }
 
 // TestConnect_ConcurrentReconnectKeepsLatest stress-checks that under many

--- a/pkg/proto/cluster/v1/broker.pb.go
+++ b/pkg/proto/cluster/v1/broker.pb.go
@@ -545,13 +545,17 @@ func (x *SessionState) GetWill() *WillMessage {
 }
 
 type InflightMessage struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	PacketId      uint32                 `protobuf:"varint,1,opt,name=packet_id,json=packetId,proto3" json:"packet_id,omitempty"`
-	Topic         string                 `protobuf:"bytes,2,opt,name=topic,proto3" json:"topic,omitempty"`
-	Payload       []byte                 `protobuf:"bytes,3,opt,name=payload,proto3" json:"payload,omitempty"`
-	Qos           uint32                 `protobuf:"varint,4,opt,name=qos,proto3" json:"qos,omitempty"`
-	Retain        bool                   `protobuf:"varint,5,opt,name=retain,proto3" json:"retain,omitempty"`
-	Timestamp     int64                  `protobuf:"varint,6,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	PacketId  uint32                 `protobuf:"varint,1,opt,name=packet_id,json=packetId,proto3" json:"packet_id,omitempty"`
+	Topic     string                 `protobuf:"bytes,2,opt,name=topic,proto3" json:"topic,omitempty"`
+	Payload   []byte                 `protobuf:"bytes,3,opt,name=payload,proto3" json:"payload,omitempty"`
+	Qos       uint32                 `protobuf:"varint,4,opt,name=qos,proto3" json:"qos,omitempty"`
+	Retain    bool                   `protobuf:"varint,5,opt,name=retain,proto3" json:"retain,omitempty"`
+	Timestamp int64                  `protobuf:"varint,6,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
+	// direction: 0 = outbound (server->client), 1 = inbound (client->server).
+	Direction uint32 `protobuf:"varint,7,opt,name=direction,proto3" json:"direction,omitempty"`
+	// state: inflight delivery state (0 = publish sent, 1 = pubrec received).
+	State         uint32 `protobuf:"varint,8,opt,name=state,proto3" json:"state,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -624,6 +628,20 @@ func (x *InflightMessage) GetRetain() bool {
 func (x *InflightMessage) GetTimestamp() int64 {
 	if x != nil {
 		return x.Timestamp
+	}
+	return 0
+}
+
+func (x *InflightMessage) GetDirection() uint32 {
+	if x != nil {
+		return x.Direction
+	}
+	return 0
+}
+
+func (x *InflightMessage) GetState() uint32 {
+	if x != nil {
+		return x.State
 	}
 	return 0
 }
@@ -2421,14 +2439,16 @@ const file_cluster_v1_broker_proto_rawDesc = "" +
 	"\x11inflight_messages\x18\x03 \x03(\v2\".fluxmq.cluster.v1.InflightMessageR\x10inflightMessages\x12I\n" +
 	"\x0fqueued_messages\x18\x04 \x03(\v2 .fluxmq.cluster.v1.QueuedMessageR\x0equeuedMessages\x12E\n" +
 	"\rsubscriptions\x18\x05 \x03(\v2\x1f.fluxmq.cluster.v1.SubscriptionR\rsubscriptions\x122\n" +
-	"\x04will\x18\x06 \x01(\v2\x1e.fluxmq.cluster.v1.WillMessageR\x04will\"\xa6\x01\n" +
+	"\x04will\x18\x06 \x01(\v2\x1e.fluxmq.cluster.v1.WillMessageR\x04will\"\xda\x01\n" +
 	"\x0fInflightMessage\x12\x1b\n" +
 	"\tpacket_id\x18\x01 \x01(\rR\bpacketId\x12\x14\n" +
 	"\x05topic\x18\x02 \x01(\tR\x05topic\x12\x18\n" +
 	"\apayload\x18\x03 \x01(\fR\apayload\x12\x10\n" +
 	"\x03qos\x18\x04 \x01(\rR\x03qos\x12\x16\n" +
 	"\x06retain\x18\x05 \x01(\bR\x06retain\x12\x1c\n" +
-	"\ttimestamp\x18\x06 \x01(\x03R\ttimestamp\"\x87\x01\n" +
+	"\ttimestamp\x18\x06 \x01(\x03R\ttimestamp\x12\x1c\n" +
+	"\tdirection\x18\a \x01(\rR\tdirection\x12\x14\n" +
+	"\x05state\x18\b \x01(\rR\x05state\"\x87\x01\n" +
 	"\rQueuedMessage\x12\x14\n" +
 	"\x05topic\x18\x01 \x01(\tR\x05topic\x12\x18\n" +
 	"\apayload\x18\x02 \x01(\fR\apayload\x12\x10\n" +

--- a/proto/cluster/v1/broker.proto
+++ b/proto/cluster/v1/broker.proto
@@ -122,6 +122,10 @@ message InflightMessage {
   uint32 qos = 4;
   bool retain = 5;
   int64 timestamp = 6;
+  // direction: 0 = outbound (server->client), 1 = inbound (client->server).
+  uint32 direction = 7;
+  // state: inflight delivery state (0 = publish sent, 1 = pubrec received).
+  uint32 state = 8;
 }
 
 message QueuedMessage {

--- a/server/api/overview_test.go
+++ b/server/api/overview_test.go
@@ -35,7 +35,7 @@ func TestOverviewCombinesStatsClusterSessions(t *testing.T) {
 		if err != nil {
 			t.Fatalf("create session %s: %v", id, err)
 		}
-		if err := s.Connect(&testConn{}); err != nil {
+		if _, err := s.Connect(&testConn{}); err != nil {
 			t.Fatalf("connect session %s: %v", id, err)
 		}
 	}

--- a/server/api/sessions_test.go
+++ b/server/api/sessions_test.go
@@ -456,7 +456,7 @@ func createSessionWithVersion(t *testing.T, b *mqttbroker.Broker, store *memory.
 	}
 	s.AddSubscription(filter, storage.SubscribeOptions{})
 
-	if err := s.Connect(&testConn{}); err != nil {
+	if _, err := s.Connect(&testConn{}); err != nil {
 		t.Fatalf("failed to connect session: %v", err)
 	}
 

--- a/storage/messages/errors.go
+++ b/storage/messages/errors.go
@@ -6,8 +6,9 @@ package messages
 import "errors"
 
 var (
-	ErrInflightFull     = errors.New("inflight queue full")
-	ErrQueueFull        = errors.New("offline queue full")
-	ErrPacketNotFound   = errors.New("packet not found in inflight")
-	ErrInvalidDirection = errors.New("invalid inflight direction")
+	ErrInflightFull       = errors.New("inflight queue full")
+	ErrQueueFull          = errors.New("offline queue full")
+	ErrPacketNotFound     = errors.New("packet not found in inflight")
+	ErrInvalidDirection   = errors.New("invalid inflight direction")
+	ErrInboundUnsupported = errors.New("inbound inflight operations unsupported")
 )

--- a/storage/messages/errors.go
+++ b/storage/messages/errors.go
@@ -6,7 +6,8 @@ package messages
 import "errors"
 
 var (
-	ErrInflightFull   = errors.New("inflight queue full")
-	ErrQueueFull      = errors.New("offline queue full")
-	ErrPacketNotFound = errors.New("packet not found in inflight")
+	ErrInflightFull     = errors.New("inflight queue full")
+	ErrQueueFull        = errors.New("offline queue full")
+	ErrPacketNotFound   = errors.New("packet not found in inflight")
+	ErrInvalidDirection = errors.New("invalid inflight direction")
 )

--- a/storage/messages/inflight.go
+++ b/storage/messages/inflight.go
@@ -59,6 +59,7 @@ type Inflight interface {
 	MarkRetry(packetID uint16) error
 	GetAll() []*InflightMessage
 	CleanupExpiredReceived(olderThan time.Duration)
+	SetMaxSize(maxSize int)
 }
 
 // inflight tracks QoS 1 and QoS 2 messages in flight.
@@ -81,6 +82,19 @@ func NewInflightTracker(maxSize int) *inflight {
 		maxSize:     maxSize,
 		receivedIDs: make(map[uint16]time.Time),
 	}
+}
+
+// SetMaxSize updates the maximum number of concurrent in-flight messages. Used
+// to reinitialise the send window when a client reconnects with a new Receive
+// Maximum. Messages already in flight are retained even if they exceed the new
+// limit; no new messages are admitted until the count drops below it.
+func (t *inflight) SetMaxSize(maxSize int) {
+	if maxSize <= 0 {
+		maxSize = 65535
+	}
+	t.mu.Lock()
+	t.maxSize = maxSize
+	t.mu.Unlock()
 }
 
 // Add adds a message to the inflight tracker.

--- a/storage/messages/inflight.go
+++ b/storage/messages/inflight.go
@@ -48,9 +48,9 @@ const (
 // MQTT packet identifiers are independent in each direction, so entries are
 // keyed by (direction, packetID). Methods that are inherently one-directional
 // operate on the outbound entries (Get, Has, UpdateState, MarkSent, MarkRetry,
-// MarkDeliveryAttempted, GetExpired); the inbound QoS 2 receive path uses Add
-// with Inbound, Ack with Inbound, and the *Received methods. Ack therefore takes
-// the direction explicitly.
+// MarkDeliveryAttempted, GetExpired). The live inbound QoS 2 receive path uses
+// the optional InboundAdder and InboundAcker extensions so external
+// implementations that do not isolate directions fail explicitly.
 type Inflight interface {
 	Add(packetID uint16, msg *storage.Message, direction Direction) error
 	// Ack acknowledges and removes an outbound message (PUBACK/PUBCOMP).
@@ -69,11 +69,19 @@ type Inflight interface {
 	CleanupExpiredReceived(olderThan time.Duration)
 }
 
+// InboundAdder is an optional extension of Inflight for atomic inbound QoS 2
+// admission. accepted reports whether the tracker took ownership of msg. A
+// duplicate returns accepted=false with no error and preserves the first
+// accepted transaction. Keeping this out of the base Inflight interface
+// preserves source compatibility for external implementations.
+type InboundAdder interface {
+	AddInbound(packetID uint16, msg *storage.Message) (accepted bool, err error)
+}
+
 // InboundAcker is an optional extension of Inflight for directional inbound
 // acknowledgement (PUBREL completing an inbound QoS 2 receive). Keeping it out
 // of the base Inflight interface preserves source compatibility for external
-// implementations; callers type-assert to it and fall back to Ack when absent.
-// The built-in tracker implements it.
+// implementations. The built-in tracker implements it.
 type InboundAcker interface {
 	AckInbound(packetID uint16) (*storage.Message, error)
 }
@@ -142,6 +150,44 @@ func (t *inflight) Add(packetID uint16, msg *storage.Message, direction Directio
 		Direction: direction,
 	}
 	return nil
+}
+
+// AddInbound atomically admits an inbound QoS 2 transaction and records its
+// duplicate-detection state. It never replaces an existing transaction with
+// the same packet ID. accepted is true only when the tracker takes ownership of
+// msg.
+func (t *inflight) AddInbound(packetID uint16, msg *storage.Message) (bool, error) {
+	return t.addInbound(packetID, msg, Inbound)
+}
+
+func (t *inflight) addInbound(packetID uint16, msg *storage.Message, direction Direction) (bool, error) {
+	if direction != Inbound {
+		return false, fmt.Errorf("add inbound packet ID %d: %w", packetID, ErrInvalidDirection)
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	key := inflightKey{direction: direction, packetID: packetID}
+	if _, exists := t.messages[key]; exists {
+		return false, nil
+	}
+	if t.counts[direction] >= t.maxSize {
+		return false, ErrInflightFull
+	}
+
+	t.messages[key] = &InflightMessage{
+		PacketID: packetID,
+		Message:  msg,
+		State:    StatePublishSent,
+		// SentAt is intentionally set only after successful socket write.
+		SentAt:    time.Time{},
+		Retries:   0,
+		Direction: direction,
+	}
+	t.counts[direction]++
+	t.receivedIDs[packetID] = time.Now()
+	return true, nil
 }
 
 // Get retrieves an outbound inflight message by packet ID.

--- a/storage/messages/inflight.go
+++ b/storage/messages/inflight.go
@@ -59,7 +59,6 @@ type Inflight interface {
 	MarkRetry(packetID uint16) error
 	GetAll() []*InflightMessage
 	CleanupExpiredReceived(olderThan time.Duration)
-	SetMaxSize(maxSize int)
 }
 
 // inflight tracks QoS 1 and QoS 2 messages in flight.
@@ -82,19 +81,6 @@ func NewInflightTracker(maxSize int) *inflight {
 		maxSize:     maxSize,
 		receivedIDs: make(map[uint16]time.Time),
 	}
-}
-
-// SetMaxSize updates the maximum number of concurrent in-flight messages. Used
-// to reinitialise the send window when a client reconnects with a new Receive
-// Maximum. Messages already in flight are retained even if they exceed the new
-// limit; no new messages are admitted until the count drops below it.
-func (t *inflight) SetMaxSize(maxSize int) {
-	if maxSize <= 0 {
-		maxSize = 65535
-	}
-	t.mu.Lock()
-	t.maxSize = maxSize
-	t.mu.Unlock()
 }
 
 // Add adds a message to the inflight tracker.

--- a/storage/messages/inflight.go
+++ b/storage/messages/inflight.go
@@ -44,9 +44,16 @@ const (
 )
 
 // Inflight defines operations on inflight messages.
+//
+// MQTT packet identifiers are independent in each direction, so entries are
+// keyed by (direction, packetID). Methods that are inherently one-directional
+// operate on the outbound entries (Get, Has, UpdateState, MarkSent, MarkRetry,
+// MarkDeliveryAttempted, GetExpired); the inbound QoS 2 receive path uses Add
+// with Inbound, Ack with Inbound, and the *Received methods. Ack therefore takes
+// the direction explicitly.
 type Inflight interface {
 	Add(packetID uint16, msg *storage.Message, direction Direction) error
-	Ack(packetID uint16) (*storage.Message, error)
+	Ack(packetID uint16, direction Direction) (*storage.Message, error)
 	Get(packetID uint16) (*InflightMessage, bool)
 	Has(packetID uint16) bool
 	WasReceived(packetID uint16) bool
@@ -61,11 +68,22 @@ type Inflight interface {
 	CleanupExpiredReceived(olderThan time.Duration)
 }
 
+// inflightKey identifies an inflight entry. Inbound and outbound flows have
+// independent packet-ID spaces, so the direction is part of the key.
+type inflightKey struct {
+	direction Direction
+	packetID  uint16
+}
+
 // inflight tracks QoS 1 and QoS 2 messages in flight.
 type inflight struct {
 	mu       sync.RWMutex
-	messages map[uint16]*InflightMessage
-	maxSize  int
+	messages map[inflightKey]*InflightMessage
+	// counts is the number of entries per direction. Each direction is capped at
+	// maxSize independently, so outbound delivery cannot consume the inbound
+	// Receive Maximum the broker advertises, and vice versa.
+	counts  [2]int
+	maxSize int
 
 	// For QoS 2 inbound: track received packet IDs to detect duplicates
 	receivedIDs map[uint16]time.Time
@@ -77,22 +95,27 @@ func NewInflightTracker(maxSize int) *inflight {
 		maxSize = 65535
 	}
 	return &inflight{
-		messages:    make(map[uint16]*InflightMessage),
+		messages:    make(map[inflightKey]*InflightMessage),
 		maxSize:     maxSize,
 		receivedIDs: make(map[uint16]time.Time),
 	}
 }
 
-// Add adds a message to the inflight tracker.
+// Add adds a message to the inflight tracker. Each direction is capped at
+// maxSize independently.
 func (t *inflight) Add(packetID uint16, msg *storage.Message, direction Direction) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if len(t.messages) >= t.maxSize {
+	if t.counts[direction] >= t.maxSize {
 		return ErrInflightFull
 	}
 
-	t.messages[packetID] = &InflightMessage{
+	key := inflightKey{direction: direction, packetID: packetID}
+	if _, exists := t.messages[key]; !exists {
+		t.counts[direction]++
+	}
+	t.messages[key] = &InflightMessage{
 		PacketID: packetID,
 		Message:  msg,
 		State:    StatePublishSent,
@@ -104,12 +127,12 @@ func (t *inflight) Add(packetID uint16, msg *storage.Message, direction Directio
 	return nil
 }
 
-// Get retrieves an inflight message by packet ID.
+// Get retrieves an outbound inflight message by packet ID.
 func (t *inflight) Get(packetID uint16) (*InflightMessage, bool) {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 
-	msg, ok := t.messages[packetID]
+	msg, ok := t.messages[inflightKey{direction: Outbound, packetID: packetID}]
 	if !ok {
 		return nil, false
 	}
@@ -119,20 +142,21 @@ func (t *inflight) Get(packetID uint16) (*InflightMessage, bool) {
 	return &cp, true
 }
 
-// Has returns true if the packet ID is in the tracker.
+// Has returns true if the outbound packet ID is in the tracker. Used to avoid
+// reusing an outbound packet identifier.
 func (t *inflight) Has(packetID uint16) bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	_, ok := t.messages[packetID]
+	_, ok := t.messages[inflightKey{direction: Outbound, packetID: packetID}]
 	return ok
 }
 
-// UpdateState updates the state of an inflight message.
+// UpdateState updates the state of an outbound inflight message.
 func (t *inflight) UpdateState(packetID uint16, state InflightState) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	msg, ok := t.messages[packetID]
+	msg, ok := t.messages[inflightKey{direction: Outbound, packetID: packetID}]
 	if !ok {
 		return fmt.Errorf("update state for packet ID %d: %w", packetID, ErrPacketNotFound)
 	}
@@ -140,25 +164,32 @@ func (t *inflight) UpdateState(packetID uint16, state InflightState) error {
 	return nil
 }
 
-// Ack acknowledges and removes a message (for QoS 1 PUBACK or QoS 2 PUBCOMP).
-func (t *inflight) Ack(packetID uint16) (*storage.Message, error) {
+// Ack acknowledges and removes a message in the given direction (outbound for
+// PUBACK/PUBCOMP, inbound for PUBREL).
+func (t *inflight) Ack(packetID uint16, direction Direction) (*storage.Message, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	msg, ok := t.messages[packetID]
+	key := inflightKey{direction: direction, packetID: packetID}
+	msg, ok := t.messages[key]
 	if !ok {
 		return nil, fmt.Errorf("ack packet ID %d: %w", packetID, ErrPacketNotFound)
 	}
 
-	delete(t.messages, packetID)
+	delete(t.messages, key)
+	t.counts[direction]--
 	return msg.Message, nil
 }
 
-// Remove removes an inflight message.
+// Remove removes an outbound inflight message.
 func (t *inflight) Remove(packetID uint16) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	delete(t.messages, packetID)
+	key := inflightKey{direction: Outbound, packetID: packetID}
+	if _, ok := t.messages[key]; ok {
+		delete(t.messages, key)
+		t.counts[Outbound]--
+	}
 }
 
 // neverSentRetryDelay is the time to wait before retrying a message that was
@@ -177,7 +208,12 @@ func (t *inflight) GetExpired(timeout time.Duration) []*InflightMessage {
 	now := time.Now()
 	var expired []*InflightMessage
 
-	for _, msg := range t.messages {
+	// Only outbound messages are retransmitted by the broker; inbound QoS 2
+	// completion is driven by the client's PUBREL.
+	for key, msg := range t.messages {
+		if key.direction != Outbound {
+			continue
+		}
 		if msg.SentAt.IsZero() {
 			// Never written to wire; retry after neverSentRetryDelay if delivery was attempted.
 			if !msg.DeliveryAttemptedAt.IsZero() && now.Sub(msg.DeliveryAttemptedAt) >= neverSentRetryDelay {
@@ -194,34 +230,35 @@ func (t *inflight) GetExpired(timeout time.Duration) []*InflightMessage {
 	return expired
 }
 
-// MarkSent marks a message as successfully written to the connection.
+// MarkSent marks an outbound message as successfully written to the connection.
 func (t *inflight) MarkSent(packetID uint16) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if msg, ok := t.messages[packetID]; ok {
+	if msg, ok := t.messages[inflightKey{direction: Outbound, packetID: packetID}]; ok {
 		msg.SentAt = time.Now()
 	}
 }
 
-// MarkDeliveryAttempted records the time of the most recent delivery attempt.
-// Each call overwrites the previous timestamp, resetting the neverSentRetryDelay
-// backoff so a failed retry doesn't immediately re-appear in GetExpired.
+// MarkDeliveryAttempted records the time of the most recent outbound delivery
+// attempt. Each call overwrites the previous timestamp, resetting the
+// neverSentRetryDelay backoff so a failed retry doesn't immediately re-appear in
+// GetExpired.
 func (t *inflight) MarkDeliveryAttempted(packetID uint16) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if msg, ok := t.messages[packetID]; ok {
+	if msg, ok := t.messages[inflightKey{direction: Outbound, packetID: packetID}]; ok {
 		msg.DeliveryAttemptedAt = time.Now()
 	}
 }
 
-// MarkRetry marks a message as retried and updates sent time.
+// MarkRetry marks an outbound message as retried and updates sent time.
 func (t *inflight) MarkRetry(packetID uint16) error {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	msg, ok := t.messages[packetID]
+	msg, ok := t.messages[inflightKey{direction: Outbound, packetID: packetID}]
 	if !ok {
 		return fmt.Errorf("mark retry for packet ID %d: %w", packetID, ErrPacketNotFound)
 	}
@@ -231,18 +268,18 @@ func (t *inflight) MarkRetry(packetID uint16) error {
 	return nil
 }
 
-// Count returns the number of inflight messages.
+// Count returns the total number of inflight messages across both directions.
 func (t *inflight) Count() int {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	return len(t.messages)
 }
 
-// IsFull returns true if the tracker is at capacity.
+// IsFull reports whether the outbound direction is at capacity.
 func (t *inflight) IsFull() bool {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	return len(t.messages) >= t.maxSize
+	return t.counts[Outbound] >= t.maxSize
 }
 
 // GetAll returns all inflight messages.
@@ -262,7 +299,8 @@ func (t *inflight) GetAll() []*InflightMessage {
 func (t *inflight) Clear() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	t.messages = make(map[uint16]*InflightMessage)
+	t.messages = make(map[inflightKey]*InflightMessage)
+	t.counts = [2]int{}
 	t.receivedIDs = make(map[uint16]time.Time)
 }
 

--- a/storage/messages/inflight.go
+++ b/storage/messages/inflight.go
@@ -57,16 +57,12 @@ type Inflight interface {
 	Ack(packetID uint16) (*storage.Message, error)
 	Get(packetID uint16) (*InflightMessage, bool)
 	Has(packetID uint16) bool
-	WasReceived(packetID uint16) bool
-	MarkReceived(packetID uint16)
 	UpdateState(packetID uint16, state InflightState) error
-	ClearReceived(packetID uint16)
 	GetExpired(expiry time.Duration) []*InflightMessage
 	MarkSent(packetID uint16)
 	MarkDeliveryAttempted(packetID uint16)
 	MarkRetry(packetID uint16) error
 	GetAll() []*InflightMessage
-	CleanupExpiredReceived(olderThan time.Duration)
 }
 
 // InboundAdder is an optional extension of Inflight for atomic inbound QoS 2
@@ -102,9 +98,6 @@ type inflight struct {
 	// Receive Maximum the broker advertises, and vice versa.
 	counts  [2]int
 	maxSize int
-
-	// For QoS 2 inbound: track received packet IDs to detect duplicates
-	receivedIDs map[uint16]time.Time
 }
 
 // NewInflightTracker creates a new inflight tracker.
@@ -113,9 +106,8 @@ func NewInflightTracker(maxSize int) *inflight {
 		maxSize = 65535
 	}
 	return &inflight{
-		messages:    make(map[inflightKey]*InflightMessage),
-		maxSize:     maxSize,
-		receivedIDs: make(map[uint16]time.Time),
+		messages: make(map[inflightKey]*InflightMessage),
+		maxSize:  maxSize,
 	}
 }
 
@@ -152,9 +144,9 @@ func (t *inflight) Add(packetID uint16, msg *storage.Message, direction Directio
 	return nil
 }
 
-// AddInbound atomically admits an inbound QoS 2 transaction and records its
-// duplicate-detection state. It never replaces an existing transaction with
-// the same packet ID. accepted is true only when the tracker takes ownership of
+// AddInbound atomically admits an inbound QoS 2 transaction, rejecting a
+// duplicate by packet ID. It never replaces an existing transaction with the
+// same packet ID. accepted is true only when the tracker takes ownership of
 // msg.
 func (t *inflight) AddInbound(packetID uint16, msg *storage.Message) (bool, error) {
 	return t.addInbound(packetID, msg, Inbound)
@@ -186,7 +178,6 @@ func (t *inflight) addInbound(packetID uint16, msg *storage.Message, direction D
 		Direction: direction,
 	}
 	t.counts[direction]++
-	t.receivedIDs[packetID] = time.Now()
 	return true, nil
 }
 
@@ -372,40 +363,4 @@ func (t *inflight) Clear() {
 	defer t.mu.Unlock()
 	t.messages = make(map[inflightKey]*InflightMessage)
 	t.counts = [2]int{}
-	t.receivedIDs = make(map[uint16]time.Time)
-}
-
-// MarkReceived marks a packet ID as received (for QoS 2 duplicate detection).
-func (t *inflight) MarkReceived(packetID uint16) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	t.receivedIDs[packetID] = time.Now()
-}
-
-// WasReceived returns true if the packet ID was previously received.
-func (t *inflight) WasReceived(packetID uint16) bool {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
-	_, ok := t.receivedIDs[packetID]
-	return ok
-}
-
-// ClearReceived clears a received packet ID (after PUBCOMP sent).
-func (t *inflight) ClearReceived(packetID uint16) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	delete(t.receivedIDs, packetID)
-}
-
-// CleanupExpiredReceived removes old received IDs.
-func (t *inflight) CleanupExpiredReceived(olderThan time.Duration) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	cutoff := time.Now().Add(-olderThan)
-	for id, received := range t.receivedIDs {
-		if received.Before(cutoff) {
-			delete(t.receivedIDs, id)
-		}
-	}
 }

--- a/storage/messages/inflight.go
+++ b/storage/messages/inflight.go
@@ -55,9 +55,6 @@ type Inflight interface {
 	Add(packetID uint16, msg *storage.Message, direction Direction) error
 	// Ack acknowledges and removes an outbound message (PUBACK/PUBCOMP).
 	Ack(packetID uint16) (*storage.Message, error)
-	// AckInbound acknowledges and removes an inbound message (PUBREL completes
-	// an inbound QoS 2 receive).
-	AckInbound(packetID uint16) (*storage.Message, error)
 	Get(packetID uint16) (*InflightMessage, bool)
 	Has(packetID uint16) bool
 	WasReceived(packetID uint16) bool
@@ -70,6 +67,15 @@ type Inflight interface {
 	MarkRetry(packetID uint16) error
 	GetAll() []*InflightMessage
 	CleanupExpiredReceived(olderThan time.Duration)
+}
+
+// InboundAcker is an optional extension of Inflight for directional inbound
+// acknowledgement (PUBREL completing an inbound QoS 2 receive). Keeping it out
+// of the base Inflight interface preserves source compatibility for external
+// implementations; callers type-assert to it and fall back to Ack when absent.
+// The built-in tracker implements it.
+type InboundAcker interface {
+	AckInbound(packetID uint16) (*storage.Message, error)
 }
 
 // inflightKey identifies an inflight entry. Inbound and outbound flows have
@@ -108,15 +114,22 @@ func NewInflightTracker(maxSize int) *inflight {
 // Add adds a message to the inflight tracker. Each direction is capped at
 // maxSize independently.
 func (t *inflight) Add(packetID uint16, msg *storage.Message, direction Direction) error {
+	if direction != Outbound && direction != Inbound {
+		return fmt.Errorf("add packet ID %d: %w", packetID, ErrInvalidDirection)
+	}
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	if t.counts[direction] >= t.maxSize {
-		return ErrInflightFull
-	}
-
 	key := inflightKey{direction: direction, packetID: packetID}
-	if _, exists := t.messages[key]; !exists {
+	_, exists := t.messages[key]
+	// Capacity only gates new keys. An existing key (e.g. a retransmitted QoS 2
+	// PUBLISH with a known packet ID) must be accepted even when the direction
+	// is at capacity, so duplicates are not rejected with ErrInflightFull.
+	if !exists {
+		if t.counts[direction] >= t.maxSize {
+			return ErrInflightFull
+		}
 		t.counts[direction]++
 	}
 	t.messages[key] = &InflightMessage{

--- a/storage/messages/inflight.go
+++ b/storage/messages/inflight.go
@@ -53,7 +53,11 @@ const (
 // the direction explicitly.
 type Inflight interface {
 	Add(packetID uint16, msg *storage.Message, direction Direction) error
-	Ack(packetID uint16, direction Direction) (*storage.Message, error)
+	// Ack acknowledges and removes an outbound message (PUBACK/PUBCOMP).
+	Ack(packetID uint16) (*storage.Message, error)
+	// AckInbound acknowledges and removes an inbound message (PUBREL completes
+	// an inbound QoS 2 receive).
+	AckInbound(packetID uint16) (*storage.Message, error)
 	Get(packetID uint16) (*InflightMessage, bool)
 	Has(packetID uint16) bool
 	WasReceived(packetID uint16) bool
@@ -164,9 +168,17 @@ func (t *inflight) UpdateState(packetID uint16, state InflightState) error {
 	return nil
 }
 
-// Ack acknowledges and removes a message in the given direction (outbound for
-// PUBACK/PUBCOMP, inbound for PUBREL).
-func (t *inflight) Ack(packetID uint16, direction Direction) (*storage.Message, error) {
+// Ack acknowledges and removes an outbound message (PUBACK/PUBCOMP).
+func (t *inflight) Ack(packetID uint16) (*storage.Message, error) {
+	return t.ackDirection(packetID, Outbound)
+}
+
+// AckInbound acknowledges and removes an inbound message (PUBREL).
+func (t *inflight) AckInbound(packetID uint16) (*storage.Message, error) {
+	return t.ackDirection(packetID, Inbound)
+}
+
+func (t *inflight) ackDirection(packetID uint16, direction Direction) (*storage.Message, error) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 

--- a/storage/messages/inflight_test.go
+++ b/storage/messages/inflight_test.go
@@ -152,7 +152,7 @@ func TestInflight_AddInboundDuplicatePreservesOriginalOnFullWindow(t *testing.T)
 	accepted, err := tr.AddInbound(7, first)
 	require.NoError(t, err)
 	require.True(t, accepted)
-	require.True(t, tr.WasReceived(7))
+	require.Contains(t, tr.messages, inflightKey{direction: Inbound, packetID: 7})
 	tr.messages[inflightKey{direction: Inbound, packetID: 7}].State = StatePubRecReceived
 
 	// The inbound window is full (capacity 1). A retransmitted PUBLISH reusing
@@ -168,7 +168,7 @@ func TestInflight_AddInboundDuplicatePreservesOriginalOnFullWindow(t *testing.T)
 	accepted, err = tr.AddInbound(8, &storage.Message{Topic: "t"})
 	require.ErrorIs(t, err, ErrInflightFull)
 	require.False(t, accepted)
-	require.False(t, tr.WasReceived(8), "failed admission must not create phantom duplicate state")
+	require.NotContains(t, tr.messages, inflightKey{direction: Inbound, packetID: 8}, "failed admission must not create phantom duplicate state")
 
 	got, err := tr.AckInbound(7)
 	require.NoError(t, err)
@@ -184,5 +184,5 @@ func TestInflight_AddInboundRejectsInvalidDirection(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidDirection)
 	require.False(t, accepted)
 	require.Empty(t, tr.GetAll())
-	require.False(t, tr.WasReceived(1))
+	require.NotContains(t, tr.messages, inflightKey{direction: Inbound, packetID: 1})
 }

--- a/storage/messages/inflight_test.go
+++ b/storage/messages/inflight_test.go
@@ -146,19 +146,43 @@ func TestInflight_InvalidDirectionReturnsErrorNotPanic(t *testing.T) {
 	require.ErrorIs(t, err, ErrInvalidDirection)
 }
 
-func TestInflight_DuplicateOnFullWindowAccepted(t *testing.T) {
+func TestInflight_AddInboundDuplicatePreservesOriginalOnFullWindow(t *testing.T) {
 	tr := NewInflightTracker(1)
-	require.NoError(t, tr.Add(7, &storage.Message{Topic: "first"}, Inbound))
+	first := &storage.Message{Topic: "first", Payload: []byte("original")}
+	accepted, err := tr.AddInbound(7, first)
+	require.NoError(t, err)
+	require.True(t, accepted)
+	require.True(t, tr.WasReceived(7))
+	tr.messages[inflightKey{direction: Inbound, packetID: 7}].State = StatePubRecReceived
 
 	// The inbound window is full (capacity 1). A retransmitted PUBLISH reusing
-	// the same packet ID must be accepted (update), not rejected with
-	// ErrInflightFull.
-	require.NoError(t, tr.Add(7, &storage.Message{Topic: "second"}, Inbound))
+	// the same packet ID is acknowledged without replacing the first accepted
+	// transaction or taking ownership of the duplicate message.
+	duplicate := &storage.Message{Topic: "second", Payload: []byte("replacement")}
+	accepted, err = tr.AddInbound(7, duplicate)
+	require.NoError(t, err)
+	require.False(t, accepted)
+	require.Equal(t, StatePubRecReceived, tr.messages[inflightKey{direction: Inbound, packetID: 7}].State)
 
 	// A different packet ID is still rejected.
-	require.ErrorIs(t, tr.Add(8, &storage.Message{Topic: "t"}, Inbound), ErrInflightFull)
+	accepted, err = tr.AddInbound(8, &storage.Message{Topic: "t"})
+	require.ErrorIs(t, err, ErrInflightFull)
+	require.False(t, accepted)
+	require.False(t, tr.WasReceived(8), "failed admission must not create phantom duplicate state")
 
 	got, err := tr.AckInbound(7)
 	require.NoError(t, err)
-	require.Equal(t, "second", got.Topic)
+	require.Same(t, first, got)
+	require.Equal(t, "first", got.Topic)
+	require.Equal(t, []byte("original"), got.Payload)
+}
+
+func TestInflight_AddInboundRejectsInvalidDirection(t *testing.T) {
+	tr := NewInflightTracker(1)
+
+	accepted, err := tr.addInbound(1, &storage.Message{Topic: "t"}, Outbound)
+	require.ErrorIs(t, err, ErrInvalidDirection)
+	require.False(t, accepted)
+	require.Empty(t, tr.GetAll())
+	require.False(t, tr.WasReceived(1))
 }

--- a/storage/messages/inflight_test.go
+++ b/storage/messages/inflight_test.go
@@ -84,7 +84,7 @@ func TestGetExpired_NeverSentEligibleAfterDelay(t *testing.T) {
 	require.Empty(t, tracker.GetExpired(20*time.Second))
 
 	// Backdate to simulate neverSentRetryDelay elapsed.
-	tracker.messages[1].DeliveryAttemptedAt = time.Now().Add(-neverSentRetryDelay - time.Millisecond)
+	tracker.messages[inflightKey{direction: Outbound, packetID: 1}].DeliveryAttemptedAt = time.Now().Add(-neverSentRetryDelay - time.Millisecond)
 
 	expired := tracker.GetExpired(20 * time.Second)
 	require.Len(t, expired, 1)
@@ -97,7 +97,7 @@ func TestMarkDeliveryAttempted_ResetsBackoffTimer(t *testing.T) {
 
 	// Simulate: delay elapsed, message is eligible.
 	tracker.MarkDeliveryAttempted(1)
-	tracker.messages[1].DeliveryAttemptedAt = time.Now().Add(-neverSentRetryDelay - time.Millisecond)
+	tracker.messages[inflightKey{direction: Outbound, packetID: 1}].DeliveryAttemptedAt = time.Now().Add(-neverSentRetryDelay - time.Millisecond)
 	require.Len(t, tracker.GetExpired(20*time.Second), 1)
 
 	// Simulate failed retry: reset backoff.
@@ -105,4 +105,35 @@ func TestMarkDeliveryAttempted_ResetsBackoffTimer(t *testing.T) {
 
 	// No longer eligible — timer reset to now.
 	require.Empty(t, tracker.GetExpired(20*time.Second))
+}
+
+func TestInflight_IndependentDirectionalCapacity(t *testing.T) {
+	tr := NewInflightTracker(2)
+
+	require.NoError(t, tr.Add(1, &storage.Message{Topic: "t"}, Outbound))
+	require.NoError(t, tr.Add(2, &storage.Message{Topic: "t"}, Outbound))
+	require.ErrorIs(t, tr.Add(3, &storage.Message{Topic: "t"}, Outbound), ErrInflightFull)
+
+	// Inbound has its own capacity; a full outbound direction must not reject
+	// inbound up to the advertised Receive Maximum.
+	require.NoError(t, tr.Add(1, &storage.Message{Topic: "t"}, Inbound))
+	require.NoError(t, tr.Add(2, &storage.Message{Topic: "t"}, Inbound))
+	require.ErrorIs(t, tr.Add(3, &storage.Message{Topic: "t"}, Inbound), ErrInflightFull)
+}
+
+func TestInflight_DirectionalKeysDoNotCollide(t *testing.T) {
+	tr := NewInflightTracker(8)
+
+	out := &storage.Message{Topic: "outbound"}
+	in := &storage.Message{Topic: "inbound"}
+	require.NoError(t, tr.Add(5, out, Outbound))
+	require.NoError(t, tr.Add(5, in, Inbound)) // same packet ID, opposite direction
+
+	gotOut, err := tr.Ack(5, Outbound)
+	require.NoError(t, err)
+	require.Equal(t, "outbound", gotOut.Topic, "inbound add must not overwrite the outbound entry")
+
+	gotIn, err := tr.Ack(5, Inbound)
+	require.NoError(t, err)
+	require.Equal(t, "inbound", gotIn.Topic)
 }

--- a/storage/messages/inflight_test.go
+++ b/storage/messages/inflight_test.go
@@ -129,11 +129,11 @@ func TestInflight_DirectionalKeysDoNotCollide(t *testing.T) {
 	require.NoError(t, tr.Add(5, out, Outbound))
 	require.NoError(t, tr.Add(5, in, Inbound)) // same packet ID, opposite direction
 
-	gotOut, err := tr.Ack(5, Outbound)
+	gotOut, err := tr.Ack(5)
 	require.NoError(t, err)
 	require.Equal(t, "outbound", gotOut.Topic, "inbound add must not overwrite the outbound entry")
 
-	gotIn, err := tr.Ack(5, Inbound)
+	gotIn, err := tr.AckInbound(5)
 	require.NoError(t, err)
 	require.Equal(t, "inbound", gotIn.Topic)
 }

--- a/storage/messages/inflight_test.go
+++ b/storage/messages/inflight_test.go
@@ -137,3 +137,28 @@ func TestInflight_DirectionalKeysDoNotCollide(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "inbound", gotIn.Topic)
 }
+
+func TestInflight_InvalidDirectionReturnsErrorNotPanic(t *testing.T) {
+	tr := NewInflightTracker(4)
+	// A corrupt/out-of-range direction must be rejected, not index counts[] out
+	// of range and panic.
+	err := tr.Add(1, &storage.Message{Topic: "t"}, Direction(99))
+	require.ErrorIs(t, err, ErrInvalidDirection)
+}
+
+func TestInflight_DuplicateOnFullWindowAccepted(t *testing.T) {
+	tr := NewInflightTracker(1)
+	require.NoError(t, tr.Add(7, &storage.Message{Topic: "first"}, Inbound))
+
+	// The inbound window is full (capacity 1). A retransmitted PUBLISH reusing
+	// the same packet ID must be accepted (update), not rejected with
+	// ErrInflightFull.
+	require.NoError(t, tr.Add(7, &storage.Message{Topic: "second"}, Inbound))
+
+	// A different packet ID is still rejected.
+	require.ErrorIs(t, tr.Add(8, &storage.Message{Topic: "t"}, Inbound), ErrInflightFull)
+
+	got, err := tr.AckInbound(7)
+	require.NoError(t, err)
+	require.Equal(t, "second", got.Topic)
+}

--- a/storage/pool.go
+++ b/storage/pool.go
@@ -67,4 +67,6 @@ func (m *Message) Reset() {
 	m.PacketID = 0
 	m.QoS = 0
 	m.Retain = false
+	m.InflightDirection = 0
+	m.InflightState = 0
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -61,6 +61,13 @@ type Message struct {
 	PacketID        uint16
 	QoS             byte
 	Retain          bool
+
+	// InflightDirection and InflightState carry inflight metadata when a message
+	// is persisted as an inflight entry (0 for non-inflight messages): direction
+	// distinguishes inbound from outbound so a restored QoS 2 transaction keeps
+	// its direction, and state preserves the QoS 2 delivery phase.
+	InflightDirection byte
+	InflightState     byte
 }
 
 // GetPayload returns the message payload, preferring PayloadBuf if available.
@@ -120,15 +127,17 @@ func CopyMessage(msg *Message) *Message {
 	}
 
 	cp := &Message{
-		Topic:         msg.Topic,
-		ClientID:      msg.ClientID,
-		QoS:           msg.QoS,
-		Retain:        msg.Retain,
-		PacketID:      msg.PacketID,
-		Expiry:        msg.Expiry,
-		ContentType:   msg.ContentType,
-		ResponseTopic: msg.ResponseTopic,
-		PublishTime:   msg.PublishTime,
+		Topic:             msg.Topic,
+		ClientID:          msg.ClientID,
+		QoS:               msg.QoS,
+		Retain:            msg.Retain,
+		PacketID:          msg.PacketID,
+		Expiry:            msg.Expiry,
+		ContentType:       msg.ContentType,
+		ResponseTopic:     msg.ResponseTopic,
+		PublishTime:       msg.PublishTime,
+		InflightDirection: msg.InflightDirection,
+		InflightState:     msg.InflightState,
 	}
 
 	if msg.MessageExpiry != nil {

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -47,7 +47,7 @@ type Message struct {
 	Expiry          time.Time
 	PublishTime     time.Time
 	Payload         []byte                 // Deprecated: Use PayloadBuf for zero-copy
-	PayloadBuf      *core.RefCountedBuffer // Zero-copy payload buffer (preferred)
+	PayloadBuf      *core.RefCountedBuffer `json:"-"` // Zero-copy payload buffer; not serialized (use Payload for persistence)
 	CorrelationData []byte
 	SubscriptionIDs []uint32
 	Topic           string

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package storage_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	core "github.com/absmach/fluxmq/mqtt"
+	"github.com/absmach/fluxmq/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMessage_PayloadBufNotSerialized_PayloadIs guards finding #1: the zero-copy
+// PayloadBuf is excluded from JSON (json:"-"), so persistence (badger) relies on
+// the Payload byte slice. A message carrying only a PayloadBuf loses its payload
+// unless Payload is materialised first.
+func TestMessage_PayloadBufNotSerialized_PayloadIs(t *testing.T) {
+	msg := &storage.Message{}
+	msg.SetPayloadFromBuffer(core.GetBufferWithData([]byte("hello")))
+	require.Equal(t, "hello", string(msg.GetPayload()))
+
+	// Round-trip without materialising Payload: payload is lost.
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+	var restored storage.Message
+	require.NoError(t, json.Unmarshal(data, &restored))
+	require.Nil(t, restored.PayloadBuf, "PayloadBuf must not be serialized")
+	require.Empty(t, restored.GetPayload())
+
+	// Materialising Payload (as the persistence paths now do) preserves it.
+	msg.Payload = append([]byte(nil), msg.GetPayload()...)
+	data, err = json.Marshal(msg)
+	require.NoError(t, err)
+	var restored2 storage.Message
+	require.NoError(t, json.Unmarshal(data, &restored2))
+	require.Equal(t, "hello", string(restored2.GetPayload()))
+}

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -37,3 +37,18 @@ func TestMessage_PayloadBufNotSerialized_PayloadIs(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &restored2))
 	require.Equal(t, "hello", string(restored2.GetPayload()))
 }
+
+func TestMessagePoolReuseClearsInflightMetadata(t *testing.T) {
+	msg := storage.AcquireMessage()
+	msg.InflightDirection = 1
+	msg.InflightState = 1
+	msg.Reset()
+	require.Zero(t, msg.InflightDirection)
+	require.Zero(t, msg.InflightState)
+	storage.ReleaseMessage(msg)
+
+	reused := storage.AcquireMessage()
+	t.Cleanup(func() { storage.ReleaseMessage(reused) })
+	require.Zero(t, reused.InflightDirection)
+	require.Zero(t, reused.InflightState)
+}


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?
This is an enhancement.
<!--
This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?
A client reconnecting with the same client ID and clean_session=false while its previous connection was still attached left two runSession goroutines sharing one Session. When the superseded goroutine's read finally errored (or its keep-alive expired), it called Disconnect and closed s.conn — which by then was the *new* connection. The client saw "connection closed by peer abruptly" and entered a reconnect loop.

On LAN the old socket's FIN was processed before the reconnect landed, so the stale goroutine exited first and the bug stayed hidden. Over high-latency links the reconnect arrived before the old FIN, exposing it (absmach/propeller#241).

Add a connection generation (epoch) to Session:

- Connect now closes any attached connection (local takeover per MQTT-3.1.4-2), bumps the epoch, and returns it.
- DisconnectIf(graceful, epoch) tears down only if the epoch still matches the current generation, so a stale goroutine becomes a no-op regardless of FIN timing.
- runSession threads its epoch and reads its own captured connection rather than s.conn, so a superseded goroutine never touches the new socket and only ever errors out on its own closed one.

Covered by deterministic session-level tests and an end-to-end delayed-FIN reconnect test through the broker; both fail without the epoch guard and pass with it under -race.

## Which issue(s) does this PR fix/relate to?
<!--
- Related Issue #
- Resolves #
-->
Should resolve https://github.com/absmach/propeller/issues/241.


## Have you included tests for your changes?
Yes.

## Did you document any new/modified features?
N/A

### Notes
N/A
