### PR TITLE
fix sitemap URLs to use trailing slashes

### DIFF
--- a/docs/lib/base-path.ts
+++ b/docs/lib/base-path.ts
@@ -14,10 +14,13 @@ export function toSiteUrl(path: string): string {
   const base =
     process.env.NEXT_PUBLIC_BASE_URL || "https://www.absmach.eu/docs/fluxmq";
   const normalizedBase = base.replace(/\/$/, "");
+  let url: string;
 
   if (path.startsWith(BASE_PATH)) {
-    return new URL(path, new URL(base).origin).toString();
+    url = new URL(path, new URL(base).origin).toString();
+  } else {
+    url = `${normalizedBase}${path.startsWith("/") ? path : `/${path}`}`;
   }
 
-  return `${normalizedBase}${path.startsWith("/") ? path : `/${path}`}`;
+  return url.endsWith("/") ? url : `${url}/`;
 }


### PR DESCRIPTION
Updates the shared site URL helper so generated sitemap and metadata page URLs use trailing slashes and avoid redirects.\n\nVerification:\n- pnpm lint (fails on existing Biome issues in app/global.css and components/mdx/mermaid.tsx)\n- pnpm types:check (fails on existing Next/fumadocs dependency type errors)\n- pnpm build (fails on existing fumadocs-openapi export mismatch)