### PR TITLE
NOISSUE - Add v3 and v5 WebSocket listeners

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -697,6 +697,8 @@ func main() {
 		name string
 		cfg  config.WSListenerConfig
 	}{
+		{name: "v3", cfg: cfg.Server.WebSocket.V3},
+		{name: "v5", cfg: cfg.Server.WebSocket.V5},
 		{name: listenerTLS, cfg: cfg.Server.WebSocket.TLS},
 		{name: listenerMTLS, cfg: cfg.Server.WebSocket.MTLS},
 	}


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?

This is a refactor because it ensures WebSocket v3 and v5 listeners are registered in `wsSlots`, matching the existing pattern in `tcpSlots`.


## What does this do?

Adds `v3` and `v5` entries to the `wsSlots` slice in `cmd/main.go` so that WebSocket listeners for MQTT v3 and v5 protocol versions are started on their configured ports (defaults `:8083`, `:8084`).


## Which issue(s) does this PR fix/relate to?

N/A

## Have you included tests for your changes?

N/A

## Did you document any new/modified features?

N/A

### Notes

N/A
