### PR TITLE
Make retained Match deterministic and complete

### DIFF
--- a/cluster/retained.go
+++ b/cluster/retained.go
@@ -4,24 +4,32 @@
 package cluster
 
 import (
+	"cmp"
 	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"sync"
 	"time"
 
 	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/topics"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
 	retainedDataPrefix   = "/mqtt/retained-data/"  // For small messages (<1KB) with full payload
 	retainedIndexPrefix  = "/mqtt/retained-index/" // For large messages (≥1KB) metadata only
 	defaultSizeThreshold = 1024                    // 1KB threshold for replication vs fetch-on-demand
+
+	// retainedMatchConcurrency bounds parallel payload fetches during Match so a
+	// wildcard subscribe over many large (remote) retained messages resolves in
+	// roughly one round-trip instead of N sequential ones.
+	retainedMatchConcurrency = 16
 )
 
 // RetainedMetadata contains metadata about a retained message stored in etcd.
@@ -39,6 +47,13 @@ type RetainedDataEntry struct {
 	Metadata   RetainedMetadata  `json:"metadata"`
 	Payload    string            `json:"payload"` // base64 encoded
 	Properties map[string]string `json:"properties"`
+}
+
+// retainedRef pairs a matched topic with the metadata pointer observed during
+// Match, so pruning can skip entries that changed concurrently.
+type retainedRef struct {
+	topic string
+	meta  *RetainedMetadata
 }
 
 // RetainedStore implements storage.RetainedStore using hybrid storage strategy:
@@ -254,45 +269,113 @@ func (h *RetainedStore) Delete(ctx context.Context, topic string) error {
 }
 
 // Match returns all retained messages matching the given topic filter.
+//
+// Matching topics are resolved in sorted order and their payloads are fetched
+// concurrently: sequential per-topic remote fetches could exceed the caller's
+// deadline and return a different partial subset on every call. Fetching in
+// parallel keeps the wall-clock cost close to a single round-trip so the full
+// set resolves within budget and in a stable order.
 func (h *RetainedStore) Match(ctx context.Context, filter string) ([]*storage.Message, error) {
-	var messages []*storage.Message
-	var fetchErrors []error
-
-	// Get matching topics from metadata cache
+	// Snapshot matching topics (with their metadata pointer) from the cache.
 	h.metadataCacheMu.RLock()
-	var matchingTopics []string
-	for topic := range h.metadataCache {
+	refs := make([]retainedRef, 0, len(h.metadataCache))
+	for topic, meta := range h.metadataCache {
 		if topics.TopicMatch(filter, topic) {
-			matchingTopics = append(matchingTopics, topic)
+			refs = append(refs, retainedRef{topic: topic, meta: meta})
 		}
 	}
 	h.metadataCacheMu.RUnlock()
 
-	// Fetch each matching message
-	for _, topic := range matchingTopics {
-		msg, err := h.Get(ctx, topic)
-		if err != nil {
-			if err != storage.ErrNotFound {
-				fetchErrors = append(fetchErrors, fmt.Errorf("topic %s: %w", topic, err))
+	if len(refs) == 0 {
+		return nil, nil
+	}
+
+	// Stable order so repeated calls deliver the same set identically.
+	slices.SortFunc(refs, func(a, b retainedRef) int {
+		return cmp.Compare(a.topic, b.topic)
+	})
+
+	// Resolve payloads concurrently, preserving the sorted order by index.
+	results := make([]*storage.Message, len(refs))
+	fetchErrs := make([]error, len(refs))
+	missing := make([]bool, len(refs))
+
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(retainedMatchConcurrency)
+	for i := range refs {
+		g.Go(func() error {
+			msg, err := h.Get(gctx, refs[i].topic)
+			switch {
+			case err == nil:
+				results[i] = msg
+			case errors.Is(err, storage.ErrNotFound):
+				// Payload is genuinely gone (owner lost it, e.g. wiped on
+				// restart). Mark for pruning so it stops matching.
+				missing[i] = true
+			default:
+				fetchErrs[i] = fmt.Errorf("topic %s: %w", refs[i].topic, err)
 			}
-			continue
+			return nil
+		})
+	}
+	_ = g.Wait() // per-topic outcomes are recorded above; no worker returns an error
+
+	messages := make([]*storage.Message, 0, len(refs))
+	var errs []error
+	var prune []retainedRef
+	for i := range refs {
+		switch {
+		case results[i] != nil:
+			messages = append(messages, results[i])
+		case missing[i]:
+			prune = append(prune, refs[i])
+		case fetchErrs[i] != nil:
+			errs = append(errs, fetchErrs[i])
 		}
-		messages = append(messages, msg)
 	}
 
-	// If all fetches failed, return error
-	if len(fetchErrors) > 0 && len(messages) == 0 {
-		return nil, fmt.Errorf("failed to fetch retained messages: %w", errors.Join(fetchErrors...))
+	if len(prune) > 0 {
+		h.pruneMissingMetadata(prune...)
 	}
 
-	// Log warnings for partial failures but still return successful fetches
-	if len(fetchErrors) > 0 {
+	// Preserve the original contract: only fail hard when nothing resolved and
+	// the reason was a real fetch error (not merely missing/pruned entries).
+	if len(errs) > 0 && len(messages) == 0 {
+		return nil, fmt.Errorf("failed to fetch retained messages: %w", errors.Join(errs...))
+	}
+
+	// Partial transient failures: deliver what resolved, but log loudly so the
+	// gap is visible rather than a silent, per-call-random drop.
+	if len(errs) > 0 {
 		h.logger.Warn("some retained messages failed to fetch",
-			slog.Int("failed", len(fetchErrors)),
+			slog.Int("failed", len(errs)),
 			slog.Int("succeeded", len(messages)))
 	}
 
 	return messages, nil
+}
+
+// pruneMissingMetadata drops metadata-cache entries whose payload could not be
+// found anywhere (the owner lost it, e.g. on a restart with ephemeral storage).
+// An entry is removed only if its cached pointer is unchanged since Match
+// observed it, so a concurrent Set for the same topic is never clobbered. This
+// is in-memory only; durable removal happens when the message is properly
+// deleted via an empty retained publish.
+func (h *RetainedStore) pruneMissingMetadata(refs ...retainedRef) {
+	h.metadataCacheMu.Lock()
+	pruned := 0
+	for _, ref := range refs {
+		if h.metadataCache[ref.topic] == ref.meta {
+			delete(h.metadataCache, ref.topic)
+			pruned++
+		}
+	}
+	h.metadataCacheMu.Unlock()
+
+	if pruned > 0 {
+		h.logger.Warn("pruned stale retained metadata (payload unavailable)",
+			slog.Int("count", pruned))
+	}
 }
 
 // Close stops the hybrid store and cleans up resources.

--- a/cluster/retained_test.go
+++ b/cluster/retained_test.go
@@ -6,8 +6,11 @@ package cluster
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"os"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +19,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+const (
+	testNode1 = "node1"
+	testNode2 = "node2"
+	testNode3 = "node3"
 )
 
 // testLogger creates a logger for testing that discards output.
@@ -44,7 +53,7 @@ func TestRetainedStore_SmallMessageReplication(t *testing.T) {
 	node2Store := memory.New()
 
 	store1 := NewRetainedStore(
-		"node1",
+		testNode1,
 		node1Store.Retained(),
 		client,
 		nil,  // no transport needed for replication test
@@ -54,7 +63,7 @@ func TestRetainedStore_SmallMessageReplication(t *testing.T) {
 	defer store1.Close()
 
 	store2 := NewRetainedStore(
-		"node2",
+		testNode2,
 		node2Store.Retained(),
 		client,
 		nil,
@@ -114,13 +123,214 @@ func TestRetainedStore_Delete_RemovesFromBothStores(t *testing.T) {
 	// 3. Metadata cache
 }
 
-// TestRetainedStore_Match_WildcardTopics tests wildcard topic matching.
-func TestRetainedStore_Match_WildcardTopics(t *testing.T) {
-	t.Skip("Requires etcd instance")
-	// Test that Match() correctly:
-	// 1. Scans metadata cache for matching topics
-	// 2. Fetches messages from local store
-	// 3. Returns all matching messages
+// newTestRetainedStore builds a RetainedStore backed by an in-memory local
+// store, bypassing NewRetainedStore's etcd load/watch. Match, Get, and pruning
+// need only localStore, metadataCache, transport, and logger.
+func newTestRetainedStore(t *testing.T, nodeID string) *RetainedStore {
+	t.Helper()
+	return &RetainedStore{
+		nodeID:        nodeID,
+		localStore:    memory.New().Retained(),
+		sizeThreshold: defaultSizeThreshold,
+		metadataCache: make(map[string]*RetainedMetadata),
+		logger:        testLogger(t),
+		stopCh:        make(chan struct{}),
+	}
+}
+
+// seedLocalRetained stores a small retained message owned by this node in both
+// the local store and the metadata cache, so Get resolves it from local.
+func seedLocalRetained(t *testing.T, h *RetainedStore, topic string, payload []byte) {
+	t.Helper()
+	msg := &storage.Message{
+		Topic:       topic,
+		Payload:     payload,
+		QoS:         1,
+		Retain:      true,
+		PublishTime: time.Now(),
+	}
+	require.NoError(t, h.localStore.Set(context.Background(), topic, msg))
+	h.metadataCache[topic] = &RetainedMetadata{
+		NodeID:     h.nodeID,
+		Topic:      topic,
+		QoS:        1,
+		Size:       len(payload),
+		Replicated: len(payload) < h.sizeThreshold,
+		Timestamp:  time.Now(),
+	}
+}
+
+// seedMetadataOnly registers a metadata entry with no local payload, simulating
+// a message whose payload lives elsewhere (or was lost). ownerNode == nodeID
+// and replicated=false both drive Get to storage.ErrNotFound without a
+// transport; a remote owner with a nil transport yields a transient error.
+func seedMetadataOnly(h *RetainedStore, topic, ownerNode string, replicated bool) {
+	h.metadataCache[topic] = &RetainedMetadata{
+		NodeID:     ownerNode,
+		Topic:      topic,
+		QoS:        1,
+		Size:       4096,
+		Replicated: replicated,
+		Timestamp:  time.Now(),
+	}
+}
+
+func matchedTopics(msgs []*storage.Message) []string {
+	out := make([]string, len(msgs))
+	for i, m := range msgs {
+		out[i] = m.Topic
+	}
+	return out
+}
+
+// TestRetainedStore_Match_CompleteAndDeterministic verifies that a wildcard
+// Match returns the full matching set in the same sorted order on every call —
+// the core fix for the "different subset each subscribe" bug.
+func TestRetainedStore_Match_CompleteAndDeterministic(t *testing.T) {
+	h := newTestRetainedStore(t, testNode1)
+
+	var want []string
+	for i := range 25 {
+		topic := fmt.Sprintf("m/dom/c/chan/sensor-%02d", i)
+		seedLocalRetained(t, h, topic, fmt.Appendf(nil, "v%d", i))
+		want = append(want, topic)
+	}
+	slices.Sort(want)
+	// A non-matching entry must never appear.
+	seedLocalRetained(t, h, "other/topic", []byte("nope"))
+
+	ctx := context.Background()
+	var first []string
+	for iter := range 50 {
+		msgs, err := h.Match(ctx, "m/dom/c/chan/#")
+		require.NoError(t, err)
+		got := matchedTopics(msgs)
+		require.True(t, slices.IsSorted(got), "iter %d: result not sorted", iter)
+		require.Equal(t, want, got, "iter %d: incomplete or reordered set", iter)
+		if iter == 0 {
+			first = got
+		}
+		assert.Equal(t, first, got, "iter %d: set differs from first call", iter)
+	}
+}
+
+// TestRetainedStore_Match_PrunesMissingPayload verifies that entries whose
+// payload is gone are excluded and their stale metadata is pruned, while
+// present entries are still returned.
+func TestRetainedStore_Match_PrunesMissingPayload(t *testing.T) {
+	tests := []struct {
+		name       string
+		ownerNode  string
+		replicated bool
+	}{
+		{"owned but payload lost", testNode1, false},
+		{"replicated but missing locally", testNode2, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newTestRetainedStore(t, testNode1)
+			seedLocalRetained(t, h, "m/x/present", []byte("here"))
+			seedMetadataOnly(h, "m/x/gone", tt.ownerNode, tt.replicated)
+
+			msgs, err := h.Match(context.Background(), "m/x/#")
+			require.NoError(t, err)
+			assert.Equal(t, []string{"m/x/present"}, matchedTopics(msgs))
+
+			h.metadataCacheMu.RLock()
+			_, stillThere := h.metadataCache["m/x/gone"]
+			_, presentKept := h.metadataCache["m/x/present"]
+			h.metadataCacheMu.RUnlock()
+			assert.False(t, stillThere, "missing entry should be pruned")
+			assert.True(t, presentKept, "present entry must not be pruned")
+		})
+	}
+}
+
+// TestRetainedStore_Match_SurfacesTransientErrors verifies that a transient
+// fetch failure (remote owner, no transport) is not silently converted into a
+// missing entry: the whole call fails when nothing resolves, and a partial
+// success keeps the failing entry's metadata for a later retry.
+func TestRetainedStore_Match_SurfacesTransientErrors(t *testing.T) {
+	t.Run("all fetches fail -> error", func(t *testing.T) {
+		h := newTestRetainedStore(t, testNode1) // transport is nil
+		seedMetadataOnly(h, "m/x/remote1", testNode2, false)
+		seedMetadataOnly(h, "m/x/remote2", testNode3, false)
+
+		msgs, err := h.Match(context.Background(), "m/x/#")
+		require.Error(t, err)
+		assert.Nil(t, msgs)
+
+		// A transient failure must NOT prune metadata.
+		h.metadataCacheMu.RLock()
+		remaining := len(h.metadataCache)
+		h.metadataCacheMu.RUnlock()
+		assert.Equal(t, 2, remaining, "transient errors must not prune metadata")
+	})
+
+	t.Run("partial success -> subset, no prune", func(t *testing.T) {
+		h := newTestRetainedStore(t, testNode1)
+		seedLocalRetained(t, h, "m/x/present", []byte("here"))
+		seedMetadataOnly(h, "m/x/remote", testNode2, false) // errors: nil transport
+
+		msgs, err := h.Match(context.Background(), "m/x/#")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"m/x/present"}, matchedTopics(msgs))
+
+		h.metadataCacheMu.RLock()
+		_, errKept := h.metadataCache["m/x/remote"]
+		h.metadataCacheMu.RUnlock()
+		assert.True(t, errKept, "entry that errored transiently must be retried later, not pruned")
+	})
+}
+
+// TestRetainedStore_pruneMissingMetadata_PointerGuard verifies that a prune
+// only removes the exact metadata pointer Match observed, so a concurrent Set
+// that replaced the entry is never clobbered.
+func TestRetainedStore_pruneMissingMetadata_PointerGuard(t *testing.T) {
+	h := newTestRetainedStore(t, testNode1)
+	topic := "m/x/topic"
+	stale := &RetainedMetadata{NodeID: testNode1, Topic: topic}
+	h.metadataCache[topic] = stale
+
+	// Simulate a concurrent Set replacing the pointer before prune runs.
+	fresh := &RetainedMetadata{NodeID: testNode1, Topic: topic}
+	h.metadataCache[topic] = fresh
+
+	h.pruneMissingMetadata(retainedRef{topic: topic, meta: stale})
+
+	h.metadataCacheMu.RLock()
+	got := h.metadataCache[topic]
+	h.metadataCacheMu.RUnlock()
+	assert.Same(t, fresh, got, "prune must not remove a concurrently-updated entry")
+
+	// Pruning the current pointer does remove it.
+	h.pruneMissingMetadata(retainedRef{topic: topic, meta: fresh})
+	h.metadataCacheMu.RLock()
+	_, exists := h.metadataCache[topic]
+	h.metadataCacheMu.RUnlock()
+	assert.False(t, exists, "prune must remove the matching pointer")
+}
+
+// TestRetainedStore_Match_ConcurrentReaders exercises Match under -race with
+// many concurrent callers to confirm the metadata-cache locking is sound.
+func TestRetainedStore_Match_ConcurrentReaders(t *testing.T) {
+	h := newTestRetainedStore(t, testNode1)
+	for i := range 30 {
+		seedLocalRetained(t, h, fmt.Sprintf("m/x/%02d", i), []byte("p"))
+	}
+
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Go(func() {
+			for range 20 {
+				msgs, err := h.Match(context.Background(), "m/x/#")
+				assert.NoError(t, err)
+				assert.Len(t, msgs, 30)
+			}
+		})
+	}
+	wg.Wait()
 }
 
 // TestRetainedStore_SizeThreshold tests messages at threshold boundary.
@@ -179,7 +389,7 @@ func TestRetainedStore_WatchEventHandling(t *testing.T) {
 // TestRetainedMetadata_JSON tests JSON marshaling/unmarshaling.
 func TestRetainedMetadata_JSON(t *testing.T) {
 	metadata := &RetainedMetadata{
-		NodeID:     "node1",
+		NodeID:     testNode1,
 		Topic:      "test/topic",
 		QoS:        1,
 		Size:       512,
@@ -209,7 +419,7 @@ func TestRetainedMetadata_JSON(t *testing.T) {
 func TestRetainedDataEntry_JSON(t *testing.T) {
 	entry := &RetainedDataEntry{
 		Metadata: RetainedMetadata{
-			NodeID:     "node1",
+			NodeID:     testNode1,
 			Topic:      "test/topic",
 			QoS:        2,
 			Size:       100,

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.44.0
 	golang.org/x/crypto v0.53.0
 	golang.org/x/net v0.56.0
+	golang.org/x/sync v0.21.0
 	golang.org/x/time v0.15.0
 	google.golang.org/grpc v1.82.0
 	google.golang.org/protobuf v1.36.11
@@ -93,7 +94,6 @@ require (
 	go.uber.org/zap v1.27.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/exp v0.0.0-20251017212417-90e834f514db // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect


### PR DESCRIPTION

<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?
This is an enhancement.
<!--
This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?
Cluster retained Match iterated the metadata cache in Go map order and fetched each matching payload sequentially.
On a wildcard subscribe this delivered retained messages in a random order on every call, and when a payload had to be fetched from a remote node the per-topic fetches could exceed the caller's deadline, silently dropping a different subset each time. Clients saw a "different set of retained messages" on every subscribe to the same filter.

Match now:
- sorts matching topics so delivery order is stable across calls;
- resolves payloads concurrently (bounded errgroup) so many remote fetches complete within the caller's budget instead of truncating;
- prunes metadata whose payload is gone (ErrNotFound), guarded by pointer identity so a concurrent Set is never clobbered;
- keeps the "all fetches failed" hard error but no longer turns a transient partial failure into a silent, per-call-random subset.

Adds cluster/retained_test.go coverage for completeness/determinism, pruning, transient-error surfacing, the pointer guard, and concurrent readers. Promotes golang.org/x/sync to a direct dependency.


## Which issue(s) does this PR fix/relate to?
<!--
- Related Issue #
- Resolves #
-->
There is no such issue.
## Have you included tests for your changes?
Yes.

## Did you document any new/modified features?
N/A

### Notes
N/A