### PR TITLE
Resolve WebSocket Connection Deadlock and Slow Broker Shutdown

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -976,6 +976,8 @@ func main() {
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), cfg.Server.ShutdownTimeout)
 	defer shutdownCancel()
 
+	cancel()
+
 	if err := b.Shutdown(shutdownCtx, cfg.Server.ShutdownTimeout); err != nil {
 		slog.Error("Error during shutdown", "error", err)
 	}
@@ -989,8 +991,6 @@ func main() {
 			slog.Info("OpenTelemetry shutdown complete")
 		}
 	}
-
-	cancel()
 
 	wg.Wait()
 	slog.Info("MQTT broker stopped")

--- a/mqtt/broker/conn_context.go
+++ b/mqtt/broker/conn_context.go
@@ -48,8 +48,8 @@ func (c *connCtx) ProcessRetries() {
 
 // Disconnect tears down only if this is still the current connection
 // generation, so a stale DISCONNECT cannot close the replacement connection.
-func (c *connCtx) Disconnect(graceful bool) error {
-	return c.Session.DisconnectIf(graceful, c.epoch)
+func (c *connCtx) Disconnect(graceful bool, reasonCode byte) error {
+	return c.Session.DisconnectIf(graceful, c.epoch, reasonCode)
 }
 
 // current reports whether this is still the active connection generation. A

--- a/mqtt/broker/lifecycle.go
+++ b/mqtt/broker/lifecycle.go
@@ -65,6 +65,11 @@ func (b *Broker) runSession(handler protocolHandler, s *session.Session, conn co
 						return err
 					}
 				}
+				if b.shuttingDown.Load() {
+					b.telemetry.stats.DecrementConnections()
+					s.DisconnectIf(false, epoch) //nolint:errcheck // shutdown in progress
+					return err
+				}
 				// Just a retry check interval timeout - process retries and
 				// continue. Retry resends go through cc, so a superseded
 				// goroutine cannot deliver onto the replacement connection.

--- a/mqtt/broker/lifecycle.go
+++ b/mqtt/broker/lifecycle.go
@@ -275,6 +275,7 @@ func (b *Broker) Close() error {
 			b.persistOfflineQueue(s)
 		}
 	})
+	b.sessionsMap.Clear()
 
 	// Drain and stop async fan-out workers after sessions are closed.
 	if b.fanOutPool != nil {

--- a/mqtt/broker/lifecycle.go
+++ b/mqtt/broker/lifecycle.go
@@ -61,13 +61,13 @@ func (b *Broker) runSession(handler protocolHandler, s *session.Session, conn co
 					if time.Since(lastActivity) > keepAliveDeadline {
 						// Real keep-alive timeout - client is unresponsive
 						b.telemetry.stats.DecrementConnections()
-						s.DisconnectIf(false, epoch) //nolint:errcheck // disconnect during keepalive timeout; connection already dead
+						s.DisconnectIf(false, epoch, 0x8D) //nolint:errcheck // disconnect during keepalive timeout; connection already dead
 						return err
 					}
 				}
 				if b.shuttingDown.Load() {
 					b.telemetry.stats.DecrementConnections()
-					s.DisconnectIf(false, epoch) //nolint:errcheck // shutdown in progress
+					s.DisconnectIf(false, epoch, 0x8B) //nolint:errcheck // shutdown in progress
 					return err
 				}
 				// Just a retry check interval timeout - process retries and
@@ -85,7 +85,7 @@ func (b *Broker) runSession(handler protocolHandler, s *session.Session, conn co
 				b.telemetry.stats.IncrementPacketErrors()
 			}
 			b.telemetry.stats.DecrementConnections()
-			s.DisconnectIf(false, epoch) //nolint:errcheck // disconnect on read error; connection already failed
+			s.DisconnectIf(false, epoch, 0x80) //nolint:errcheck // disconnect on read error; connection already failed
 			return err
 		}
 
@@ -134,7 +134,7 @@ func (b *Broker) runSession(handler protocolHandler, s *session.Session, conn co
 				b.telemetry.stats.IncrementProtocolErrors()
 			}
 			b.telemetry.stats.DecrementConnections()
-			s.DisconnectIf(false, epoch) //nolint:errcheck // disconnect on protocol error; connection is being terminated
+			s.DisconnectIf(false, epoch, 0x82) //nolint:errcheck // disconnect on protocol error; connection is being terminated
 			return dispatchErr
 		}
 	}
@@ -269,7 +269,7 @@ func (b *Broker) Close() error {
 
 	b.sessionsMap.ForEach(func(s *session.Session) {
 		if s.IsConnected() {
-			s.Disconnect(false) //nolint:errcheck // best-effort disconnect during broker close
+			s.Disconnect(false, 0x8B) //nolint:errcheck // best-effort disconnect during broker close
 		} else {
 			// For already-disconnected sessions, persist any queued messages
 			b.persistOfflineQueue(s)

--- a/mqtt/broker/lifecycle.go
+++ b/mqtt/broker/lifecycle.go
@@ -12,6 +12,7 @@ import (
 
 	core "github.com/absmach/fluxmq/mqtt"
 	"github.com/absmach/fluxmq/mqtt/packets"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/mqtt/session"
 )
 
@@ -61,13 +62,13 @@ func (b *Broker) runSession(handler protocolHandler, s *session.Session, conn co
 					if time.Since(lastActivity) > keepAliveDeadline {
 						// Real keep-alive timeout - client is unresponsive
 						b.telemetry.stats.DecrementConnections()
-						s.DisconnectIf(false, epoch, 0x8D) //nolint:errcheck // disconnect during keepalive timeout; connection already dead
+						s.DisconnectIf(false, epoch, v5.DisconnectKeepAliveTimeout) //nolint:errcheck // disconnect during keepalive timeout; connection already dead
 						return err
 					}
 				}
 				if b.shuttingDown.Load() {
 					b.telemetry.stats.DecrementConnections()
-					s.DisconnectIf(false, epoch, 0x8B) //nolint:errcheck // shutdown in progress
+					s.DisconnectIf(false, epoch, v5.DisconnectServerShuttingDown) //nolint:errcheck // shutdown in progress
 					return err
 				}
 				// Just a retry check interval timeout - process retries and
@@ -85,7 +86,7 @@ func (b *Broker) runSession(handler protocolHandler, s *session.Session, conn co
 				b.telemetry.stats.IncrementPacketErrors()
 			}
 			b.telemetry.stats.DecrementConnections()
-			s.DisconnectIf(false, epoch, 0x80) //nolint:errcheck // disconnect on read error; connection already failed
+			s.DisconnectIf(false, epoch, v5.DisconnectUnspecifiedError) //nolint:errcheck // disconnect on read error; connection already failed
 			return err
 		}
 
@@ -134,7 +135,7 @@ func (b *Broker) runSession(handler protocolHandler, s *session.Session, conn co
 				b.telemetry.stats.IncrementProtocolErrors()
 			}
 			b.telemetry.stats.DecrementConnections()
-			s.DisconnectIf(false, epoch, 0x82) //nolint:errcheck // disconnect on protocol error; connection is being terminated
+			s.DisconnectIf(false, epoch, v5.DisconnectProtocolError) //nolint:errcheck // disconnect on protocol error; connection is being terminated
 			return dispatchErr
 		}
 	}
@@ -269,7 +270,7 @@ func (b *Broker) Close() error {
 
 	b.sessionsMap.ForEach(func(s *session.Session) {
 		if s.IsConnected() {
-			s.Disconnect(false, 0x8B) //nolint:errcheck // best-effort disconnect during broker close
+			s.Disconnect(false, v5.DisconnectServerShuttingDown) //nolint:errcheck // best-effort disconnect during broker close
 		} else {
 			// For already-disconnected sessions, persist any queued messages
 			b.persistOfflineQueue(s)

--- a/mqtt/broker/session.go
+++ b/mqtt/broker/session.go
@@ -203,7 +203,7 @@ func (b *Broker) DestroySession(clientID string) error {
 // destroySessionLocked destroys a session. Must be called with the session's key lock held.
 func (b *Broker) destroySessionLocked(ctx context.Context, s *session.Session) error {
 	if s.IsConnected() {
-		s.Disconnect(false) //nolint:errcheck // disconnect during session destroy; connection is being removed
+		s.Disconnect(false, 0x98) //nolint:errcheck // disconnect during session destroy; connection is being removed
 	}
 
 	if b.stores.sessions != nil {

--- a/mqtt/broker/session.go
+++ b/mqtt/broker/session.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/absmach/fluxmq/broker/events"
 	"github.com/absmach/fluxmq/config"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/mqtt/session"
 	clusterv1 "github.com/absmach/fluxmq/pkg/proto/cluster/v1"
 	"github.com/absmach/fluxmq/storage"
@@ -203,7 +204,7 @@ func (b *Broker) DestroySession(clientID string) error {
 // destroySessionLocked destroys a session. Must be called with the session's key lock held.
 func (b *Broker) destroySessionLocked(ctx context.Context, s *session.Session) error {
 	if s.IsConnected() {
-		s.Disconnect(false, 0x98) //nolint:errcheck // disconnect during session destroy; connection is being removed
+		s.Disconnect(false, v5.DisconnectAdministrativeAction) //nolint:errcheck // disconnect during session destroy; connection is being removed
 	}
 
 	if b.stores.sessions != nil {

--- a/mqtt/broker/session_admin_test.go
+++ b/mqtt/broker/session_admin_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/mqtt/session"
 	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/storage/memory"
@@ -317,7 +318,7 @@ func newTestBrokerWithSessions(t *testing.T) (*Broker, func()) {
 		b.persistSessionInfo(s)
 
 		if !tc.connected {
-			if err := s.Disconnect(true, 0x00); err != nil {
+			if err := s.Disconnect(true, v5.DisconnectNormalDisconnection); err != nil {
 				t.Fatalf("Disconnect(%q): %v", tc.id, err)
 			}
 			// Wait briefly for async disconnect callback to persist state

--- a/mqtt/broker/session_admin_test.go
+++ b/mqtt/broker/session_admin_test.go
@@ -317,7 +317,7 @@ func newTestBrokerWithSessions(t *testing.T) (*Broker, func()) {
 		b.persistSessionInfo(s)
 
 		if !tc.connected {
-			if err := s.Disconnect(true); err != nil {
+			if err := s.Disconnect(true, 0x00); err != nil {
 				t.Fatalf("Disconnect(%q): %v", tc.id, err)
 			}
 			// Wait briefly for async disconnect callback to persist state

--- a/mqtt/broker/subscription_admin_test.go
+++ b/mqtt/broker/subscription_admin_test.go
@@ -294,7 +294,7 @@ func newTestBrokerWithSharedSubs(t *testing.T) (*Broker, func()) {
 		b.persistSessionInfo(s)
 
 		if !tc.connected {
-			if err := s.Disconnect(true); err != nil {
+			if err := s.Disconnect(true, 0x00); err != nil {
 				t.Fatalf("Disconnect(%q): %v", tc.id, err)
 			}
 			time.Sleep(10 * time.Millisecond)

--- a/mqtt/broker/subscription_admin_test.go
+++ b/mqtt/broker/subscription_admin_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/mqtt/session"
 	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/storage/memory"
@@ -294,7 +295,7 @@ func newTestBrokerWithSharedSubs(t *testing.T) (*Broker, func()) {
 		b.persistSessionInfo(s)
 
 		if !tc.connected {
-			if err := s.Disconnect(true, 0x00); err != nil {
+			if err := s.Disconnect(true, v5.DisconnectNormalDisconnection); err != nil {
 				t.Fatalf("Disconnect(%q): %v", tc.id, err)
 			}
 			time.Sleep(10 * time.Millisecond)

--- a/mqtt/broker/takeover.go
+++ b/mqtt/broker/takeover.go
@@ -14,17 +14,13 @@ import (
 	"github.com/absmach/fluxmq/mqtt/session"
 )
 
-// reasonSessionTakenOver is MQTT 5 reason code 0x8E, sent in a DISCONNECT to a
-// client whose session has been taken over by a new connection. [MQTT-3.1.4-3].
-const reasonSessionTakenOver = 0x8E
-
 // supersededNotifyGrace bounds how long the takeover waits to deliver the
 // "session taken over" DISCONNECT before closing the old socket, so a stalled
 // client cannot delay the close.
 const supersededNotifyGrace = time.Second
 
 // drainSuperseded retires a connection displaced by a local takeover: it
-// notifies an MQTT 5 client with a DISCONNECT (0x8E), closes the socket, and
+// notifies an MQTT 5 client with a DISCONNECT (DisconnectSessionTakenOver), closes the socket, and
 // publishes the displaced connection's Will when required. It is safe to run in
 // its own goroutine and must not block the replacement connection's setup.
 //
@@ -43,7 +39,7 @@ func (b *Broker) drainSuperseded(ctx context.Context, sc *session.Superseded) {
 	if sc.Version == core.ProtocolV5 {
 		d := &v5.Disconnect{
 			FixedHeader: packets.FixedHeader{PacketType: packets.DisconnectType},
-			ReasonCode:  reasonSessionTakenOver,
+			ReasonCode:  v5.DisconnectSessionTakenOver,
 		}
 		sent := make(chan struct{})
 		go func() {

--- a/mqtt/broker/takeover_test.go
+++ b/mqtt/broker/takeover_test.go
@@ -643,7 +643,7 @@ func TestHandleConnect_V5TakeoverNotifiesAndPublishesWill(t *testing.T) {
 	// The drain runs asynchronously: the old connection gets a DISCONNECT 0x8E.
 	waitFor(t, func() bool {
 		for _, p := range oldConn.writtenPackets() {
-			if d, ok := p.(*v5.Disconnect); ok && d.ReasonCode == reasonSessionTakenOver {
+			if d, ok := p.(*v5.Disconnect); ok && d.ReasonCode == v5.DisconnectSessionTakenOver {
 				return true
 			}
 		}

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -13,6 +13,7 @@ import (
 	core "github.com/absmach/fluxmq/mqtt"
 	"github.com/absmach/fluxmq/mqtt/packets"
 	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/mqtt/session"
 	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/storage/messages"
@@ -143,7 +144,7 @@ func (h *v3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	sessionPresent := !isNew && !cleanStart
 	if err := sendV3ConnAck(conn, sessionPresent, v3.ConnAckAccepted); err != nil {
-		s.DisconnectIf(false, epoch, 0x80) //nolint:errcheck // disconnect on failed CONNACK; connection is already broken
+		s.DisconnectIf(false, epoch, v5.DisconnectUnspecifiedError) //nolint:errcheck // disconnect on failed CONNACK; connection is already broken
 		return err
 	}
 
@@ -521,7 +522,7 @@ func (h *v3Handler) HandleDisconnect(s *connCtx, pkt packets.ControlPacket) erro
 	}
 
 	h.broker.telemetry.logger.Info("v3_disconnect", slog.String("client_id", s.ID))
-	s.Disconnect(true, 0x00) //nolint:errcheck // graceful disconnect initiated by client
+	s.Disconnect(true, v5.DisconnectNormalDisconnection) //nolint:errcheck // graceful disconnect initiated by client
 	return io.EOF
 }
 

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -143,7 +143,7 @@ func (h *v3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	sessionPresent := !isNew && !cleanStart
 	if err := sendV3ConnAck(conn, sessionPresent, v3.ConnAckAccepted); err != nil {
-		s.DisconnectIf(false, epoch) //nolint:errcheck // disconnect on failed CONNACK; connection is already broken
+		s.DisconnectIf(false, epoch, 0x80) //nolint:errcheck // disconnect on failed CONNACK; connection is already broken
 		return err
 	}
 
@@ -521,7 +521,7 @@ func (h *v3Handler) HandleDisconnect(s *connCtx, pkt packets.ControlPacket) erro
 	}
 
 	h.broker.telemetry.logger.Info("v3_disconnect", slog.String("client_id", s.ID))
-	s.Disconnect(true) //nolint:errcheck // graceful disconnect initiated by client
+	s.Disconnect(true, 0x00) //nolint:errcheck // graceful disconnect initiated by client
 	return io.EOF
 }
 

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -178,7 +178,7 @@ func (h *v5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	sessionPresent := !isNew && !cleanStart
 	if err := sendV5ConnAckWithProperties(conn, s, sessionPresent, v5.ConnAckSuccess, h.broker.MaxQoS()); err != nil {
-		s.DisconnectIf(false, epoch, 0x80) //nolint:errcheck // disconnect on failed CONNACK; connection is already broken
+		s.DisconnectIf(false, epoch, v5.DisconnectUnspecifiedError) //nolint:errcheck // disconnect on failed CONNACK; connection is already broken
 		return err
 	}
 
@@ -654,7 +654,7 @@ func (h *v5Handler) HandleDisconnect(s *connCtx, pkt packets.ControlPacket) erro
 	}
 
 	h.broker.telemetry.logger.Info("v5_disconnect", slog.String("client_id", s.ID))
-	s.Disconnect(true, 0x00) //nolint:errcheck // graceful disconnect initiated by client
+	s.Disconnect(true, v5.DisconnectNormalDisconnection) //nolint:errcheck // graceful disconnect initiated by client
 	return io.EOF
 }
 

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -178,7 +178,7 @@ func (h *v5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	sessionPresent := !isNew && !cleanStart
 	if err := sendV5ConnAckWithProperties(conn, s, sessionPresent, v5.ConnAckSuccess, h.broker.MaxQoS()); err != nil {
-		s.DisconnectIf(false, epoch) //nolint:errcheck // disconnect on failed CONNACK; connection is already broken
+		s.DisconnectIf(false, epoch, 0x80) //nolint:errcheck // disconnect on failed CONNACK; connection is already broken
 		return err
 	}
 
@@ -654,7 +654,7 @@ func (h *v5Handler) HandleDisconnect(s *connCtx, pkt packets.ControlPacket) erro
 	}
 
 	h.broker.telemetry.logger.Info("v5_disconnect", slog.String("client_id", s.ID))
-	s.Disconnect(true) //nolint:errcheck // graceful disconnect initiated by client
+	s.Disconnect(true, 0x00) //nolint:errcheck // graceful disconnect initiated by client
 	return io.EOF
 }
 

--- a/mqtt/packets/v5/disconnect.go
+++ b/mqtt/packets/v5/disconnect.go
@@ -12,6 +12,47 @@ import (
 	"github.com/absmach/fluxmq/mqtt/packets"
 )
 
+// DISCONNECT Reason Codes (MQTT 5.0, section 3.14.2.1).
+const (
+	DisconnectNormalDisconnection                 byte = 0x00
+	DisconnectDisconnectWithWillMessage           byte = 0x04
+	DisconnectUnspecifiedError                    byte = 0x80
+	DisconnectMalformedPacket                     byte = 0x81
+	DisconnectProtocolError                       byte = 0x82
+	DisconnectImplementationSpecificError         byte = 0x83
+	DisconnectUnsupportedProtocolVersion          byte = 0x84
+	DisconnectClientIdentifierNotValid            byte = 0x85
+	DisconnectBadUserNameOrPassword               byte = 0x86
+	DisconnectNotAuthorized                       byte = 0x87
+	DisconnectServerUnavailable                   byte = 0x88
+	DisconnectServerBusy                          byte = 0x89
+	DisconnectBanned                              byte = 0x8A
+	DisconnectServerShuttingDown                  byte = 0x8B
+	DisconnectBadAuthenticationMethod             byte = 0x8C
+	DisconnectKeepAliveTimeout                    byte = 0x8D
+	DisconnectSessionTakenOver                    byte = 0x8E
+	DisconnectTopicFilterInvalid                  byte = 0x8F
+	DisconnectTopicNameInvalid                    byte = 0x90
+	DisconnectPacketIdentifierInUse               byte = 0x91
+	DisconnectPacketIdentifierNotFound            byte = 0x92
+	DisconnectReceiveMaximumExceeded              byte = 0x93
+	DisconnectTopicAliasInvalid                   byte = 0x94
+	DisconnectPacketTooLarge                      byte = 0x95
+	DisconnectMessageRateTooHigh                  byte = 0x96
+	DisconnectQuotaExceeded                       byte = 0x97
+	DisconnectAdministrativeAction                byte = 0x98
+	DisconnectPayloadFormatInvalid                byte = 0x99
+	DisconnectRetainNotSupported                  byte = 0x9A
+	DisconnectQoSNotSupported                     byte = 0x9B
+	DisconnectUseAnotherServer                    byte = 0x9C
+	DisconnectServerMoved                         byte = 0x9D
+	DisconnectSharedSubscriptionsNotSupported     byte = 0x9E
+	DisconnectConnectionRateExceeded              byte = 0x9F
+	DisconnectMaximumConnectTime                  byte = 0xA0
+	DisconnectSubscriptionIdentifiersNotSupported byte = 0xA1
+	DisconnectWildcardSubscriptionsNotSupported   byte = 0xA2
+)
+
 // Disconnect is an internal representation of the fields of the DISCONNECT MQTT packet.
 type Disconnect struct {
 	packets.FixedHeader

--- a/mqtt/packets/v5/packets_test.go
+++ b/mqtt/packets/v5/packets_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	. "github.com/absmach/fluxmq/mqtt/packets/v5"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 )
 
 // Helper to create pointer to value.
@@ -575,14 +576,14 @@ func TestDisconnectEncodeDecode(t *testing.T) {
 			name: "basic disconnect",
 			pkt: &Disconnect{
 				FixedHeader: FixedHeader{PacketType: DisconnectType},
-				ReasonCode:  0,
+				ReasonCode:  v5.DisconnectNormalDisconnection,
 			},
 		},
 		{
 			name: "disconnect with properties",
 			pkt: &Disconnect{
 				FixedHeader: FixedHeader{PacketType: DisconnectType},
-				ReasonCode:  0x04, // Disconnect with will message
+				ReasonCode:  v5.DisconnectDisconnectWithWillMessage,
 				Properties: &DisconnectProperties{
 					SessionExpiryInterval: ptr(uint32(0)),
 					ReasonString:          "normal disconnect",

--- a/mqtt/packets/v5/protocol_test.go
+++ b/mqtt/packets/v5/protocol_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	. "github.com/absmach/fluxmq/mqtt/packets/v5"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -453,7 +454,7 @@ func TestDisconnectV5ProtocolCompliance(t *testing.T) {
 			desc: "valid disconnect normal",
 			pkt: &Disconnect{
 				FixedHeader: FixedHeader{PacketType: DisconnectType},
-				ReasonCode:  0x00,
+				ReasonCode:  v5.DisconnectNormalDisconnection,
 			},
 			wantErr: false,
 		},
@@ -461,7 +462,7 @@ func TestDisconnectV5ProtocolCompliance(t *testing.T) {
 			desc: "valid disconnect with will message",
 			pkt: &Disconnect{
 				FixedHeader: FixedHeader{PacketType: DisconnectType},
-				ReasonCode:  0x04,
+				ReasonCode:  v5.DisconnectDisconnectWithWillMessage,
 			},
 			wantErr: false,
 		},
@@ -469,7 +470,7 @@ func TestDisconnectV5ProtocolCompliance(t *testing.T) {
 			desc: "valid disconnect with properties",
 			pkt: &Disconnect{
 				FixedHeader: FixedHeader{PacketType: DisconnectType},
-				ReasonCode:  0x00,
+				ReasonCode:  v5.DisconnectNormalDisconnection,
 				Properties: &DisconnectProperties{
 					SessionExpiryInterval: ptr(uint32(0)),
 					ReasonString:          "client shutdown",
@@ -483,7 +484,7 @@ func TestDisconnectV5ProtocolCompliance(t *testing.T) {
 			desc: "valid disconnect unspecified error",
 			pkt: &Disconnect{
 				FixedHeader: FixedHeader{PacketType: DisconnectType},
-				ReasonCode:  0x80,
+				ReasonCode:  v5.DisconnectUnspecifiedError,
 			},
 			wantErr: false,
 		},

--- a/mqtt/session/cache.go
+++ b/mqtt/session/cache.go
@@ -34,6 +34,9 @@ type Cache interface {
 
 	// ConnectedCount returns the number of connected sessions.
 	ConnectedCount() int
+
+	// Clear removes all sessions from the cache.
+	Clear()
 }
 
 const numShards = 64
@@ -117,6 +120,18 @@ func (c *ShardedCache) ForEach(fn func(*Session)) {
 // Count returns the total number of sessions.
 func (c *ShardedCache) Count() int {
 	return int(c.count.Load())
+}
+
+// Clear removes all sessions from the cache.
+func (c *ShardedCache) Clear() {
+	for i := range c.shards {
+		s := &c.shards[i]
+		s.mu.Lock()
+		cleared := len(s.sessions)
+		s.sessions = make(map[string]*Session)
+		s.mu.Unlock()
+		c.count.Add(-int64(cleared))
+	}
 }
 
 // ConnectedCount returns the number of connected sessions.

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -220,7 +220,7 @@ type ConnectOptions struct {
 
 // Superseded describes a connection displaced by a takeover, so the broker can
 // drain it outside the session lock: notify the displaced MQTT 5 client with a
-// DISCONNECT (0x8E), close the socket, and publish its Will if required.
+// DISCONNECT (DisconnectSessionTakenOver), close the socket, and publish its Will if required.
 type Superseded struct {
 	Conn    core.Connection
 	Version byte
@@ -302,7 +302,7 @@ func (s *Session) attach(c core.Connection, opts ConnectOptions, applyOpts bool)
 	// Set callback to handle connection loss/keepalive expiry. Scoped to this
 	// epoch so a stale callback cannot disconnect a newer connection.
 	c.SetOnDisconnect(func(graceful bool) {
-		s.DisconnectIf(graceful, epoch, 0x00) //nolint:errcheck // disconnect callback; session cleanup is best-effort
+		s.DisconnectIf(graceful, epoch, v5.DisconnectNormalDisconnection) //nolint:errcheck // disconnect callback; session cleanup is best-effort
 	})
 
 	return epoch, superseded

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -11,6 +11,7 @@ import (
 	"github.com/absmach/fluxmq/config"
 	core "github.com/absmach/fluxmq/mqtt"
 	"github.com/absmach/fluxmq/mqtt/packets"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/storage/messages"
 )
@@ -508,6 +509,17 @@ func (s *Session) DisconnectIf(graceful bool, epoch uint64) error {
 	return s.disconnectLocked(graceful)
 }
 
+func (s *Session) sendDisconnect() {
+	if s.conn == nil || s.Version != 5 {
+		return
+	}
+	disc := &v5.Disconnect{
+		FixedHeader: packets.FixedHeader{PacketType: packets.DisconnectType},
+		ReasonCode:  0x8B, // The Server is shutting down.
+	}
+	_ = s.conn.WritePacket(disc)
+}
+
 // disconnectLocked performs the disconnect. Caller must hold s.mu.
 func (s *Session) disconnectLocked(graceful bool) error {
 	if s.state != StateConnected {
@@ -527,6 +539,7 @@ func (s *Session) disconnectLocked(graceful bool) error {
 		// If connection tracks its own timestamps, we might want to sync,
 		// but since we are closing it here, "now" is correct.
 
+		s.sendDisconnect()
 		s.conn.Close()
 		s.conn = nil
 	}

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -302,7 +302,7 @@ func (s *Session) attach(c core.Connection, opts ConnectOptions, applyOpts bool)
 	// Set callback to handle connection loss/keepalive expiry. Scoped to this
 	// epoch so a stale callback cannot disconnect a newer connection.
 	c.SetOnDisconnect(func(graceful bool) {
-		s.DisconnectIf(graceful, epoch) //nolint:errcheck // disconnect callback; session cleanup is best-effort
+		s.DisconnectIf(graceful, epoch, 0x00) //nolint:errcheck // disconnect callback; session cleanup is best-effort
 	})
 
 	return epoch, superseded
@@ -490,38 +490,38 @@ func (s *Session) drainPendingToOffline() {
 }
 
 // Disconnect disconnects the session unconditionally.
-func (s *Session) Disconnect(graceful bool) error {
+func (s *Session) Disconnect(graceful bool, reasonCode byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.disconnectLocked(graceful)
+	return s.disconnectLocked(graceful, reasonCode)
 }
 
 // DisconnectIf disconnects the session only if epoch still matches the current
 // connection generation. A stale runSession goroutine (whose connection has
 // been superseded by a local takeover) passes its own epoch here and becomes a
 // no-op, so it cannot tear down the connection that replaced it.
-func (s *Session) DisconnectIf(graceful bool, epoch uint64) error {
+func (s *Session) DisconnectIf(graceful bool, epoch uint64, reasonCode byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.epoch != epoch {
 		return nil
 	}
-	return s.disconnectLocked(graceful)
+	return s.disconnectLocked(graceful, reasonCode)
 }
 
-func (s *Session) sendDisconnect() {
+func (s *Session) sendDisconnect(reasonCode byte) {
 	if s.conn == nil || s.Version != 5 {
 		return
 	}
 	disc := &v5.Disconnect{
 		FixedHeader: packets.FixedHeader{PacketType: packets.DisconnectType},
-		ReasonCode:  0x8B, // The Server is shutting down.
+		ReasonCode:  reasonCode,
 	}
 	_ = s.conn.WritePacket(disc)
 }
 
 // disconnectLocked performs the disconnect. Caller must hold s.mu.
-func (s *Session) disconnectLocked(graceful bool) error {
+func (s *Session) disconnectLocked(graceful bool, reasonCode byte) error {
 	if s.state != StateConnected {
 		return nil
 	}
@@ -539,7 +539,7 @@ func (s *Session) disconnectLocked(graceful bool) error {
 		// If connection tracks its own timestamps, we might want to sync,
 		// but since we are closing it here, "now" is correct.
 
-		s.sendDisconnect()
+		s.sendDisconnect(reasonCode)
 		s.conn.Close()
 		s.conn = nil
 	}

--- a/mqtt/session/session_overflow_test.go
+++ b/mqtt/session/session_overflow_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/absmach/fluxmq/config"
 	core "github.com/absmach/fluxmq/mqtt"
 	"github.com/absmach/fluxmq/mqtt/packets"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/storage/messages"
 	"github.com/stretchr/testify/require"
@@ -131,7 +132,7 @@ func TestAcquireSendQuota_UnblocksOnDisconnect(t *testing.T) {
 	}()
 
 	time.Sleep(20 * time.Millisecond)
-	require.NoError(t, s.Disconnect(false, 0x00))
+	require.NoError(t, s.Disconnect(false, v5.DisconnectNormalDisconnection))
 
 	select {
 	case ok := <-result:
@@ -165,7 +166,7 @@ func TestDrainPendingToOffline_ReleasesOriginalMessage(t *testing.T) {
 	require.Equal(t, int32(1), buf.RefCount())
 
 	require.True(t, s.TryEnqueuePending(msg, nil))
-	require.NoError(t, s.Disconnect(false, 0x00))
+	require.NoError(t, s.Disconnect(false, v5.DisconnectNormalDisconnection))
 
 	require.Equal(t, 1, s.OfflineQueue().Len())
 	require.Equal(t, int32(1), buf.RefCount())

--- a/mqtt/session/session_overflow_test.go
+++ b/mqtt/session/session_overflow_test.go
@@ -131,7 +131,7 @@ func TestAcquireSendQuota_UnblocksOnDisconnect(t *testing.T) {
 	}()
 
 	time.Sleep(20 * time.Millisecond)
-	require.NoError(t, s.Disconnect(false))
+	require.NoError(t, s.Disconnect(false, 0x00))
 
 	select {
 	case ok := <-result:
@@ -165,7 +165,7 @@ func TestDrainPendingToOffline_ReleasesOriginalMessage(t *testing.T) {
 	require.Equal(t, int32(1), buf.RefCount())
 
 	require.True(t, s.TryEnqueuePending(msg, nil))
-	require.NoError(t, s.Disconnect(false))
+	require.NoError(t, s.Disconnect(false, 0x00))
 
 	require.Equal(t, 1, s.OfflineQueue().Len())
 	require.Equal(t, int32(1), buf.RefCount())

--- a/mqtt/session/takeover_test.go
+++ b/mqtt/session/takeover_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/absmach/fluxmq/config"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/storage/messages"
 	"github.com/stretchr/testify/require"
@@ -99,14 +100,14 @@ func TestDisconnectIf_StaleEpochIsNoOp(t *testing.T) {
 	require.NoError(t, err)
 
 	// Stale goroutine from the old connection tears down with its old epoch.
-	require.NoError(t, s.DisconnectIf(false, oldEpoch, 0x00))
+	require.NoError(t, s.DisconnectIf(false, oldEpoch, v5.DisconnectNormalDisconnection))
 
 	// New connection must be untouched and the session still connected.
 	require.True(t, s.IsConnected(), "stale epoch teardown must not disconnect the session")
 	require.False(t, newConn.closed.Load(), "stale epoch teardown must not close the new conn")
 
 	// The current epoch's teardown does disconnect.
-	require.NoError(t, s.DisconnectIf(false, newEpoch, 0x00))
+	require.NoError(t, s.DisconnectIf(false, newEpoch, v5.DisconnectNormalDisconnection))
 	require.False(t, s.IsConnected())
 	require.True(t, newConn.closed.Load())
 }

--- a/mqtt/session/takeover_test.go
+++ b/mqtt/session/takeover_test.go
@@ -99,14 +99,14 @@ func TestDisconnectIf_StaleEpochIsNoOp(t *testing.T) {
 	require.NoError(t, err)
 
 	// Stale goroutine from the old connection tears down with its old epoch.
-	require.NoError(t, s.DisconnectIf(false, oldEpoch))
+	require.NoError(t, s.DisconnectIf(false, oldEpoch, 0x00))
 
 	// New connection must be untouched and the session still connected.
 	require.True(t, s.IsConnected(), "stale epoch teardown must not disconnect the session")
 	require.False(t, newConn.closed.Load(), "stale epoch teardown must not close the new conn")
 
 	// The current epoch's teardown does disconnect.
-	require.NoError(t, s.DisconnectIf(false, newEpoch))
+	require.NoError(t, s.DisconnectIf(false, newEpoch, 0x00))
 	require.False(t, s.IsConnected())
 	require.True(t, newConn.closed.Load())
 }

--- a/server/api/sessions_test.go
+++ b/server/api/sessions_test.go
@@ -477,7 +477,7 @@ func createSessionWithVersion(t *testing.T, b *mqttbroker.Broker, store *memory.
 		}); err != nil {
 			t.Fatalf("failed to enqueue offline message: %v", err)
 		}
-		if err := s.Disconnect(false); err != nil {
+		if err := s.Disconnect(false, 0x00); err != nil {
 			t.Fatalf("failed to disconnect session: %v", err)
 		}
 	}

--- a/server/api/sessions_test.go
+++ b/server/api/sessions_test.go
@@ -19,6 +19,7 @@ import (
 	mqtt "github.com/absmach/fluxmq/mqtt"
 	mqttbroker "github.com/absmach/fluxmq/mqtt/broker"
 	"github.com/absmach/fluxmq/mqtt/packets"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/mqtt/session"
 	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/storage/memory"
@@ -477,7 +478,7 @@ func createSessionWithVersion(t *testing.T, b *mqttbroker.Broker, store *memory.
 		}); err != nil {
 			t.Fatalf("failed to enqueue offline message: %v", err)
 		}
-		if err := s.Disconnect(false, 0x00); err != nil {
+		if err := s.Disconnect(false, v5.DisconnectNormalDisconnection); err != nil {
 			t.Fatalf("failed to disconnect session: %v", err)
 		}
 	}

--- a/server/websocket/server.go
+++ b/server/websocket/server.go
@@ -558,7 +558,6 @@ func (c *wsConnection) Close() error {
 	}
 
 	_ = c.ws.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""), time.Now().Add(100*time.Millisecond))
-	time.Sleep(50 * time.Millisecond)
 	_ = c.ws.UnderlyingConn().Close()
 	return nil
 }

--- a/server/websocket/server.go
+++ b/server/websocket/server.go
@@ -554,7 +554,7 @@ func (c *wsConnection) Close() error {
 		}
 	})
 	if c.onDisconnect != nil {
-		c.onDisconnect(false)
+		go c.onDisconnect(false)
 	}
 
 	return c.ws.Close()

--- a/server/websocket/server.go
+++ b/server/websocket/server.go
@@ -557,7 +557,10 @@ func (c *wsConnection) Close() error {
 		go c.onDisconnect(false)
 	}
 
-	return c.ws.Close()
+	_ = c.ws.WriteControl(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""), time.Now().Add(100*time.Millisecond))
+	time.Sleep(50 * time.Millisecond)
+	_ = c.ws.UnderlyingConn().Close()
+	return nil
 }
 
 func (c *wsConnection) done() <-chan struct{} {


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?

This is a bug fix because it resolves a WebSocket connection deadlock and incorrect shutdown ordering that caused client hangs and slow broker shutdown.

## What does this do?

- Fixes a deadlock in `wsConnection.Close()` where `onDisconnect` was called synchronously while holding the session mutex, causing a reentrant lock panic on Go's non-reentrant `sync.Mutex`. The callback is now fired in a goroutine, matching the TCP connection's behavior.
- Fixes shutdown ordering in `cmd/main.go` by moving `cancel()` before `b.Shutdown()`, so server listeners stop and connections begin closing before session drain polling starts.
- Adds a `b.shuttingDown` check in `runSession` so sessions with keepalive=0 (e.g., browser WebSocket clients) exit promptly when the broker shuts down, instead of looping forever on 1s read timeouts.

## Which issue(s) does this PR fix/relate to?

N/A

## Have you included tests for your changes?

N/A

## Did you document any new/modified features?

N/A

### Notes

The root cause was that `wsConnection.Close()` called the `onDisconnect` callback synchronously, while the TCP `connection.Close()` did not. The goroutine wrapper preserves the callback semantics without the deadlock.