### PR TITLE
Fix etcd watch gaps causing silent cluster state loss

### DIFF
--- a/cluster/etcd.go
+++ b/cluster/etcd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/absmach/fluxmq/broker/router"
 	clusterv1 "github.com/absmach/fluxmq/pkg/proto/cluster/v1"
 	"github.com/absmach/fluxmq/storage"
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 	"go.etcd.io/etcd/server/v3/embed"
@@ -573,9 +574,9 @@ func (c *EtcdCluster) loadRetainedCache() error {
 		return fmt.Errorf("failed to load retained messages: %w", err)
 	}
 
-	c.retainedCacheMu.Lock()
-	defer c.retainedCacheMu.Unlock()
-
+	// Rebuild from scratch so reloads after watch interruptions also evict
+	// entries whose delete events were missed.
+	fresh := make(map[string]*storage.Message, len(resp.Kvs))
 	for _, kv := range resp.Kvs {
 		var msg storage.Message
 		if err := json.Unmarshal(kv.Value, &msg); err != nil {
@@ -585,11 +586,15 @@ func (c *EtcdCluster) loadRetainedCache() error {
 
 		// Extract topic from key (remove prefix)
 		topic := strings.TrimPrefix(string(kv.Key), retainedPrefix)
-		c.retainedCache[topic] = &msg
+		fresh[topic] = &msg
 	}
-	c.retainedCacheRev = resp.Header.Revision
 
-	c.logger.Info("loaded retained messages into cache", slog.Int("count", len(c.retainedCache)))
+	c.retainedCacheMu.Lock()
+	c.retainedCache = fresh
+	c.retainedCacheRev = resp.Header.Revision
+	c.retainedCacheMu.Unlock()
+
+	c.logger.Info("loaded retained messages into cache", slog.Int("count", len(fresh)))
 	return nil
 }
 
@@ -867,7 +872,7 @@ func prefixWatchOpts(rev int64) []clientv3.OpOption {
 }
 
 func isLeaseNotFoundErr(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "requested lease not found")
+	return err != nil && errors.Is(rpctypes.Error(err), rpctypes.ErrLeaseNotFound)
 }
 
 func (c *EtcdCluster) putWithSessionLease(ctx context.Context, key, value string) error {

--- a/cluster/etcd.go
+++ b/cluster/etcd.go
@@ -450,6 +450,15 @@ func (c *EtcdCluster) Stop() error {
 	}
 	c.leaseMu.Unlock()
 
+	// Stop hybrid store watchers before closing the etcd client so they
+	// don't keep retrying against a closed client.
+	if c.hybridRetained != nil {
+		c.hybridRetained.Close() //nolint:errcheck // best-effort shutdown
+	}
+	if c.hybridWill != nil {
+		c.hybridWill.Close() //nolint:errcheck // best-effort shutdown
+	}
+
 	// Stop gRPC transport
 	if c.transport != nil {
 		c.transport.Stop() //nolint:errcheck // best-effort shutdown; transport is being discarded

--- a/cluster/etcd.go
+++ b/cluster/etcd.go
@@ -83,11 +83,14 @@ type EtcdCluster struct {
 
 	logger *slog.Logger
 
-	// Local subscription cache for fast topic matching
-	subCache   map[string]*storage.Subscription // key: clientID|filter
-	clientSubs map[string][]string              // clientID → []cacheKey (reverse index)
-	subTrie    *router.TrieRouter
-	subCacheMu sync.RWMutex
+	// Local subscription cache for fast topic matching.
+	// subCacheRev is the etcd revision the cache was loaded at; the watch
+	// resumes from it so no event is missed between load and watch.
+	subCache    map[string]*storage.Subscription // key: clientID|filter
+	clientSubs  map[string][]string              // clientID → []cacheKey (reverse index)
+	subTrie     *router.TrieRouter
+	subCacheRev int64
+	subCacheMu  sync.RWMutex
 
 	// Local session owner cache to avoid etcd roundtrips in RoutePublish.
 	// ownerCacheRev is the etcd revision the cache was loaded at; the owner
@@ -97,10 +100,12 @@ type EtcdCluster struct {
 	ownerCacheMu  sync.RWMutex
 
 	// Local queue consumer cache for fast queue delivery/routing lookups.
-	queueConsumersAll     map[string]*QueueConsumerInfo                       // key: queue|group|consumer
-	queueConsumersByQueue map[string]map[string]*QueueConsumerInfo            // queue -> key -> info
-	queueConsumersByGroup map[string]map[string]map[string]*QueueConsumerInfo // queue -> group -> key -> info
-	queueConsumersCacheMu sync.RWMutex
+	// queueConsumersCacheRev: see subCacheRev.
+	queueConsumersAll      map[string]*QueueConsumerInfo                       // key: queue|group|consumer
+	queueConsumersByQueue  map[string]map[string]*QueueConsumerInfo            // queue -> key -> info
+	queueConsumersByGroup  map[string]map[string]map[string]*QueueConsumerInfo // queue -> group -> key -> info
+	queueConsumersCacheRev int64
+	queueConsumersCacheMu  sync.RWMutex
 
 	routeBatchMaxSize      int
 	routeBatchMaxDelay     time.Duration
@@ -108,9 +113,11 @@ type EtcdCluster struct {
 	forwardBatcher         *nodeBatcher[*clusterv1.ForwardPublishRequest]
 	queueBatcher           *nodeBatcher[QueueDelivery]
 
-	// Local retained message cache for fast wildcard matching (deprecated, use hybridRetained)
-	retainedCache   map[string]*storage.Message // key: topic
-	retainedCacheMu sync.RWMutex
+	// Local retained message cache for fast wildcard matching (deprecated, use hybridRetained).
+	// retainedCacheRev: see subCacheRev.
+	retainedCache    map[string]*storage.Message // key: topic
+	retainedCacheRev int64
+	retainedCacheMu  sync.RWMutex
 
 	// Hybrid storage
 	localStore     storage.Store  // BadgerDB for local payload storage
@@ -580,6 +587,7 @@ func (c *EtcdCluster) loadRetainedCache() error {
 		topic := strings.TrimPrefix(string(kv.Key), retainedPrefix)
 		c.retainedCache[topic] = &msg
 	}
+	c.retainedCacheRev = resp.Header.Revision
 
 	c.logger.Info("loaded retained messages into cache", slog.Int("count", len(c.retainedCache)))
 	return nil
@@ -588,7 +596,10 @@ func (c *EtcdCluster) loadRetainedCache() error {
 // watchRetained watches etcd for retained message changes and updates the local cache.
 func (c *EtcdCluster) watchRetained() {
 	for {
-		watchCh := c.client.Watch(c.lifecycleCtx, retainedPrefix, clientv3.WithPrefix())
+		c.retainedCacheMu.RLock()
+		rev := c.retainedCacheRev
+		c.retainedCacheMu.RUnlock()
+		watchCh := c.client.Watch(c.lifecycleCtx, retainedPrefix, prefixWatchOpts(rev)...)
 
 		for {
 			select {
@@ -841,6 +852,18 @@ func (c *EtcdCluster) reregisterLeasedKeysLocked(ctx context.Context) error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// prefixWatchOpts returns watch options that resume right after the given
+// revision, so events landing between a cache load and the watch registration
+// are replayed instead of lost. A compacted revision surfaces as a watch
+// error, which the callers handle by reloading the cache and re-watching.
+func prefixWatchOpts(rev int64) []clientv3.OpOption {
+	opts := []clientv3.OpOption{clientv3.WithPrefix()}
+	if rev > 0 {
+		opts = append(opts, clientv3.WithRev(rev+1))
+	}
+	return opts
 }
 
 func isLeaseNotFoundErr(err error) bool {
@@ -1787,6 +1810,7 @@ func (c *EtcdCluster) loadQueueConsumerCache() error {
 	c.queueConsumersAll = freshAll
 	c.queueConsumersByQueue = freshByQueue
 	c.queueConsumersByGroup = freshByGroup
+	c.queueConsumersCacheRev = resp.Header.Revision
 	c.queueConsumersCacheMu.Unlock()
 
 	c.logger.Info("loaded queue consumers into cache", slog.Int("cache_len", len(freshAll)))
@@ -1795,7 +1819,10 @@ func (c *EtcdCluster) loadQueueConsumerCache() error {
 
 func (c *EtcdCluster) watchQueueConsumers() {
 	for {
-		watchCh := c.client.Watch(c.lifecycleCtx, queueConsumersPrefix, clientv3.WithPrefix())
+		c.queueConsumersCacheMu.RLock()
+		rev := c.queueConsumersCacheRev
+		c.queueConsumersCacheMu.RUnlock()
+		watchCh := c.client.Watch(c.lifecycleCtx, queueConsumersPrefix, prefixWatchOpts(rev)...)
 
 		for {
 			select {
@@ -2095,19 +2122,10 @@ func (c *EtcdCluster) getLeasedKey(key string) (string, bool) {
 // watchSessionOwners watches etcd for session owner changes and updates the local cache.
 func (c *EtcdCluster) watchSessionOwners() {
 	for {
-		// Resume from the revision the cache was loaded at so events that
-		// land between the load and the watch registration are replayed
-		// instead of lost. A compacted revision surfaces as a watch error,
-		// which reloads the cache and restarts from the new revision.
 		c.ownerCacheMu.RLock()
 		rev := c.ownerCacheRev
 		c.ownerCacheMu.RUnlock()
-
-		opts := []clientv3.OpOption{clientv3.WithPrefix()}
-		if rev > 0 {
-			opts = append(opts, clientv3.WithRev(rev+1))
-		}
-		watchCh := c.client.Watch(c.lifecycleCtx, sessionsPrefix, opts...)
+		watchCh := c.client.Watch(c.lifecycleCtx, sessionsPrefix, prefixWatchOpts(rev)...)
 
 		for {
 			select {
@@ -2229,6 +2247,7 @@ func (c *EtcdCluster) loadSubscriptionCache() error {
 	c.subCache = fresh
 	c.clientSubs = freshClientSubs
 	c.subTrie = freshTrie
+	c.subCacheRev = resp.Header.Revision
 	c.subCacheMu.Unlock()
 
 	if staleRemoved := prevSize - len(fresh); staleRemoved > 0 {
@@ -2267,7 +2286,10 @@ func (c *EtcdCluster) reconcileSubscriptionCache() {
 // watchSubscriptions watches etcd for subscription changes and updates the local cache.
 func (c *EtcdCluster) watchSubscriptions() {
 	for {
-		watchCh := c.client.Watch(c.lifecycleCtx, subscriptionsPrefix, clientv3.WithPrefix())
+		c.subCacheMu.RLock()
+		rev := c.subCacheRev
+		c.subCacheMu.RUnlock()
+		watchCh := c.client.Watch(c.lifecycleCtx, subscriptionsPrefix, prefixWatchOpts(rev)...)
 
 		for {
 			select {

--- a/cluster/etcd.go
+++ b/cluster/etcd.go
@@ -89,9 +89,12 @@ type EtcdCluster struct {
 	subTrie    *router.TrieRouter
 	subCacheMu sync.RWMutex
 
-	// Local session owner cache to avoid etcd roundtrips in RoutePublish
-	ownerCache   map[string]string // clientID -> nodeID
-	ownerCacheMu sync.RWMutex
+	// Local session owner cache to avoid etcd roundtrips in RoutePublish.
+	// ownerCacheRev is the etcd revision the cache was loaded at; the owner
+	// watch resumes from it so no event is missed between load and watch.
+	ownerCache    map[string]string // clientID -> nodeID
+	ownerCacheRev int64
+	ownerCacheMu  sync.RWMutex
 
 	// Local queue consumer cache for fast queue delivery/routing lookups.
 	queueConsumersAll     map[string]*QueueConsumerInfo                       // key: queue|group|consumer
@@ -1999,6 +2002,7 @@ func (c *EtcdCluster) loadSessionOwnerCache() error {
 	c.ownerCacheMu.Lock()
 	prevSize := len(c.ownerCache)
 	c.ownerCache = fresh
+	c.ownerCacheRev = resp.Header.Revision
 	c.ownerCacheMu.Unlock()
 
 	if staleRemoved := prevSize - len(fresh); staleRemoved > 0 {
@@ -2091,7 +2095,19 @@ func (c *EtcdCluster) getLeasedKey(key string) (string, bool) {
 // watchSessionOwners watches etcd for session owner changes and updates the local cache.
 func (c *EtcdCluster) watchSessionOwners() {
 	for {
-		watchCh := c.client.Watch(c.lifecycleCtx, sessionsPrefix, clientv3.WithPrefix())
+		// Resume from the revision the cache was loaded at so events that
+		// land between the load and the watch registration are replayed
+		// instead of lost. A compacted revision surfaces as a watch error,
+		// which reloads the cache and restarts from the new revision.
+		c.ownerCacheMu.RLock()
+		rev := c.ownerCacheRev
+		c.ownerCacheMu.RUnlock()
+
+		opts := []clientv3.OpOption{clientv3.WithPrefix()}
+		if rev > 0 {
+			opts = append(opts, clientv3.WithRev(rev+1))
+		}
+		watchCh := c.client.Watch(c.lifecycleCtx, sessionsPrefix, opts...)
 
 		for {
 			select {

--- a/cluster/etcd_lease_recovery_test.go
+++ b/cluster/etcd_lease_recovery_test.go
@@ -21,6 +21,7 @@ const (
 	testQueueName    = "events"
 	testGroupID      = "workers@#"
 	testConsumerMode = "stream"
+	testOtherNode    = "other-node"
 )
 
 func sessionOwnerKey(clientID string) string {
@@ -151,13 +152,13 @@ func TestWatchDeleteEvictsUntrackedOwnerKey(t *testing.T) {
 	// A key owned by another node: present in etcd and cache, not tracked.
 	clientID := "watch-evict-client"
 	key := sessionOwnerKey(clientID)
-	_, err := c.client.Put(ctx, key, "other-node")
+	_, err := c.client.Put(ctx, key, testOtherNode)
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
 		c.ownerCacheMu.RLock()
 		defer c.ownerCacheMu.RUnlock()
-		return c.ownerCache[clientID] == "other-node"
+		return c.ownerCache[clientID] == testOtherNode
 	}, recoveryWait, pollInterval)
 
 	_, err = c.client.Delete(ctx, key)

--- a/cluster/etcd_watch_gap_test.go
+++ b/cluster/etcd_watch_gap_test.go
@@ -86,12 +86,12 @@ func TestQueueConsumerWatchSeesEarlyPut(t *testing.T) {
 	}, recoveryWait, pollInterval, "queue consumer written before watch registration never reached the cache")
 }
 
-func retainedDataEntryJSON(t *testing.T, topic, payload string) string {
+func retainedDataEntryJSON(t *testing.T, nodeID, topic, payload string) string {
 	t.Helper()
 
 	entry := RetainedDataEntry{
 		Metadata: RetainedMetadata{
-			NodeID:     testOtherNode,
+			NodeID:     nodeID,
 			Topic:      topic,
 			QoS:        1,
 			Size:       len(payload),
@@ -105,12 +105,12 @@ func retainedDataEntryJSON(t *testing.T, topic, payload string) string {
 	return string(data)
 }
 
-func willDataEntryJSON(t *testing.T, clientID string) string {
+func willDataEntryJSON(t *testing.T, nodeID, clientID string) string {
 	t.Helper()
 
 	entry := WillDataEntry{
 		Metadata: WillMetadata{
-			NodeID:         testOtherNode,
+			NodeID:         nodeID,
 			ClientID:       clientID,
 			Replicated:     true,
 			DisconnectedAt: time.Now().Add(-time.Minute),
@@ -136,7 +136,7 @@ func TestRetainedStoreWatchSeesEarlyPut(t *testing.T) {
 	defer cancel()
 
 	topic := "gap/retained-store"
-	_, err := c.client.Put(ctx, retainedDataPrefix+topic, retainedDataEntryJSON(t, topic, "hello"))
+	_, err := c.client.Put(ctx, retainedDataPrefix+topic, retainedDataEntryJSON(t, testOtherNode, topic, "hello"))
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
@@ -153,7 +153,7 @@ func TestRetainedStoreLoadSeesPreexistingEntries(t *testing.T) {
 	defer cancel()
 
 	topic := "gap/retained-preexisting"
-	_, err := c.client.Put(ctx, retainedDataPrefix+topic, retainedDataEntryJSON(t, topic, "old"))
+	_, err := c.client.Put(ctx, retainedDataPrefix+topic, retainedDataEntryJSON(t, testOtherNode, topic, "old"))
 	require.NoError(t, err)
 
 	// Reload as a restarting node would; the entry must become readable
@@ -166,6 +166,53 @@ func TestRetainedStoreLoadSeesPreexistingEntries(t *testing.T) {
 	require.Equal(t, "old", string(msg.Payload))
 }
 
+func TestRetainedStoreLoadRestoresOwnNodeEntries(t *testing.T) {
+	c := newSingleNodeEtcdCluster(t)
+	require.NotNil(t, c.hybridRetained)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Entry owned by this node, but absent from the local store — the
+	// cold-start case where the node restarted with a fresh disk while its
+	// replicated entries survived in etcd.
+	topic := "gap/retained-own-node"
+	_, err := c.client.Put(ctx, retainedDataPrefix+topic, retainedDataEntryJSON(t, c.nodeID, topic, "mine"))
+	require.NoError(t, err)
+
+	require.NoError(t, c.hybridRetained.loadMetadataCache())
+
+	msg, err := c.hybridRetained.Get(ctx, topic)
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+	require.Equal(t, "mine", string(msg.Payload))
+}
+
+func TestWillStoreLoadRestoresOwnNodeEntries(t *testing.T) {
+	c := newSingleNodeEtcdCluster(t)
+	require.NotNil(t, c.hybridWill)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	clientID := "gap-will-own-node"
+	_, err := c.client.Put(ctx, willDataPrefix+clientID, willDataEntryJSON(t, c.nodeID, clientID))
+	require.NoError(t, err)
+
+	require.NoError(t, c.hybridWill.loadMetadataCache())
+
+	pending, err := c.hybridWill.GetPending(ctx, time.Now())
+	require.NoError(t, err)
+	found := false
+	for _, will := range pending {
+		if will.ClientID == clientID {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "own-node will not restored after cache load")
+}
+
 func TestWillStoreWatchSeesEarlyPut(t *testing.T) {
 	c := newSingleNodeEtcdCluster(t)
 	require.NotNil(t, c.hybridWill)
@@ -174,7 +221,7 @@ func TestWillStoreWatchSeesEarlyPut(t *testing.T) {
 	defer cancel()
 
 	clientID := "gap-will-client"
-	_, err := c.client.Put(ctx, willDataPrefix+clientID, willDataEntryJSON(t, clientID))
+	_, err := c.client.Put(ctx, willDataPrefix+clientID, willDataEntryJSON(t, testOtherNode, clientID))
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
@@ -199,7 +246,7 @@ func TestWillStoreLoadSeesPreexistingEntries(t *testing.T) {
 	defer cancel()
 
 	clientID := "gap-will-preexisting"
-	_, err := c.client.Put(ctx, willDataPrefix+clientID, willDataEntryJSON(t, clientID))
+	_, err := c.client.Put(ctx, willDataPrefix+clientID, willDataEntryJSON(t, testOtherNode, clientID))
 	require.NoError(t, err)
 
 	require.NoError(t, c.hybridWill.loadMetadataCache())
@@ -235,4 +282,21 @@ func TestRetainedWatchSeesEarlyPut(t *testing.T) {
 		defer c.retainedCacheMu.RUnlock()
 		return c.retainedCache[topic] != nil
 	}, recoveryWait, pollInterval, "retained message written before watch registration never reached the cache")
+}
+
+func TestRetainedCacheReloadEvictsStaleEntries(t *testing.T) {
+	c := newSingleNodeEtcdCluster(t)
+
+	// Simulate a topic whose delete event was missed while the watch was
+	// down: present in the cache, absent from etcd.
+	stale := "gap/retained-stale"
+	c.retainedCacheMu.Lock()
+	c.retainedCache[stale] = &storage.Message{Topic: stale}
+	c.retainedCacheMu.Unlock()
+
+	require.NoError(t, c.loadRetainedCache())
+
+	c.retainedCacheMu.RLock()
+	defer c.retainedCacheMu.RUnlock()
+	require.NotContains(t, c.retainedCache, stale, "reload must evict entries deleted while the watch was down")
 }

--- a/cluster/etcd_watch_gap_test.go
+++ b/cluster/etcd_watch_gap_test.go
@@ -284,6 +284,39 @@ func TestRetainedWatchSeesEarlyPut(t *testing.T) {
 	}, recoveryWait, pollInterval, "retained message written before watch registration never reached the cache")
 }
 
+func TestRetainedStoreSetHandlesBufferBackedPayload(t *testing.T) {
+	c := newSingleNodeEtcdCluster(t)
+	require.NotNil(t, c.hybridRetained)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Publish-path messages carry the payload in PayloadBuf with the
+	// legacy Payload field cleared.
+	topic := "gap/retained-buffer"
+	msg := &storage.Message{Topic: topic, QoS: 1, Retain: true}
+	msg.SetPayloadFromBytes([]byte("buffered"))
+
+	require.NoError(t, c.hybridRetained.Set(ctx, topic, msg))
+	msg.ReleasePayload()
+
+	// The replicated etcd entry must contain the payload.
+	resp, err := c.client.Get(ctx, retainedDataPrefix+topic)
+	require.NoError(t, err)
+	require.Len(t, resp.Kvs, 1)
+	var entry RetainedDataEntry
+	require.NoError(t, json.Unmarshal(resp.Kvs[0].Value, &entry))
+	decoded, err := base64.StdEncoding.DecodeString(entry.Payload)
+	require.NoError(t, err)
+	require.Equal(t, "buffered", string(decoded))
+
+	// And the message must be readable after the pooled buffer is gone.
+	got, err := c.hybridRetained.Get(ctx, topic)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equal(t, "buffered", string(got.GetPayload()))
+}
+
 func TestRetainedCacheReloadEvictsStaleEntries(t *testing.T) {
 	c := newSingleNodeEtcdCluster(t)
 

--- a/cluster/etcd_watch_gap_test.go
+++ b/cluster/etcd_watch_gap_test.go
@@ -5,6 +5,7 @@ package cluster
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -61,7 +62,7 @@ func TestQueueConsumerWatchSeesEarlyPut(t *testing.T) {
 		ClientID:     "gap-consumer-client",
 		Pattern:      "#",
 		Mode:         testConsumerMode,
-		ProxyNodeID:  "other-node",
+		ProxyNodeID:  testOtherNode,
 		RegisteredAt: time.Now(),
 	}
 	data, err := json.Marshal(info)
@@ -83,6 +84,136 @@ func TestQueueConsumerWatchSeesEarlyPut(t *testing.T) {
 		}
 		return false
 	}, recoveryWait, pollInterval, "queue consumer written before watch registration never reached the cache")
+}
+
+func retainedDataEntryJSON(t *testing.T, topic, payload string) string {
+	t.Helper()
+
+	entry := RetainedDataEntry{
+		Metadata: RetainedMetadata{
+			NodeID:     testOtherNode,
+			Topic:      topic,
+			QoS:        1,
+			Size:       len(payload),
+			Replicated: true,
+			Timestamp:  time.Now(),
+		},
+		Payload: base64.StdEncoding.EncodeToString([]byte(payload)),
+	}
+	data, err := json.Marshal(entry)
+	require.NoError(t, err)
+	return string(data)
+}
+
+func willDataEntryJSON(t *testing.T, clientID string) string {
+	t.Helper()
+
+	entry := WillDataEntry{
+		Metadata: WillMetadata{
+			NodeID:         testOtherNode,
+			ClientID:       clientID,
+			Replicated:     true,
+			DisconnectedAt: time.Now().Add(-time.Minute),
+			Delay:          0,
+		},
+		Will: &storage.WillMessage{
+			ClientID: clientID,
+			Topic:    "will/" + clientID,
+			Payload:  []byte("gone"),
+			QoS:      1,
+		},
+	}
+	data, err := json.Marshal(entry)
+	require.NoError(t, err)
+	return string(data)
+}
+
+func TestRetainedStoreWatchSeesEarlyPut(t *testing.T) {
+	c := newSingleNodeEtcdCluster(t)
+	require.NotNil(t, c.hybridRetained)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	topic := "gap/retained-store"
+	_, err := c.client.Put(ctx, retainedDataPrefix+topic, retainedDataEntryJSON(t, topic, "hello"))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		msg, err := c.hybridRetained.Get(context.Background(), topic)
+		return err == nil && msg != nil && string(msg.Payload) == "hello"
+	}, recoveryWait, pollInterval, "retained entry written before watch registration never became readable")
+}
+
+func TestRetainedStoreLoadSeesPreexistingEntries(t *testing.T) {
+	c := newSingleNodeEtcdCluster(t)
+	require.NotNil(t, c.hybridRetained)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	topic := "gap/retained-preexisting"
+	_, err := c.client.Put(ctx, retainedDataPrefix+topic, retainedDataEntryJSON(t, topic, "old"))
+	require.NoError(t, err)
+
+	// Reload as a restarting node would; the entry must become readable
+	// even if the watch never saw the put.
+	require.NoError(t, c.hybridRetained.loadMetadataCache())
+
+	msg, err := c.hybridRetained.Get(ctx, topic)
+	require.NoError(t, err)
+	require.NotNil(t, msg)
+	require.Equal(t, "old", string(msg.Payload))
+}
+
+func TestWillStoreWatchSeesEarlyPut(t *testing.T) {
+	c := newSingleNodeEtcdCluster(t)
+	require.NotNil(t, c.hybridWill)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	clientID := "gap-will-client"
+	_, err := c.client.Put(ctx, willDataPrefix+clientID, willDataEntryJSON(t, clientID))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		pending, err := c.hybridWill.GetPending(context.Background(), time.Now())
+		if err != nil {
+			return false
+		}
+		for _, will := range pending {
+			if will.ClientID == clientID {
+				return true
+			}
+		}
+		return false
+	}, recoveryWait, pollInterval, "will written before watch registration never became pending")
+}
+
+func TestWillStoreLoadSeesPreexistingEntries(t *testing.T) {
+	c := newSingleNodeEtcdCluster(t)
+	require.NotNil(t, c.hybridWill)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	clientID := "gap-will-preexisting"
+	_, err := c.client.Put(ctx, willDataPrefix+clientID, willDataEntryJSON(t, clientID))
+	require.NoError(t, err)
+
+	require.NoError(t, c.hybridWill.loadMetadataCache())
+
+	pending, err := c.hybridWill.GetPending(ctx, time.Now())
+	require.NoError(t, err)
+	found := false
+	for _, will := range pending {
+		if will.ClientID == clientID {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "preexisting will not visible after cache load")
 }
 
 func TestRetainedWatchSeesEarlyPut(t *testing.T) {

--- a/cluster/etcd_watch_gap_test.go
+++ b/cluster/etcd_watch_gap_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/absmach/fluxmq/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests write directly through the raw etcd client right after Start,
+// bypassing the cluster API that updates local caches synchronously. The
+// watchers must observe the writes even when they land before the watch
+// stream is registered — the watch resumes from the cache-load revision, so
+// nothing can fall between the load and the watch.
+
+func TestSubscriptionWatchSeesEarlyPut(t *testing.T) {
+	c := newSingleNodeEtcdCluster(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	clientID := "gap-sub-client"
+	subs := []storage.Subscription{{ClientID: clientID, Filter: "gap/sub/#", QoS: 1}}
+	data, err := json.Marshal(subs)
+	require.NoError(t, err)
+
+	_, err = c.client.Put(ctx, subscriptionsPrefix+clientID, string(data))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		matched, err := c.GetSubscribersForTopic(context.Background(), "gap/sub/x")
+		if err != nil {
+			return false
+		}
+		for _, sub := range matched {
+			if sub.ClientID == clientID {
+				return true
+			}
+		}
+		return false
+	}, recoveryWait, pollInterval, "subscription written before watch registration never reached the cache")
+}
+
+func TestQueueConsumerWatchSeesEarlyPut(t *testing.T) {
+	c := newSingleNodeEtcdCluster(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	info := QueueConsumerInfo{
+		QueueName:    testQueueName,
+		GroupID:      testGroupID,
+		ConsumerID:   "gap-consumer",
+		ClientID:     "gap-consumer-client",
+		Pattern:      "#",
+		Mode:         testConsumerMode,
+		ProxyNodeID:  "other-node",
+		RegisteredAt: time.Now(),
+	}
+	data, err := json.Marshal(info)
+	require.NoError(t, err)
+
+	key := fmt.Sprintf("%s%s/%s/%s", queueConsumersPrefix, info.QueueName, info.GroupID, info.ConsumerID)
+	_, err = c.client.Put(ctx, key, string(data))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		consumers, err := c.ListQueueConsumers(context.Background(), testQueueName)
+		if err != nil {
+			return false
+		}
+		for _, consumer := range consumers {
+			if consumer.ConsumerID == info.ConsumerID {
+				return true
+			}
+		}
+		return false
+	}, recoveryWait, pollInterval, "queue consumer written before watch registration never reached the cache")
+}
+
+func TestRetainedWatchSeesEarlyPut(t *testing.T) {
+	c := newSingleNodeEtcdCluster(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	topic := "gap/retained"
+	msg := storage.Message{Topic: topic, Payload: []byte("hello"), QoS: 1}
+	data, err := json.Marshal(msg)
+	require.NoError(t, err)
+
+	_, err = c.client.Put(ctx, retainedPrefix+topic, string(data))
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		c.retainedCacheMu.RLock()
+		defer c.retainedCacheMu.RUnlock()
+		return c.retainedCache[topic] != nil
+	}, recoveryWait, pollInterval, "retained message written before watch registration never reached the cache")
+}

--- a/cluster/retained.go
+++ b/cluster/retained.go
@@ -51,8 +51,12 @@ type RetainedStore struct {
 	transport     *Transport
 	sizeThreshold int
 
-	// Metadata cache (synced from etcd)
+	// Metadata cache (synced from etcd). dataRev/indexRev are the etcd
+	// revisions the cache was loaded at; the watches resume from them so no
+	// event is missed between load and watch registration.
 	metadataCache   map[string]*RetainedMetadata // key: topic
+	dataRev         int64
+	indexRev        int64
 	metadataCacheMu sync.RWMutex
 
 	logger *slog.Logger
@@ -84,11 +88,67 @@ func NewRetainedStore(
 		stopCh:        make(chan struct{}),
 	}
 
+	// Load existing metadata before watching so restarts see retained
+	// messages set while this node was down.
+	if err := h.loadMetadataCache(); err != nil {
+		logger.Warn("failed to load retained metadata cache", slog.String("error", err.Error()))
+	}
+
 	// Start background watchers for etcd updates
 	h.wg.Add(1)
 	go h.watchRetainedData()
 
 	return h
+}
+
+// loadMetadataCache rebuilds the metadata cache from both etcd prefixes and
+// records the revisions the watches must resume from.
+func (h *RetainedStore) loadMetadataCache() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	dataResp, err := h.etcdClient.Get(ctx, retainedDataPrefix, clientv3.WithPrefix())
+	if err != nil {
+		return fmt.Errorf("failed to load retained data entries: %w", err)
+	}
+	indexResp, err := h.etcdClient.Get(ctx, retainedIndexPrefix, clientv3.WithPrefix())
+	if err != nil {
+		return fmt.Errorf("failed to load retained index entries: %w", err)
+	}
+
+	fresh := make(map[string]*RetainedMetadata, len(dataResp.Kvs)+len(indexResp.Kvs))
+	for _, kv := range dataResp.Kvs {
+		topic := string(kv.Key)[len(retainedDataPrefix):]
+		var entry RetainedDataEntry
+		if err := json.Unmarshal(kv.Value, &entry); err != nil {
+			h.logger.Warn("failed to unmarshal retained data entry during load",
+				slog.String("topic", topic),
+				slog.String("error", err.Error()))
+			continue
+		}
+		fresh[topic] = &entry.Metadata
+		h.storeReplicatedEntry(ctx, topic, &entry)
+	}
+	for _, kv := range indexResp.Kvs {
+		topic := string(kv.Key)[len(retainedIndexPrefix):]
+		var metadata RetainedMetadata
+		if err := json.Unmarshal(kv.Value, &metadata); err != nil {
+			h.logger.Warn("failed to unmarshal retained metadata during load",
+				slog.String("topic", topic),
+				slog.String("error", err.Error()))
+			continue
+		}
+		fresh[topic] = &metadata
+	}
+
+	h.metadataCacheMu.Lock()
+	h.metadataCache = fresh
+	h.dataRev = dataResp.Header.Revision
+	h.indexRev = indexResp.Header.Revision
+	h.metadataCacheMu.Unlock()
+
+	h.logger.Info("loaded retained metadata into cache", slog.Int("count", len(fresh)))
+	return nil
 }
 
 // Set stores a retained message using the hybrid strategy.
@@ -338,49 +398,75 @@ func (h *RetainedStore) fetchRemoteRetained(ctx context.Context, topic, nodeID s
 	return msg, nil
 }
 
-// watchRetainedData watches etcd for retained message updates and updates local cache/store.
+// watchRetainedData watches etcd for retained message updates and updates
+// local cache/store. Watches resume from the cache-load revisions; any
+// channel close or watch error triggers a cache reload and a re-watch so no
+// event is lost across the interruption.
 func (h *RetainedStore) watchRetainedData() {
 	defer h.wg.Done()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Watch both prefixes
-	dataChan := h.etcdClient.Watch(ctx, retainedDataPrefix, clientv3.WithPrefix())
-	indexChan := h.etcdClient.Watch(ctx, retainedIndexPrefix, clientv3.WithPrefix())
-
 	for {
+		h.metadataCacheMu.RLock()
+		dataRev, indexRev := h.dataRev, h.indexRev
+		h.metadataCacheMu.RUnlock()
+
+		dataChan := h.etcdClient.Watch(ctx, retainedDataPrefix, prefixWatchOpts(dataRev)...)
+		indexChan := h.etcdClient.Watch(ctx, retainedIndexPrefix, prefixWatchOpts(indexRev)...)
+
+		if !h.consumeWatchEvents(dataChan, indexChan) {
+			return
+		}
+
+		if err := h.loadMetadataCache(); err != nil {
+			h.logger.Error("failed to reload retained metadata cache",
+				slog.String("error", err.Error()))
+		}
 		select {
 		case <-h.stopCh:
 			return
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+// consumeWatchEvents processes both watch streams until one breaks. Returns
+// false when the store is shutting down, true when the watches must be
+// re-established.
+func (h *RetainedStore) consumeWatchEvents(dataChan, indexChan clientv3.WatchChan) bool {
+	for {
+		select {
+		case <-h.stopCh:
+			return false
 
 		case resp, ok := <-dataChan:
-			if !ok {
-				h.logger.Warn("watch channel closed on retained-data, restarting")
-				dataChan = h.etcdClient.Watch(ctx, retainedDataPrefix, clientv3.WithPrefix())
-				continue
-			}
-			if resp.Err() != nil {
-				h.logger.Error("watch error on retained-data",
-					slog.String("error", resp.Err().Error()))
-				continue
+			if !ok || resp.Err() != nil {
+				h.logWatchBreak("retained-data", ok, resp)
+				return true
 			}
 			h.handleDataWatchEvents(resp.Events)
 
 		case resp, ok := <-indexChan:
-			if !ok {
-				h.logger.Warn("watch channel closed on retained-index, restarting")
-				indexChan = h.etcdClient.Watch(ctx, retainedIndexPrefix, clientv3.WithPrefix())
-				continue
-			}
-			if resp.Err() != nil {
-				h.logger.Error("watch error on retained-index",
-					slog.String("error", resp.Err().Error()))
-				continue
+			if !ok || resp.Err() != nil {
+				h.logWatchBreak("retained-index", ok, resp)
+				return true
 			}
 			h.handleIndexWatchEvents(resp.Events)
 		}
 	}
+}
+
+func (h *RetainedStore) logWatchBreak(name string, ok bool, resp clientv3.WatchResponse) {
+	if !ok {
+		h.logger.Warn("watch channel closed, reloading cache and re-watching",
+			slog.String("watch", name))
+		return
+	}
+	h.logger.Error("watch error, reloading cache and re-watching",
+		slog.String("watch", name),
+		slog.String("error", resp.Err().Error()))
 }
 
 // handleDataWatchEvents processes watch events for replicated small messages.
@@ -413,32 +499,38 @@ func (h *RetainedStore) handleDataWatchEvents(events []*clientv3.Event) {
 		h.metadataCache[topic] = &entry.Metadata
 		h.metadataCacheMu.Unlock()
 
-		// If replicated and not from this node, store payload locally
-		if entry.Metadata.Replicated && entry.Metadata.NodeID != h.nodeID {
-			payload, err := base64.StdEncoding.DecodeString(entry.Payload)
-			if err != nil {
-				h.logger.Warn("failed to decode payload",
-					slog.String("topic", topic),
-					slog.String("error", err.Error()))
-				continue
-			}
+		h.storeReplicatedEntry(context.Background(), topic, &entry)
+	}
+}
 
-			msg := &storage.Message{
-				Topic:       topic,
-				Payload:     payload,
-				QoS:         entry.Metadata.QoS,
-				Retain:      true,
-				Properties:  entry.Properties,
-				PublishTime: entry.Metadata.Timestamp,
-			}
+// storeReplicatedEntry persists the payload of a small replicated message
+// from another node into the local store.
+func (h *RetainedStore) storeReplicatedEntry(ctx context.Context, topic string, entry *RetainedDataEntry) {
+	if !entry.Metadata.Replicated || entry.Metadata.NodeID == h.nodeID {
+		return
+	}
 
-			ctx := context.Background()
-			if err := h.localStore.Set(ctx, topic, msg); err != nil {
-				h.logger.Warn("failed to store replicated message locally",
-					slog.String("topic", topic),
-					slog.String("error", err.Error()))
-			}
-		}
+	payload, err := base64.StdEncoding.DecodeString(entry.Payload)
+	if err != nil {
+		h.logger.Warn("failed to decode payload",
+			slog.String("topic", topic),
+			slog.String("error", err.Error()))
+		return
+	}
+
+	msg := &storage.Message{
+		Topic:       topic,
+		Payload:     payload,
+		QoS:         entry.Metadata.QoS,
+		Retain:      true,
+		Properties:  entry.Properties,
+		PublishTime: entry.Metadata.Timestamp,
+	}
+
+	if err := h.localStore.Set(ctx, topic, msg); err != nil {
+		h.logger.Warn("failed to store replicated message locally",
+			slog.String("topic", topic),
+			slog.String("error", err.Error()))
 	}
 }
 

--- a/cluster/retained.go
+++ b/cluster/retained.go
@@ -153,33 +153,39 @@ func (h *RetainedStore) loadMetadataCache() error {
 
 // Set stores a retained message using the hybrid strategy.
 func (h *RetainedStore) Set(ctx context.Context, topic string, msg *storage.Message) error {
+	// Materialize the payload: publish-path messages carry it in a pooled
+	// PayloadBuf (with the legacy Payload field cleared), while a retained
+	// message must outlive the buffer and survive serialization.
+	payload := msg.GetPayload()
+
 	// Empty payload = delete
-	if len(msg.Payload) == 0 {
+	if len(payload) == 0 {
 		return h.Delete(ctx, topic)
 	}
 
+	stored := *msg
+	stored.PayloadBuf = nil
+	stored.Payload = append([]byte(nil), payload...)
+
 	// Always write to local BadgerDB first
-	if err := h.localStore.Set(ctx, topic, msg); err != nil {
+	if err := h.localStore.Set(ctx, topic, &stored); err != nil {
 		return fmt.Errorf("failed to write to local store: %w", err)
 	}
-
-	// Calculate payload size
-	payloadSize := len(msg.Payload)
 
 	// Create metadata
 	metadata := &RetainedMetadata{
 		NodeID:     h.nodeID,
 		Topic:      topic,
 		QoS:        msg.QoS,
-		Size:       payloadSize,
-		Replicated: payloadSize < h.sizeThreshold,
+		Size:       len(payload),
+		Replicated: len(payload) < h.sizeThreshold,
 		Timestamp:  time.Now(),
 	}
 
 	// Publish to etcd based on size
 	var etcdErr error
 	if metadata.Replicated {
-		etcdErr = h.publishReplicatedMessage(ctx, topic, msg, metadata)
+		etcdErr = h.publishReplicatedMessage(ctx, topic, &stored, metadata)
 	} else {
 		etcdErr = h.publishMetadata(ctx, topic, metadata)
 	}

--- a/cluster/retained.go
+++ b/cluster/retained.go
@@ -413,10 +413,16 @@ func (h *RetainedStore) watchRetainedData() {
 		dataRev, indexRev := h.dataRev, h.indexRev
 		h.metadataCacheMu.RUnlock()
 
-		dataChan := h.etcdClient.Watch(ctx, retainedDataPrefix, prefixWatchOpts(dataRev)...)
-		indexChan := h.etcdClient.Watch(ctx, retainedIndexPrefix, prefixWatchOpts(indexRev)...)
+		// Per-iteration context: when one stream breaks, the surviving
+		// watch must be cancelled too, or abandoned watches accumulate on
+		// the etcd server across restarts.
+		iterCtx, iterCancel := context.WithCancel(ctx)
+		dataChan := h.etcdClient.Watch(iterCtx, retainedDataPrefix, prefixWatchOpts(dataRev)...)
+		indexChan := h.etcdClient.Watch(iterCtx, retainedIndexPrefix, prefixWatchOpts(indexRev)...)
 
-		if !h.consumeWatchEvents(dataChan, indexChan) {
+		alive := h.consumeWatchEvents(dataChan, indexChan)
+		iterCancel()
+		if !alive {
 			return
 		}
 
@@ -499,14 +505,20 @@ func (h *RetainedStore) handleDataWatchEvents(events []*clientv3.Event) {
 		h.metadataCache[topic] = &entry.Metadata
 		h.metadataCacheMu.Unlock()
 
-		h.storeReplicatedEntry(context.Background(), topic, &entry)
+		// Own writes are already in the local store.
+		if entry.Metadata.NodeID != h.nodeID {
+			h.storeReplicatedEntry(context.Background(), topic, &entry)
+		}
 	}
 }
 
 // storeReplicatedEntry persists the payload of a small replicated message
-// from another node into the local store.
+// into the local store. Callers decide whether own-node entries apply: the
+// watch path skips them (Set already wrote the payload locally), while the
+// startup load includes them so a node restarting with a fresh local store
+// recovers its own replicated messages from etcd.
 func (h *RetainedStore) storeReplicatedEntry(ctx context.Context, topic string, entry *RetainedDataEntry) {
-	if !entry.Metadata.Replicated || entry.Metadata.NodeID == h.nodeID {
+	if !entry.Metadata.Replicated {
 		return
 	}
 

--- a/cluster/will.go
+++ b/cluster/will.go
@@ -395,10 +395,16 @@ func (h *WillStore) watchWillData() {
 		dataRev, indexRev := h.dataRev, h.indexRev
 		h.metadataCacheMu.RUnlock()
 
-		dataChan := h.etcdClient.Watch(ctx, willDataPrefix, prefixWatchOpts(dataRev)...)
-		indexChan := h.etcdClient.Watch(ctx, willIndexPrefix, prefixWatchOpts(indexRev)...)
+		// Per-iteration context: when one stream breaks, the surviving
+		// watch must be cancelled too, or abandoned watches accumulate on
+		// the etcd server across restarts.
+		iterCtx, iterCancel := context.WithCancel(ctx)
+		dataChan := h.etcdClient.Watch(iterCtx, willDataPrefix, prefixWatchOpts(dataRev)...)
+		indexChan := h.etcdClient.Watch(iterCtx, willIndexPrefix, prefixWatchOpts(indexRev)...)
 
-		if !h.consumeWatchEvents(dataChan, indexChan) {
+		alive := h.consumeWatchEvents(dataChan, indexChan)
+		iterCancel()
+		if !alive {
 			return
 		}
 
@@ -481,14 +487,20 @@ func (h *WillStore) handleDataWatchEvents(events []*clientv3.Event) {
 		h.metadataCache[clientID] = &entry.Metadata
 		h.metadataCacheMu.Unlock()
 
-		h.storeReplicatedWill(context.Background(), clientID, &entry)
+		// Own writes are already in the local store.
+		if entry.Metadata.NodeID != h.nodeID {
+			h.storeReplicatedWill(context.Background(), clientID, &entry)
+		}
 	}
 }
 
-// storeReplicatedWill persists a small replicated will from another node
-// into the local store.
+// storeReplicatedWill persists a small replicated will into the local store.
+// Callers decide whether own-node entries apply: the watch path skips them
+// (Set already wrote the will locally), while the startup load includes them
+// so a node restarting with a fresh local store recovers its own replicated
+// wills from etcd.
 func (h *WillStore) storeReplicatedWill(ctx context.Context, clientID string, entry *WillDataEntry) {
-	if !entry.Metadata.Replicated || entry.Metadata.NodeID == h.nodeID {
+	if !entry.Metadata.Replicated {
 		return
 	}
 

--- a/cluster/will.go
+++ b/cluster/will.go
@@ -44,8 +44,12 @@ type WillStore struct {
 	transport     *Transport
 	sizeThreshold int
 
-	// Metadata cache (synced from etcd)
+	// Metadata cache (synced from etcd). dataRev/indexRev are the etcd
+	// revisions the cache was loaded at; the watches resume from them so no
+	// event is missed between load and watch registration.
 	metadataCache   map[string]*WillMetadata // key: clientID
+	dataRev         int64
+	indexRev        int64
 	metadataCacheMu sync.RWMutex
 
 	logger *slog.Logger
@@ -77,11 +81,67 @@ func NewWillStore(
 		stopCh:        make(chan struct{}),
 	}
 
+	// Load existing metadata before watching so restarts see wills set
+	// while this node was down.
+	if err := h.loadMetadataCache(); err != nil {
+		logger.Warn("failed to load will metadata cache", slog.String("error", err.Error()))
+	}
+
 	// Start background watchers for etcd updates
 	h.wg.Add(1)
 	go h.watchWillData()
 
 	return h
+}
+
+// loadMetadataCache rebuilds the metadata cache from both etcd prefixes and
+// records the revisions the watches must resume from.
+func (h *WillStore) loadMetadataCache() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	dataResp, err := h.etcdClient.Get(ctx, willDataPrefix, clientv3.WithPrefix())
+	if err != nil {
+		return fmt.Errorf("failed to load will data entries: %w", err)
+	}
+	indexResp, err := h.etcdClient.Get(ctx, willIndexPrefix, clientv3.WithPrefix())
+	if err != nil {
+		return fmt.Errorf("failed to load will index entries: %w", err)
+	}
+
+	fresh := make(map[string]*WillMetadata, len(dataResp.Kvs)+len(indexResp.Kvs))
+	for _, kv := range dataResp.Kvs {
+		clientID := string(kv.Key)[len(willDataPrefix):]
+		var entry WillDataEntry
+		if err := json.Unmarshal(kv.Value, &entry); err != nil {
+			h.logger.Warn("failed to unmarshal will data entry during load",
+				slog.String("client_id", clientID),
+				slog.String("error", err.Error()))
+			continue
+		}
+		fresh[clientID] = &entry.Metadata
+		h.storeReplicatedWill(ctx, clientID, &entry)
+	}
+	for _, kv := range indexResp.Kvs {
+		clientID := string(kv.Key)[len(willIndexPrefix):]
+		var metadata WillMetadata
+		if err := json.Unmarshal(kv.Value, &metadata); err != nil {
+			h.logger.Warn("failed to unmarshal will metadata during load",
+				slog.String("client_id", clientID),
+				slog.String("error", err.Error()))
+			continue
+		}
+		fresh[clientID] = &metadata
+	}
+
+	h.metadataCacheMu.Lock()
+	h.metadataCache = fresh
+	h.dataRev = dataResp.Header.Revision
+	h.indexRev = indexResp.Header.Revision
+	h.metadataCacheMu.Unlock()
+
+	h.logger.Info("loaded will metadata into cache", slog.Int("count", len(fresh)))
+	return nil
 }
 
 // Set stores a will message using the hybrid strategy.
@@ -320,48 +380,75 @@ func (h *WillStore) fetchRemoteWill(ctx context.Context, clientID, nodeID string
 }
 
 // watchWillData watches etcd for will message updates and updates local cache/store.
+// watchWillData watches etcd for will updates and updates local cache/store.
+// Watches resume from the cache-load revisions; any channel close or watch
+// error triggers a cache reload and a re-watch so no event is lost across
+// the interruption.
 func (h *WillStore) watchWillData() {
 	defer h.wg.Done()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Watch both prefixes
-	dataChan := h.etcdClient.Watch(ctx, willDataPrefix, clientv3.WithPrefix())
-	indexChan := h.etcdClient.Watch(ctx, willIndexPrefix, clientv3.WithPrefix())
-
 	for {
+		h.metadataCacheMu.RLock()
+		dataRev, indexRev := h.dataRev, h.indexRev
+		h.metadataCacheMu.RUnlock()
+
+		dataChan := h.etcdClient.Watch(ctx, willDataPrefix, prefixWatchOpts(dataRev)...)
+		indexChan := h.etcdClient.Watch(ctx, willIndexPrefix, prefixWatchOpts(indexRev)...)
+
+		if !h.consumeWatchEvents(dataChan, indexChan) {
+			return
+		}
+
+		if err := h.loadMetadataCache(); err != nil {
+			h.logger.Error("failed to reload will metadata cache",
+				slog.String("error", err.Error()))
+		}
 		select {
 		case <-h.stopCh:
 			return
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+// consumeWatchEvents processes both watch streams until one breaks. Returns
+// false when the store is shutting down, true when the watches must be
+// re-established.
+func (h *WillStore) consumeWatchEvents(dataChan, indexChan clientv3.WatchChan) bool {
+	for {
+		select {
+		case <-h.stopCh:
+			return false
 
 		case resp, ok := <-dataChan:
-			if !ok {
-				h.logger.Warn("watch channel closed on will-data, restarting")
-				dataChan = h.etcdClient.Watch(ctx, willDataPrefix, clientv3.WithPrefix())
-				continue
-			}
-			if resp.Err() != nil {
-				h.logger.Error("watch error on will-data",
-					slog.String("error", resp.Err().Error()))
-				continue
+			if !ok || resp.Err() != nil {
+				h.logWatchBreak("will-data", ok, resp)
+				return true
 			}
 			h.handleDataWatchEvents(resp.Events)
 
 		case resp, ok := <-indexChan:
-			if !ok {
-				h.logger.Warn("watch channel closed on will-index, restarting")
-				indexChan = h.etcdClient.Watch(ctx, willIndexPrefix, clientv3.WithPrefix())
-				continue
-			}
-			if resp.Err() != nil {
-				h.logger.Error("watch error on will-index",
-					slog.String("error", resp.Err().Error()))
-				continue
+			if !ok || resp.Err() != nil {
+				h.logWatchBreak("will-index", ok, resp)
+				return true
 			}
 			h.handleIndexWatchEvents(resp.Events)
 		}
 	}
+}
+
+func (h *WillStore) logWatchBreak(name string, ok bool, resp clientv3.WatchResponse) {
+	if !ok {
+		h.logger.Warn("watch channel closed, reloading cache and re-watching",
+			slog.String("watch", name))
+		return
+	}
+	h.logger.Error("watch error, reloading cache and re-watching",
+		slog.String("watch", name),
+		slog.String("error", resp.Err().Error()))
 }
 
 // handleDataWatchEvents processes watch events for replicated small wills.
@@ -394,15 +481,21 @@ func (h *WillStore) handleDataWatchEvents(events []*clientv3.Event) {
 		h.metadataCache[clientID] = &entry.Metadata
 		h.metadataCacheMu.Unlock()
 
-		// If replicated and not from this node, store will locally
-		if entry.Metadata.Replicated && entry.Metadata.NodeID != h.nodeID {
-			ctx := context.Background()
-			if err := h.localStore.Set(ctx, clientID, entry.Will); err != nil {
-				h.logger.Warn("failed to store replicated will locally",
-					slog.String("client_id", clientID),
-					slog.String("error", err.Error()))
-			}
-		}
+		h.storeReplicatedWill(context.Background(), clientID, &entry)
+	}
+}
+
+// storeReplicatedWill persists a small replicated will from another node
+// into the local store.
+func (h *WillStore) storeReplicatedWill(ctx context.Context, clientID string, entry *WillDataEntry) {
+	if !entry.Metadata.Replicated || entry.Metadata.NodeID == h.nodeID {
+		return
+	}
+
+	if err := h.localStore.Set(ctx, clientID, entry.Will); err != nil {
+		h.logger.Warn("failed to store replicated will locally",
+			slog.String("client_id", clientID),
+			slog.String("error", err.Error()))
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/rabbitmq/amqp091-go v1.12.0
 	github.com/sony/gobreaker v1.0.0
 	github.com/stretchr/testify v1.11.1
+	go.etcd.io/etcd/api/v3 v3.6.13
 	go.etcd.io/etcd/client/v3 v3.6.13
 	go.etcd.io/etcd/server/v3 v3.6.13
 	go.opentelemetry.io/otel v1.44.0
@@ -80,7 +81,6 @@ require (
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	go.etcd.io/bbolt v1.4.3 // indirect
-	go.etcd.io/etcd/api/v3 v3.6.13 // indirect
 	go.etcd.io/etcd/client/pkg/v3 v3.6.13 // indirect
 	go.etcd.io/etcd/pkg/v3 v3.6.13 // indirect
 	go.etcd.io/raft/v3 v3.6.0 // indirect

--- a/mqtt/broker/broker.go
+++ b/mqtt/broker/broker.go
@@ -138,6 +138,9 @@ type Broker struct {
 	closed        atomic.Bool
 	sharedSubs    *SharedSubscriptionManager
 	fanOutPool    *fanOutPool // non-nil only when AsyncFanOut is true
+
+	// Throttles the unroutable-forward warning (unix nanos of last log).
+	lastUnroutableWarn atomic.Int64
 }
 
 // NewBroker creates a new broker instance.

--- a/mqtt/broker/forward_warn_test.go
+++ b/mqtt/broker/forward_warn_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/absmach/fluxmq/cluster"
+	"github.com/absmach/fluxmq/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// syncBuffer guards concurrent writes from broker goroutines.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func TestForwardPublishWarnsWhenNoLocalSubscription(t *testing.T) {
+	var logBuf syncBuffer
+	b := NewBroker(nil, nil, WithLogger(slog.New(slog.NewTextHandler(&logBuf, nil))))
+	defer b.Close()
+
+	err := b.ForwardPublish(context.Background(), &cluster.Message{
+		Topic:   "no/subscribers/here",
+		Payload: []byte("lost?"),
+		QoS:     1,
+	})
+	require.NoError(t, err)
+
+	logged := logBuf.String()
+	require.Contains(t, logged, "forwarded publish matched no local subscription")
+	require.Contains(t, logged, "no/subscribers/here")
+
+	// Immediately repeated misses are throttled to one warning.
+	err = b.ForwardPublish(context.Background(), &cluster.Message{
+		Topic:   "still/no/subscribers",
+		Payload: []byte("lost?"),
+		QoS:     1,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, strings.Count(logBuf.String(), "forwarded publish matched no local subscription"))
+}
+
+func TestForwardPublishDoesNotWarnWhenSubscriptionMatches(t *testing.T) {
+	var logBuf syncBuffer
+	b := NewBroker(nil, nil, WithLogger(slog.New(slog.NewTextHandler(&logBuf, nil))))
+	defer b.Close()
+
+	require.NoError(t, b.router.Subscribe("local-sub", "telemetry/#", 1, storage.SubscribeOptions{}))
+
+	err := b.ForwardPublish(context.Background(), &cluster.Message{
+		Topic:   testTelemetryRoom,
+		Payload: []byte("hello"),
+		QoS:     1,
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, logBuf.String(), "forwarded publish matched no local subscription")
+}

--- a/mqtt/broker/publish.go
+++ b/mqtt/broker/publish.go
@@ -218,7 +218,7 @@ func (b *Broker) Distribute(topic string, payload []byte, qos byte, retain bool,
 func (b *Broker) distribute(ctx context.Context, msg *storage.Message) error {
 	msg.Properties = broker.AddClientIDProperty(msg.Properties, msg.ClientID)
 
-	if err := b.distributeLocal(ctx, msg, true); err != nil {
+	if _, err := b.distributeLocal(ctx, msg, true); err != nil {
 		return err
 	}
 
@@ -244,14 +244,15 @@ func (b *Broker) distribute(ctx context.Context, msg *storage.Message) error {
 	return nil
 }
 
-// distributeLocal delivers a message to local subscribers.
+// distributeLocal delivers a message to local subscribers and returns the
+// number of matched subscriptions.
 // allowCross controls whether cross-protocol delivery callbacks may run.
-func (b *Broker) distributeLocal(ctx context.Context, msg *storage.Message, allowCross bool) error {
+func (b *Broker) distributeLocal(ctx context.Context, msg *storage.Message, allowCross bool) (int, error) {
 	matched := router.AcquireSubscriptionSlice()
 	defer router.ReleaseSubscriptionSlice(matched)
 
 	if err := b.router.MatchInto(msg.Topic, matched); err != nil {
-		return err
+		return 0, err
 	}
 
 	// Track which share groups have already received the message (lazy init)
@@ -359,7 +360,7 @@ func (b *Broker) distributeLocal(ctx context.Context, msg *storage.Message, allo
 		}
 	}
 
-	return nil
+	return len(*matched), nil
 }
 
 // ForwardPublish handles a forwarded publish from a remote cluster node.
@@ -373,9 +374,27 @@ func (b *Broker) ForwardPublish(ctx context.Context, msg *cluster.Message) error
 	storeMsg.ClientID = broker.ClientIDFromProperties(msg.Properties)
 	storeMsg.SetPayloadFromBytes(msg.Payload)
 
-	err := b.distributeLocal(ctx, storeMsg, false)
+	matched, err := b.distributeLocal(ctx, storeMsg, false)
 	storeMsg.ReleasePayload()
+	if err == nil && matched == 0 {
+		// The sending node believed a subscriber lives here (stale owner
+		// route); without this the message vanishes with no trace.
+		b.warnUnroutableForward(msg.Topic)
+	}
 	return err
+}
+
+// warnUnroutableForward logs (at most once per 10s) that a forwarded publish
+// matched no local subscription.
+func (b *Broker) warnUnroutableForward(topic string) {
+	const throttle = int64(10 * time.Second)
+	now := time.Now().UnixNano()
+	last := b.lastUnroutableWarn.Load()
+	if now-last < throttle || !b.lastUnroutableWarn.CompareAndSwap(last, now) {
+		return
+	}
+	b.telemetry.logger.Warn("forwarded publish matched no local subscription",
+		slog.String("topic", topic))
 }
 
 // handleQueueAck handles queue acknowledgment messages ($ack, $nack, $reject).


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?
This is a bug fix.
<!--
This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?
Closes the load/watch revision gap in every etcd-backed cluster cache and makes the hybrid retained/will stores converge after restarts and watch interruptions.

## Which issue(s) does this PR fix/relate to?
<!--
- Related Issue #
- Resolves #
-->

## Have you included tests for your changes?
Yes.

## Did you document any new/modified features?
N/A

### Notes
N/A
