### PR TITLE
Add isolated AMQP local principals for Atom audit publishing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,13 @@ test-client-integration:
 	# Optional override: FLUXMQ_AMQP_TEST_HOST=<docker-host-ip-or-name>
 	$(GO) test ./client/... -tags=integration -run RabbitMQ -count=1 -v -timeout 10m
 
+# Build and start the real broker, then exercise the dedicated mTLS AMQP 0.9.1
+# local-principal path, external-callout isolation, rotation, and persistence.
+.PHONY: smoke-local-auth
+smoke-local-auth: build
+	FLUXMQ_SMOKE_BINARY=$(CURDIR)/$(BUILD_DIR)/$(BINARY) \
+		$(GO) test -tags=smoke -count=1 -v -timeout 3m ./tests/smoke
+
 # Run full tests (including stress)
 .PHONY: test-full
 test-full:

--- a/amqp/broker/broker.go
+++ b/amqp/broker/broker.go
@@ -223,6 +223,11 @@ func (b *Broker) DisconnectInvalidLocalSessions(isValid func(LocalSessionIdentit
 		return 0
 	}
 
+	// Each disconnect writes a Connection.Close under a write deadline, so an
+	// unresponsive peer costs up to that deadline. Revocation runs while the
+	// reload holds its lock, so disconnect concurrently: the cost stays one
+	// deadline in total rather than one per stalled peer.
+	var revoked sync.WaitGroup
 	disconnected := 0
 	b.connections.Range(func(_, value any) bool {
 		conn, ok := value.(*Connection)
@@ -234,9 +239,14 @@ func (b *Broker) DisconnectInvalidLocalSessions(isValid func(LocalSessionIdentit
 			return true
 		}
 		disconnected++
-		conn.disconnect(codec.AccessRefused, "local principal credentials revoked")
+		revoked.Add(1)
+		go func() {
+			defer revoked.Done()
+			conn.disconnect(codec.AccessRefused, "local principal credentials revoked")
+		}()
 		return true
 	})
+	revoked.Wait()
 	if disconnected > 0 {
 		b.stats.AddLocalForcedDisconnects(uint64(disconnected))
 		b.logger.Warn("amqp091_local_sessions_disconnected",

--- a/amqp/broker/broker.go
+++ b/amqp/broker/broker.go
@@ -11,8 +11,10 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/absmach/fluxmq/amqp/codec"
 	corebroker "github.com/absmach/fluxmq/broker"
 	"github.com/absmach/fluxmq/broker/router"
 	"github.com/absmach/fluxmq/cluster"
@@ -34,6 +36,13 @@ type channelQueueManager interface {
 	CommitOffset(ctx context.Context, queueName, groupID string, offset uint64) error
 }
 
+// durableStreamQueuePublisher is intentionally separate from the general
+// queue-manager interface. The local-principal listener fails closed unless
+// the concrete manager can target and durably sync one exact stream.
+type durableStreamQueuePublisher interface {
+	PublishToDurableStream(ctx context.Context, queueName string, publish qtypes.PublishRequest) error
+}
+
 // IsAMQP091Client checks if a client ID belongs to an AMQP 0.9.1 client.
 func IsAMQP091Client(clientID string) bool {
 	return corebroker.IsAMQP091Client(clientID)
@@ -47,6 +56,7 @@ func PrefixedClientID(connID string) string {
 // Broker is the core AMQP 0.9.1 broker.
 type Broker struct {
 	connections         sync.Map // connID -> *Connection
+	connectionSeq       atomic.Uint64
 	router              *router.TrieRouter
 	routeResolver       *corebroker.RoutingResolver
 	queueManager        channelQueueManager
@@ -57,6 +67,14 @@ type Broker struct {
 	routePublishTimeout time.Duration
 	stats               *Stats
 	logger              *slog.Logger
+}
+
+func (b *Broker) nextConnectionID(remote net.Addr) string {
+	remoteAddress := "unknown"
+	if remote != nil {
+		remoteAddress = remote.String()
+	}
+	return fmt.Sprintf("%s@%d", remoteAddress, b.connectionSeq.Add(1))
 }
 
 // New creates a new AMQP 0.9.1 broker.
@@ -133,7 +151,18 @@ func (b *Broker) SetRoutePublishTimeout(d time.Duration) {
 
 // HandleConnection handles a new raw TCP connection through the full AMQP 0.9.1 lifecycle.
 func (b *Broker) HandleConnection(ctx context.Context, netConn net.Conn) {
-	c := newConnection(b, netConn)
+	b.handleConnection(ctx, netConn, nil)
+}
+
+// HandleConnectionWithPolicy handles a connection using an immutable,
+// listener-scoped security policy. This is the entry point for servers that
+// expose multiple AMQP listeners with different trust boundaries.
+func (b *Broker) HandleConnectionWithPolicy(ctx context.Context, netConn net.Conn, policy *ConnectionPolicy) {
+	b.handleConnection(ctx, netConn, policy)
+}
+
+func (b *Broker) handleConnection(ctx context.Context, netConn net.Conn, policy *ConnectionPolicy) {
+	c := newConnection(ctx, b, netConn, policy)
 	if err := c.run(); err != nil { //nolint:contextcheck // connection lifecycle manages its own context for cleanup
 		b.logger.Debug("AMQP 0.9.1 connection ended", "remote", netConn.RemoteAddr(), "error", err)
 	}
@@ -181,6 +210,59 @@ func (b *Broker) ConnectionName(connID string) string {
 		return ""
 	}
 	return v.(*Connection).connectionName
+}
+
+// DisconnectInvalidLocalSessions disconnects every local-principal session for
+// which isValid returns false. It is intended for atomic credential/ACL reloads
+// and never evaluates or mutates external-auth sessions.
+//
+// The returned value is the number of connections selected for disconnection.
+func (b *Broker) DisconnectInvalidLocalSessions(isValid func(LocalSessionIdentity) bool) int {
+	if isValid == nil {
+		return 0
+	}
+
+	disconnected := 0
+	b.connections.Range(func(_, value any) bool {
+		conn, ok := value.(*Connection)
+		if !ok {
+			return true
+		}
+		identity, ok := conn.localSessionIdentity()
+		if !ok || isValid(identity) {
+			return true
+		}
+		disconnected++
+		conn.disconnect(codec.AccessRefused, "local principal credentials revoked")
+		return true
+	})
+	if disconnected > 0 {
+		b.stats.AddLocalForcedDisconnects(uint64(disconnected))
+		b.logger.Warn("amqp091_local_sessions_disconnected",
+			"auth_mode", "local",
+			"outcome", "disconnected",
+			"reason", "credentials_or_policy_revoked",
+			"count", disconnected)
+	}
+	return disconnected
+}
+
+// RecordLocalPrincipalReload records one completed local-principal reload
+// attempt. Successful no-op reloads count as successes because mounted secret
+// files are intentionally revalidated on every attempt.
+func (b *Broker) RecordLocalPrincipalReload(success bool) {
+	if success {
+		b.stats.IncrementLocalReloadSuccess()
+		b.logger.Info("amqp091_local_principal_reload",
+			"auth_mode", "local",
+			"outcome", "success")
+		return
+	}
+	b.stats.IncrementLocalReloadFailures()
+	b.logger.Warn("amqp091_local_principal_reload",
+		"auth_mode", "local",
+		"outcome", "failure",
+		"reason", "validation_or_load_failed")
 }
 
 // Publish routes a message to local AMQP 0.9.1 subscribers and remote cluster nodes.

--- a/amqp/broker/broker.go
+++ b/amqp/broker/broker.go
@@ -65,6 +65,7 @@ type Broker struct {
 	cluster             cluster.Cluster
 	crossDeliver        corebroker.CrossDeliverFunc
 	routePublishTimeout time.Duration
+	durableAppends      durableAppendLimiter
 	stats               *Stats
 	logger              *slog.Logger
 }

--- a/amqp/broker/broker_test.go
+++ b/amqp/broker/broker_test.go
@@ -253,3 +253,27 @@ func TestPrefixedClientIDUsesCorePrefix(t *testing.T) {
 		t.Fatalf("PrefixedClientID mismatch: got %q", got)
 	}
 }
+
+func TestConnectionIDsAreUniqueForSameRemoteAddress(t *testing.T) {
+	b := New(nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	firstTransport := &memoryConn{}
+	secondTransport := &memoryConn{}
+	first := newConnection(context.Background(), b, firstTransport, nil)
+	second := newConnection(context.Background(), b, secondTransport, nil)
+
+	if first.connID == second.connID {
+		t.Fatalf("connections sharing RemoteAddr received the same ID %q", first.connID)
+	}
+	if !IsAMQP091Client(PrefixedClientID(first.connID)) || !IsAMQP091Client(PrefixedClientID(second.connID)) {
+		t.Fatal("unique connection IDs lost the AMQP 0.9.1 client prefix")
+	}
+	b.registerConnection(first.connID, first)
+	b.registerConnection(second.connID, second)
+	if got := len(b.ConnectionIDs()); got != 2 {
+		t.Fatalf("active connection count = %d, want 2", got)
+	}
+	b.unregisterConnection(first.connID)
+	if !b.HasConnection(second.connID) {
+		t.Fatal("unregistering one connection removed the other connection with the same RemoteAddr")
+	}
+}

--- a/amqp/broker/channel.go
+++ b/amqp/broker/channel.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -20,6 +21,7 @@ import (
 	"github.com/absmach/fluxmq/amqp/codec"
 	corebroker "github.com/absmach/fluxmq/broker"
 	"github.com/absmach/fluxmq/internal/bufpool"
+	queuepkg "github.com/absmach/fluxmq/queue"
 	qtypes "github.com/absmach/fluxmq/queue/types"
 	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/topics"
@@ -105,7 +107,8 @@ type Channel struct {
 	// Queue sequence for server-generated names
 	queueSeq atomic.Uint64
 
-	closed atomic.Bool
+	serverClosing atomic.Bool
+	closed        atomic.Bool
 }
 
 type unackedDelivery struct {
@@ -137,6 +140,24 @@ func newChannel(c *Connection, id uint16) *Channel {
 }
 
 func (ch *Channel) handleMethod(decoded any) error {
+	if ch.serverClosing.Load() {
+		switch decoded.(type) {
+		case *codec.ChannelClose, *codec.ChannelCloseOk:
+		default:
+			return nil
+		}
+	}
+
+	if ch.conn.connectionPolicy().mode == ConnectionPolicyLocalPublishOnly {
+		allowed, err := ch.authorizeLocalMethod(decoded)
+		if err != nil {
+			return err
+		}
+		if !allowed {
+			return nil
+		}
+	}
+
 	switch m := decoded.(type) {
 	// Channel
 	case *codec.ChannelFlow:
@@ -187,14 +208,14 @@ func (ch *Channel) handleMethod(decoded any) error {
 		return ch.handleBasicCancel(m)
 	case *codec.BasicPublish:
 		if ch.pendingMethod != nil || ch.pendingHeader != nil {
-			_ = ch.conn.sendChannelClose(ch.id, codec.CommandInvalid,
+			_ = ch.sendChannelClose(codec.CommandInvalid,
 				"publish in progress", codec.ClassBasic, codec.MethodBasicPublish)
 			ch.resetPendingPublish()
 			return nil
 		}
-		m.Exchange = normalizeExchange(m.Exchange)
-		if m.Exchange != "" && !ch.exchangeExists(m.Exchange) {
-			_ = ch.conn.sendChannelClose(ch.id, codec.NotFound,
+		exchangeName := normalizeExchange(m.Exchange)
+		if exchangeName != "" && !ch.exchangeExists(exchangeName) {
+			_ = ch.sendChannelClose(codec.NotFound,
 				"exchange not found", codec.ClassBasic, codec.MethodBasicPublish)
 			ch.resetPendingPublish()
 			return nil
@@ -235,10 +256,103 @@ func (ch *Channel) handleMethod(decoded any) error {
 	}
 }
 
+func (ch *Channel) authorizeLocalMethod(decoded any) (bool, error) {
+	principalID := ""
+	if ch.conn.localIdentity != nil {
+		principalID = ch.conn.localIdentity.PrincipalID
+	}
+	switch method := decoded.(type) {
+	case *codec.ChannelFlow, *codec.ChannelClose, *codec.ChannelCloseOk, *codec.ConfirmSelect:
+		return true, nil
+	case *codec.BasicPublish:
+		if ch.conn.canPublishLocal(method.Exchange, method.RoutingKey) {
+			return true, nil
+		}
+		ch.conn.broker.stats.IncrementLocalPublishDenials()
+		ch.conn.logger.Warn("amqp091_local_authorization",
+			"auth_mode", "local",
+			"outcome", "denied",
+			"reason", "publish_acl_mismatch",
+			"principal_id", principalID,
+			"exchange", method.Exchange,
+			"routing_key", method.RoutingKey)
+		return false, ch.sendChannelClose(codec.AccessRefused, "publish not authorized", codec.ClassBasic, codec.MethodBasicPublish)
+	default:
+		classID, methodID := methodIdentifier(decoded)
+		ch.conn.broker.stats.IncrementLocalOperationDenials()
+		ch.conn.logger.Warn("amqp091_local_authorization",
+			"auth_mode", "local",
+			"outcome", "denied",
+			"reason", "operation_not_permitted",
+			"principal_id", principalID,
+			"class_id", classID,
+			"method_id", methodID)
+		return false, ch.sendChannelClose(codec.AccessRefused, "operation not permitted for local publisher", classID, methodID)
+	}
+}
+
+func (ch *Channel) sendChannelClose(code uint16, text string, classID, methodID uint16) error {
+	ch.serverClosing.Store(true)
+	ch.resetPendingPublish()
+	return ch.conn.sendChannelClose(ch.id, code, text, classID, methodID)
+}
+
+func methodIdentifier(method any) (uint16, uint16) {
+	switch method.(type) {
+	case *codec.ExchangeDeclare:
+		return codec.ClassExchange, codec.MethodExchangeDeclare
+	case *codec.ExchangeDelete:
+		return codec.ClassExchange, codec.MethodExchangeDelete
+	case *codec.ExchangeBind:
+		return codec.ClassExchange, codec.MethodExchangeBind
+	case *codec.ExchangeUnbind:
+		return codec.ClassExchange, codec.MethodExchangeUnbind
+	case *codec.QueueDeclare:
+		return codec.ClassQueue, codec.MethodQueueDeclare
+	case *codec.QueueBind:
+		return codec.ClassQueue, codec.MethodQueueBind
+	case *codec.QueueUnbind:
+		return codec.ClassQueue, codec.MethodQueueUnbind
+	case *codec.QueuePurge:
+		return codec.ClassQueue, codec.MethodQueuePurge
+	case *codec.QueueDelete:
+		return codec.ClassQueue, codec.MethodQueueDelete
+	case *codec.BasicQos:
+		return codec.ClassBasic, codec.MethodBasicQos
+	case *codec.BasicConsume:
+		return codec.ClassBasic, codec.MethodBasicConsume
+	case *codec.BasicCancel:
+		return codec.ClassBasic, codec.MethodBasicCancel
+	case *codec.BasicGet:
+		return codec.ClassBasic, codec.MethodBasicGet
+	case *codec.BasicAck:
+		return codec.ClassBasic, codec.MethodBasicAck
+	case *codec.BasicReject:
+		return codec.ClassBasic, codec.MethodBasicReject
+	case *codec.BasicNack:
+		return codec.ClassBasic, codec.MethodBasicNack
+	case *codec.BasicRecover:
+		return codec.ClassBasic, codec.MethodBasicRecover
+	case *codec.BasicRecoverAsync:
+		return codec.ClassBasic, codec.MethodBasicRecoverAsync
+	case *codec.TxSelect:
+		return codec.ClassTx, codec.MethodTxSelect
+	case *codec.TxCommit:
+		return codec.ClassTx, codec.MethodTxCommit
+	case *codec.TxRollback:
+		return codec.ClassTx, codec.MethodTxRollback
+	default:
+		return 0, 0
+	}
+}
+
 // handleHeaderFrame processes a content header frame (part of a publish).
 func (ch *Channel) handleHeaderFrame(frame *codec.Frame) {
+	if ch.serverClosing.Load() {
+		return
+	}
 	if ch.pendingMethod == nil || ch.pendingHeader != nil {
-		_ = ch.conn.sendChannelClose(ch.id, codec.UnexpectedFrame,
+		_ = ch.sendChannelClose(codec.UnexpectedFrame,
 			"unexpected content header", codec.ClassBasic, codec.MethodBasicPublish)
 		ch.resetPendingPublish()
 		return
@@ -248,6 +362,12 @@ func (ch *Channel) handleHeaderFrame(frame *codec.Frame) {
 	header, err := codec.ReadContentHeader(r)
 	if err != nil {
 		ch.conn.logger.Error("failed to read content header", "error", err)
+		return
+	}
+	if limit := ch.conn.connectionPolicy().maxMessageSize; limit > 0 && header.BodySize > limit {
+		_ = ch.sendChannelClose(codec.ContentTooLarge,
+			"message exceeds maximum size", codec.ClassBasic, codec.MethodBasicPublish)
+		ch.resetPendingPublish()
 		return
 	}
 	ch.pendingHeader = header
@@ -267,8 +387,11 @@ func (ch *Channel) handleHeaderFrame(frame *codec.Frame) {
 
 // handleBodyFrame processes a content body frame.
 func (ch *Channel) handleBodyFrame(frame *codec.Frame) {
+	if ch.serverClosing.Load() {
+		return
+	}
 	if ch.pendingMethod == nil || ch.pendingHeader == nil {
-		_ = ch.conn.sendChannelClose(ch.id, codec.UnexpectedFrame,
+		_ = ch.sendChannelClose(codec.UnexpectedFrame,
 			"unexpected content body", codec.ClassBasic, codec.MethodBasicPublish)
 		ch.resetPendingPublish()
 		return
@@ -276,7 +399,7 @@ func (ch *Channel) handleBodyFrame(frame *codec.Frame) {
 
 	nextSize := ch.pendingBodyReceived + uint64(len(frame.Payload))
 	if nextSize > ch.pendingBodySize {
-		_ = ch.conn.sendChannelClose(ch.id, codec.ContentTooLarge,
+		_ = ch.sendChannelClose(codec.ContentTooLarge,
 			"content body larger than header", codec.ClassBasic, codec.MethodBasicPublish)
 		ch.resetPendingPublish()
 		return
@@ -326,9 +449,14 @@ func (ch *Channel) completePublish() {
 		props["type"] = header.Properties.Type
 	}
 
-	if v, ok := header.Properties.Headers[corebroker.ExternalIDProperty].(string); ok && v != "" {
+	clientID := PrefixedClientID(ch.conn.connID)
+	if ch.conn.connectionPolicy().mode == ConnectionPolicyLocalPublishOnly {
+		if principalID := ch.conn.externalID(clientID); principalID != "" {
+			props[corebroker.ExternalIDProperty] = principalID
+		}
+	} else if v, ok := header.Properties.Headers[corebroker.ExternalIDProperty].(string); ok && v != "" {
 		props[corebroker.ExternalIDProperty] = v
-	} else if externalID := ch.conn.broker.ExternalID(PrefixedClientID(ch.conn.connID)); externalID != "" {
+	} else if externalID := ch.conn.externalID(clientID); externalID != "" {
 		props[corebroker.ExternalIDProperty] = externalID
 	}
 	if v, ok := header.Properties.Headers[corebroker.ProtocolProperty].(string); ok && v != "" {
@@ -346,30 +474,55 @@ func (ch *Channel) completePublish() {
 		topic = exchangeName + "/" + routingKey
 	}
 
-	clientID := PrefixedClientID(ch.conn.connID)
 	props = corebroker.AddClientIDProperty(props, clientID)
 	originalTopic := topic
 
-	hookReq, ok := ch.conn.broker.ApplyHook(context.Background(), corebroker.BlockingHookRequest{
-		Hook:       corebroker.HookAuthOnPublish,
-		ClientID:   clientID,
-		ExternalID: ch.conn.broker.ExternalID(clientID),
-		Topic:      topic,
-		Payload:    body,
-		Properties: props,
-	})
-	if !ok {
-		ch.conn.logger.Warn("publish hook denied", "client_id", clientID, "topic", topic)
-		_ = ch.conn.sendChannelClose(ch.id, codec.AccessRefused, "publish hook denied", codec.ClassBasic, codec.MethodBasicPublish)
-		return
-	}
-	topic, body, props = hookReq.Topic, hookReq.Payload, hookReq.Properties
-	if auth := ch.conn.broker.auth; auth != nil {
-		if !auth.CanPublish(clientID, topic) {
-			ch.conn.logger.Warn("publish denied", "client_id", clientID, "topic", topic)
-			_ = ch.conn.sendChannelClose(ch.id, codec.AccessRefused, "publish not authorized", codec.ClassBasic, codec.MethodBasicPublish)
+	policy := ch.conn.connectionPolicy()
+	if policy.mode == ConnectionPolicyLocalPublishOnly {
+		// Re-evaluate at completion so an ACL reduction made while content frames
+		// are in flight takes effect immediately.
+		if !ch.conn.canPublishLocal(method.Exchange, method.RoutingKey) {
+			ch.conn.broker.stats.IncrementLocalPublishDenials()
+			ch.conn.logger.Warn("amqp091_local_authorization",
+				"auth_mode", "local",
+				"outcome", "denied",
+				"reason", "publish_acl_changed",
+				"principal_id", ch.conn.externalID(clientID),
+				"exchange", method.Exchange,
+				"routing_key", method.RoutingKey)
+			_ = ch.sendChannelClose(codec.AccessRefused, "publish not authorized", codec.ClassBasic, codec.MethodBasicPublish)
 			return
 		}
+	} else {
+		hookReq, ok := ch.conn.applyHook(context.Background(), corebroker.BlockingHookRequest{
+			Hook:       corebroker.HookAuthOnPublish,
+			ClientID:   clientID,
+			ExternalID: ch.conn.externalID(clientID),
+			Topic:      topic,
+			Payload:    body,
+			Properties: props,
+		})
+		if !ok {
+			ch.conn.logger.Warn("publish hook denied", "client_id", clientID, "topic", topic)
+			_ = ch.sendChannelClose(codec.AccessRefused, "publish hook denied", codec.ClassBasic, codec.MethodBasicPublish)
+			return
+		}
+		topic, body, props = hookReq.Topic, hookReq.Payload, hookReq.Properties
+		if auth := policy.externalAuth; auth != nil {
+			if !auth.CanPublish(clientID, topic) {
+				ch.conn.logger.Warn("publish denied", "client_id", clientID, "topic", topic)
+				_ = ch.sendChannelClose(codec.AccessRefused, "publish not authorized", codec.ClassBasic, codec.MethodBasicPublish)
+				return
+			}
+		}
+	}
+	if policy.mode == ConnectionPolicyLocalPublishOnly {
+		if exchangeName != "" {
+			ch.rejectLocalStreamPublish(fmt.Errorf("local durable stream publish requires the default exchange"))
+			return
+		}
+		ch.handleLocalDurableStreamPublish(routingKey, body, props, clientID)
+		return
 	}
 
 	// Route through resolver for default-exchange queue operations.
@@ -813,7 +966,7 @@ func (ch *Channel) handleExchangeDeclare(m *codec.ExchangeDeclare) error {
 	m.Exchange = normalizeExchange(m.Exchange)
 	if m.Passive {
 		if !ch.exchangeExists(m.Exchange) {
-			return ch.conn.sendChannelClose(ch.id, codec.NotFound,
+			return ch.sendChannelClose(codec.NotFound,
 				"exchange not found", codec.ClassExchange, codec.MethodExchangeDeclare)
 		}
 		if !m.NoWait {
@@ -895,7 +1048,7 @@ func (ch *Channel) handleQueueDeclare(m *codec.QueueDeclare) error {
 		_, exists := ch.queues[m.Queue]
 		ch.exchangeMu.RUnlock()
 		if !exists {
-			return ch.conn.sendChannelClose(ch.id, codec.NotFound,
+			return ch.sendChannelClose(codec.NotFound,
 				"queue not found", codec.ClassQueue, codec.MethodQueueDeclare)
 		}
 		if !m.NoWait {
@@ -942,6 +1095,10 @@ func (ch *Channel) handleQueueDeclare(m *codec.QueueDeclare) error {
 		}
 
 		if err := qm.CreateQueue(context.Background(), cfg); err != nil {
+			if errors.Is(err, queuepkg.ErrProtectedQueueMutation) {
+				return ch.sendChannelClose(codec.PreconditionFailed,
+					"protected queue contract cannot be changed", codec.ClassQueue, codec.MethodQueueDeclare)
+			}
 			if existing, getErr := qm.GetQueue(context.Background(), m.Queue); getErr == nil && existing != nil {
 				existing.Type = qtypes.QueueType(queueType)
 				if queueType == string(qtypes.QueueTypeStream) {
@@ -957,6 +1114,10 @@ func (ch *Channel) handleQueueDeclare(m *codec.QueueDeclare) error {
 					}
 				}
 				if err := qm.UpdateQueue(context.Background(), *existing); err != nil {
+					if errors.Is(err, queuepkg.ErrProtectedQueueMutation) {
+						return ch.sendChannelClose(codec.PreconditionFailed,
+							"protected queue contract cannot be changed", codec.ClassQueue, codec.MethodQueueDeclare)
+					}
 					ch.conn.logger.Warn("failed to update queue config", "queue", m.Queue, "error", err)
 				}
 			}
@@ -1063,10 +1224,10 @@ func (ch *Channel) handleBasicConsume(m *codec.BasicConsume) error {
 	}
 
 	clientID := PrefixedClientID(ch.conn.connID)
-	externalID := ch.conn.broker.ExternalID(clientID)
+	externalID := ch.conn.externalID(clientID)
 	queueFilter := m.Queue
 
-	req, ok := ch.conn.broker.ApplyHook(context.Background(), corebroker.BlockingHookRequest{
+	req, ok := ch.conn.applyHook(context.Background(), corebroker.BlockingHookRequest{
 		Hook:       corebroker.HookAuthOnSubscribe,
 		ClientID:   clientID,
 		ExternalID: externalID,
@@ -1074,14 +1235,14 @@ func (ch *Channel) handleBasicConsume(m *codec.BasicConsume) error {
 	})
 	if !ok {
 		ch.conn.logger.Warn("subscribe hook denied", "client_id", clientID, "filter", queueFilter)
-		return ch.conn.sendChannelClose(ch.id, codec.AccessRefused, "subscribe hook denied", codec.ClassBasic, codec.MethodBasicConsume)
+		return ch.sendChannelClose(codec.AccessRefused, "subscribe hook denied", codec.ClassBasic, codec.MethodBasicConsume)
 	}
 	queueFilter = req.Topic
 
-	if auth := ch.conn.broker.auth; auth != nil {
+	if auth := ch.conn.connectionPolicy().externalAuth; auth != nil {
 		if !auth.CanSubscribe(clientID, queueFilter) {
 			ch.conn.logger.Warn("subscribe denied", "client_id", clientID, "filter", queueFilter)
-			return ch.conn.sendChannelClose(ch.id, codec.AccessRefused, "subscribe not authorized", codec.ClassBasic, codec.MethodBasicConsume)
+			return ch.sendChannelClose(codec.AccessRefused, "subscribe not authorized", codec.ClassBasic, codec.MethodBasicConsume)
 		}
 	}
 
@@ -1115,7 +1276,7 @@ func (ch *Channel) handleBasicConsume(m *codec.BasicConsume) error {
 	ch.consumersMu.Lock()
 	if _, exists := ch.consumers[tag]; exists {
 		ch.consumersMu.Unlock()
-		return ch.conn.sendChannelClose(ch.id, codec.NotAllowed,
+		return ch.sendChannelClose(codec.NotAllowed,
 			fmt.Sprintf("consumer tag %q already exists", tag), codec.ClassBasic, codec.MethodBasicConsume)
 	}
 	ch.consumers[tag] = &consumer{
@@ -1491,6 +1652,39 @@ func (ch *Channel) handleQueuePublish(queueTopic string, body []byte, props map[
 	}
 }
 
+func (ch *Channel) handleLocalDurableStreamPublish(queueName string, body []byte, props map[string]string, clientID string) {
+	qm := ch.conn.broker.queueManager
+	publisher, ok := qm.(durableStreamQueuePublisher)
+	if qm == nil || !ok {
+		ch.rejectLocalStreamPublish(fmt.Errorf("durable exact stream publisher is unavailable"))
+		return
+	}
+	props = corebroker.AddClientIDProperty(props, clientID)
+	err := publisher.PublishToDurableStream(context.Background(), queueName, qtypes.PublishRequest{
+		ClientID:   clientID,
+		Topic:      ch.conn.broker.routeResolver.QueueTopic(queueName),
+		Payload:    body,
+		Properties: props,
+	})
+	if err != nil {
+		ch.rejectLocalStreamPublish(err)
+		return
+	}
+	if ch.confirmMode {
+		ch.sendPublisherAck()
+	}
+}
+
+func (ch *Channel) rejectLocalStreamPublish(err error) {
+	ch.conn.logger.Error("local durable stream publish failed", "error", err)
+	if ch.confirmMode {
+		ch.sendPublisherNack()
+		return
+	}
+	_ = ch.sendChannelClose(codec.InternalError,
+		"durable stream publish failed", codec.ClassBasic, codec.MethodBasicPublish)
+}
+
 // handleQueueCommit processes a stream offset commit routed via the resolver.
 func (ch *Channel) handleQueueCommit(route corebroker.RouteResult, header *codec.ContentHeader) {
 	qm := ch.conn.broker.queueManager
@@ -1554,9 +1748,21 @@ func (ch *Channel) isStreamQueue(name string) bool {
 	if info := ch.getQueueInfo(name); info != nil && info.queueType == string(qtypes.QueueTypeStream) {
 		return true
 	}
+	queueNames := []string{name}
 	if queueName, _ := corebroker.ParseQueueFilter(name); queueName != "" {
 		if info := ch.getQueueInfo(queueName); info != nil && info.queueType == string(qtypes.QueueTypeStream) {
 			return true
+		}
+		if queueName != name {
+			queueNames = append(queueNames, queueName)
+		}
+	}
+	if qm := ch.conn.broker.queueManager; qm != nil {
+		for _, queueName := range queueNames {
+			cfg, err := qm.GetQueue(context.Background(), queueName)
+			if err == nil && cfg != nil && cfg.Type == qtypes.QueueTypeStream {
+				return true
+			}
 		}
 	}
 	return false

--- a/amqp/broker/channel.go
+++ b/amqp/broker/channel.go
@@ -1660,7 +1660,9 @@ func (ch *Channel) handleLocalDurableStreamPublish(queueName string, body []byte
 		return
 	}
 	props = corebroker.AddClientIDProperty(props, clientID)
-	err := publisher.PublishToDurableStream(context.Background(), queueName, qtypes.PublishRequest{
+	ctx, cancel := context.WithTimeout(ch.conn.publishContext(), localPublishTimeout)
+	defer cancel()
+	err := publisher.PublishToDurableStream(ctx, queueName, qtypes.PublishRequest{
 		ClientID:   clientID,
 		Topic:      ch.conn.broker.routeResolver.QueueTopic(queueName),
 		Payload:    body,

--- a/amqp/broker/channel.go
+++ b/amqp/broker/channel.go
@@ -1659,6 +1659,20 @@ func (ch *Channel) handleLocalDurableStreamPublish(queueName string, body []byte
 		ch.rejectLocalStreamPublish(fmt.Errorf("durable exact stream publisher is unavailable"))
 		return
 	}
+	// Abandoned appends keep running and keep their payload, so a stream that
+	// already has the maximum waiting on storage refuses new work outright
+	// rather than starting a barrier that nothing will wait for.
+	if !ch.conn.broker.durableAppends.acquire(queueName) {
+		ch.conn.broker.stats.IncrementLocalPublishRejections()
+		ch.conn.logger.Warn("amqp091_local_publish",
+			"auth_mode", "local",
+			"outcome", "rejected",
+			"reason", "durable_append_backlog",
+			"queue", queueName)
+		ch.abandonLocalStreamPublish(fmt.Errorf("stream %q already has the maximum durable appends waiting on storage", queueName))
+		return
+	}
+
 	props = corebroker.AddClientIDProperty(props, clientID)
 	ctx, cancel := context.WithTimeout(ch.conn.publishContext(), localPublishTimeout)
 	defer cancel()
@@ -1669,9 +1683,11 @@ func (ch *Channel) handleLocalDurableStreamPublish(queueName string, body []byte
 	// deadline passes: the connection goroutine stays responsive and the session
 	// can be closed, instead of a stalled disk holding a listener slot open
 	// indefinitely. The abandoned append may still complete and become visible,
-	// which is why a NACK is not proof that the record was not written.
+	// which is why a NACK is not proof that the record was not written. The slot
+	// is released only when the barrier really finishes.
 	result := make(chan error, 1)
 	go func() {
+		defer ch.conn.broker.durableAppends.release(queueName)
 		result <- publisher.PublishToDurableStream(ctx, queueName, qtypes.PublishRequest{
 			ClientID:   clientID,
 			Topic:      ch.conn.broker.routeResolver.QueueTopic(queueName),
@@ -1691,10 +1707,13 @@ func (ch *Channel) handleLocalDurableStreamPublish(queueName string, body []byte
 		}
 	case <-ctx.Done():
 		ch.conn.broker.stats.IncrementLocalPublishTimeouts()
-		ch.rejectLocalStreamPublish(fmt.Errorf("durable stream barrier did not complete: %w", ctx.Err()))
+		ch.abandonLocalStreamPublish(fmt.Errorf("durable stream barrier did not complete: %w", ctx.Err()))
 	}
 }
 
+// rejectLocalStreamPublish reports a publication that storage refused. The
+// channel stays usable because the outcome is final and the publisher can
+// retry on it.
 func (ch *Channel) rejectLocalStreamPublish(err error) {
 	ch.conn.logger.Error("local durable stream publish failed", "error", err)
 	if ch.confirmMode {
@@ -1703,6 +1722,20 @@ func (ch *Channel) rejectLocalStreamPublish(err error) {
 	}
 	_ = ch.sendChannelClose(codec.InternalError,
 		"durable stream publish failed", codec.ClassBasic, codec.MethodBasicPublish)
+}
+
+// abandonLocalStreamPublish reports a publication whose outcome FluxMQ no
+// longer knows, because it stopped waiting for the barrier or refused to start
+// one. The channel is closed after the NACK: retrying on it would queue more
+// work behind storage that has not recovered, and the publisher must treat the
+// record as undetermined rather than failed.
+func (ch *Channel) abandonLocalStreamPublish(err error) {
+	ch.conn.logger.Error("local durable stream publish abandoned", "error", err)
+	if ch.confirmMode {
+		ch.sendPublisherNack()
+	}
+	_ = ch.sendChannelClose(codec.InternalError,
+		"durable stream publish abandoned", codec.ClassBasic, codec.MethodBasicPublish)
 }
 
 // handleQueueCommit processes a stream offset commit routed via the resolver.

--- a/amqp/broker/channel.go
+++ b/amqp/broker/channel.go
@@ -1662,18 +1662,36 @@ func (ch *Channel) handleLocalDurableStreamPublish(queueName string, body []byte
 	props = corebroker.AddClientIDProperty(props, clientID)
 	ctx, cancel := context.WithTimeout(ch.conn.publishContext(), localPublishTimeout)
 	defer cancel()
-	err := publisher.PublishToDurableStream(ctx, queueName, qtypes.PublishRequest{
-		ClientID:   clientID,
-		Topic:      ch.conn.broker.routeResolver.QueueTopic(queueName),
-		Payload:    body,
-		Properties: props,
-	})
-	if err != nil {
-		ch.rejectLocalStreamPublish(err)
-		return
-	}
-	if ch.confirmMode {
-		ch.sendPublisherAck()
+
+	// The append and its fsync cannot be interrupted once the storage layer has
+	// entered them, so the deadline is enforced here rather than inside the
+	// store. Run the barrier on its own goroutine and stop waiting when the
+	// deadline passes: the connection goroutine stays responsive and the session
+	// can be closed, instead of a stalled disk holding a listener slot open
+	// indefinitely. The abandoned append may still complete and become visible,
+	// which is why a NACK is not proof that the record was not written.
+	result := make(chan error, 1)
+	go func() {
+		result <- publisher.PublishToDurableStream(ctx, queueName, qtypes.PublishRequest{
+			ClientID:   clientID,
+			Topic:      ch.conn.broker.routeResolver.QueueTopic(queueName),
+			Payload:    body,
+			Properties: props,
+		})
+	}()
+
+	select {
+	case err := <-result:
+		if err != nil {
+			ch.rejectLocalStreamPublish(err)
+			return
+		}
+		if ch.confirmMode {
+			ch.sendPublisherAck()
+		}
+	case <-ctx.Done():
+		ch.conn.broker.stats.IncrementLocalPublishTimeouts()
+		ch.rejectLocalStreamPublish(fmt.Errorf("durable stream barrier did not complete: %w", ctx.Err()))
 	}
 }
 

--- a/amqp/broker/channel.go
+++ b/amqp/broker/channel.go
@@ -1746,28 +1746,42 @@ func (ch *Channel) getQueueInfo(name string) *queueInfo {
 	return ch.queues[name]
 }
 
+// isStreamQueue reports whether a publish target is a stream, checking the
+// names this channel declared before falling back to the globally configured
+// queues. It runs on every default-exchange publication, so it resolves the at
+// most two candidate names in place rather than building a slice of them.
 func (ch *Channel) isStreamQueue(name string) bool {
-	if info := ch.getQueueInfo(name); info != nil && info.queueType == string(qtypes.QueueTypeStream) {
+	if ch.isDeclaredStreamQueue(name) {
 		return true
 	}
-	queueNames := []string{name}
-	if queueName, _ := corebroker.ParseQueueFilter(name); queueName != "" {
-		if info := ch.getQueueInfo(queueName); info != nil && info.queueType == string(qtypes.QueueTypeStream) {
-			return true
-		}
-		if queueName != name {
-			queueNames = append(queueNames, queueName)
-		}
+
+	queueName, _ := corebroker.ParseQueueFilter(name)
+	sameName := queueName == "" || queueName == name
+	if !sameName && ch.isDeclaredStreamQueue(queueName) {
+		return true
 	}
-	if qm := ch.conn.broker.queueManager; qm != nil {
-		for _, queueName := range queueNames {
-			cfg, err := qm.GetQueue(context.Background(), queueName)
-			if err == nil && cfg != nil && cfg.Type == qtypes.QueueTypeStream {
-				return true
-			}
-		}
+
+	qm := ch.conn.broker.queueManager
+	if qm == nil {
+		return false
 	}
-	return false
+	if ch.isConfiguredStreamQueue(qm, name) {
+		return true
+	}
+	return !sameName && ch.isConfiguredStreamQueue(qm, queueName)
+}
+
+// isDeclaredStreamQueue checks the queues declared on this channel.
+func (ch *Channel) isDeclaredStreamQueue(name string) bool {
+	info := ch.getQueueInfo(name)
+	return info != nil && info.queueType == string(qtypes.QueueTypeStream)
+}
+
+// isConfiguredStreamQueue checks queues that exist without a channel-local
+// declaration, such as streams provisioned from the broker configuration.
+func (ch *Channel) isConfiguredStreamQueue(qm channelQueueManager, name string) bool {
+	cfg, err := qm.GetQueue(ch.conn.publishContext(), name)
+	return err == nil && cfg != nil && cfg.Type == qtypes.QueueTypeStream
 }
 
 func extractQueueType(args map[string]any) string {

--- a/amqp/broker/channel_bench_test.go
+++ b/amqp/broker/channel_bench_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/absmach/fluxmq/amqp/codec"
+	qtypes "github.com/absmach/fluxmq/queue/types"
+)
+
+func newBenchChannel(b *testing.B, cfg *qtypes.QueueConfig) *Channel {
+	b.Helper()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	broker := New(nil, logger)
+	broker.queueManager = &mockChannelQueueManager{queueCfg: cfg}
+	conn := &Connection{
+		broker:   broker,
+		ctx:      context.Background(),
+		writer:   bufio.NewWriter(&bytes.Buffer{}),
+		frameMax: defaultFrameMax,
+		logger:   logger,
+		connID:   testConnectionID,
+		channels: make(map[uint16]*Channel),
+	}
+	return newChannel(conn, 1)
+}
+
+// BenchmarkIsStreamQueue covers the classic-queue path, where every
+// channel-local and queue-manager lookup misses. That is the worst case a
+// remote publisher on the default exchange pays per publication.
+func BenchmarkIsStreamQueue(b *testing.B) {
+	b.Run("classic/miss", func(b *testing.B) {
+		ch := newBenchChannel(b, &qtypes.QueueConfig{Name: testOrders, Type: qtypes.QueueTypeClassic})
+		b.ReportAllocs()
+		for b.Loop() {
+			if ch.isStreamQueue(testOrders) {
+				b.Fatal("classic queue reported as stream")
+			}
+		}
+	})
+
+	b.Run("stream/manager", func(b *testing.B) {
+		ch := newBenchChannel(b, &qtypes.QueueConfig{Name: testAuditQueue, Type: qtypes.QueueTypeStream})
+		b.ReportAllocs()
+		for b.Loop() {
+			if !ch.isStreamQueue(testAuditQueue) {
+				b.Fatal("configured stream not detected")
+			}
+		}
+	})
+
+	b.Run("stream/channel-local", func(b *testing.B) {
+		ch := newBenchChannel(b, nil)
+		ch.queues[testAuditQueue] = &queueInfo{queueType: string(qtypes.QueueTypeStream)}
+		b.ReportAllocs()
+		for b.Loop() {
+			if !ch.isStreamQueue(testAuditQueue) {
+				b.Fatal("declared stream not detected")
+			}
+		}
+	})
+
+	b.Run("queue-filter/miss", func(b *testing.B) {
+		ch := newBenchChannel(b, &qtypes.QueueConfig{Name: testOrders, Type: qtypes.QueueTypeClassic})
+		b.ReportAllocs()
+		for b.Loop() {
+			if ch.isStreamQueue("$queue/" + testOrders + "/events") {
+				b.Fatal("classic queue reported as stream")
+			}
+		}
+	})
+}
+
+// BenchmarkCompletePublishRemoteDefaultExchange measures the full remote
+// publish path through the default exchange, which is where the stream lookup
+// sits.
+func BenchmarkCompletePublishRemoteDefaultExchange(b *testing.B) {
+	ch := newBenchChannel(b, &qtypes.QueueConfig{Name: testOrders, Type: qtypes.QueueTypeClassic})
+	body := []byte(`{"event":"benchmark"}`)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		ch.pendingMethod = &codec.BasicPublish{RoutingKey: testOrders}
+		ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: uint64(len(body))}
+		ch.pendingBody = body
+		ch.completePublish()
+	}
+}

--- a/amqp/broker/channel_test.go
+++ b/amqp/broker/channel_test.go
@@ -118,7 +118,7 @@ func newTestChannel(t *testing.T) (*Channel, *bytes.Buffer) {
 		writer:   bufio.NewWriter(buf),
 		frameMax: defaultFrameMax,
 		logger:   logger,
-		connID:   "test-conn",
+		connID:   testConnectionID,
 		channels: make(map[uint16]*Channel),
 	}
 	ch := newChannel(c, 1)
@@ -314,8 +314,8 @@ func TestPublishStateMachineStampsPublisherForCrossDeliver(t *testing.T) {
 	if calls != 1 {
 		t.Fatalf("expected 1 cross-deliver call, got %d", calls)
 	}
-	if gotProps[corebroker.ClientIDProperty] != PrefixedClientID("test-conn") {
-		t.Fatalf("expected client_id property %q, got %q", PrefixedClientID("test-conn"), gotProps[corebroker.ClientIDProperty])
+	if gotProps[corebroker.ClientIDProperty] != PrefixedClientID(testConnectionID) {
+		t.Fatalf("expected client_id property %q, got %q", PrefixedClientID(testConnectionID), gotProps[corebroker.ClientIDProperty])
 	}
 }
 
@@ -401,19 +401,19 @@ func TestHandleQueuePublishCarriesClientID(t *testing.T) {
 	mockQM := &mockChannelQueueManager{}
 	ch.conn.broker.queueManager = mockQM
 
-	ch.handleQueuePublish("$queue/orders/process", []byte("hello"), map[string]string{"trace": "1"}, PrefixedClientID("test-conn"))
+	ch.handleQueuePublish("$queue/orders/process", []byte("hello"), map[string]string{"trace": "1"}, PrefixedClientID(testConnectionID))
 
 	if mockQM.publishCalls != 1 {
 		t.Fatalf("expected 1 queue publish, got %d", mockQM.publishCalls)
 	}
-	if mockQM.lastPublish.ClientID != PrefixedClientID("test-conn") {
-		t.Fatalf("expected client ID %q, got %q", PrefixedClientID("test-conn"), mockQM.lastPublish.ClientID)
+	if mockQM.lastPublish.ClientID != PrefixedClientID(testConnectionID) {
+		t.Fatalf("expected client ID %q, got %q", PrefixedClientID(testConnectionID), mockQM.lastPublish.ClientID)
 	}
 	if mockQM.lastPublish.Properties["trace"] != "1" {
 		t.Fatalf("expected trace property preserved, got %q", mockQM.lastPublish.Properties["trace"])
 	}
-	if mockQM.lastPublish.Properties[corebroker.ClientIDProperty] != PrefixedClientID("test-conn") {
-		t.Fatalf("expected client_id property %q, got %q", PrefixedClientID("test-conn"), mockQM.lastPublish.Properties[corebroker.ClientIDProperty])
+	if mockQM.lastPublish.Properties[corebroker.ClientIDProperty] != PrefixedClientID(testConnectionID) {
+		t.Fatalf("expected client_id property %q, got %q", PrefixedClientID(testConnectionID), mockQM.lastPublish.Properties[corebroker.ClientIDProperty])
 	}
 }
 

--- a/amqp/broker/channel_test.go
+++ b/amqp/broker/channel_test.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/absmach/fluxmq/amqp/codec"
 	corebroker "github.com/absmach/fluxmq/broker"
+	queuepkg "github.com/absmach/fluxmq/queue"
+	qstorage "github.com/absmach/fluxmq/queue/storage"
 	qtypes "github.com/absmach/fluxmq/queue/types"
 	"github.com/absmach/fluxmq/storage"
 )
@@ -21,18 +23,31 @@ import (
 const eventsExchange = "events"
 
 type mockChannelQueueManager struct {
-	lastCursor    *qtypes.CursorOption
-	lastPublish   qtypes.PublishRequest
-	publishCalls  int
-	queueCfg      *qtypes.QueueConfig
-	createdQueues []qtypes.QueueConfig
-	updatedQueues []qtypes.QueueConfig
+	lastCursor        *qtypes.CursorOption
+	lastPublish       qtypes.PublishRequest
+	publishCalls      int
+	exactStreamName   string
+	exactPublish      qtypes.PublishRequest
+	exactPublishCalls int
+	exactPublishErr   error
+	queueCfg          *qtypes.QueueConfig
+	createdQueues     []qtypes.QueueConfig
+	updatedQueues     []qtypes.QueueConfig
+	createQueueErr    error
+	updateQueueErr    error
 }
 
 func (m *mockChannelQueueManager) Publish(_ context.Context, publish qtypes.PublishRequest) error {
 	m.lastPublish = publish
 	m.publishCalls++
 	return nil
+}
+
+func (m *mockChannelQueueManager) PublishToDurableStream(_ context.Context, queueName string, publish qtypes.PublishRequest) error {
+	m.exactStreamName = queueName
+	m.exactPublish = publish
+	m.exactPublishCalls++
+	return m.exactPublishErr
 }
 
 func (m *mockChannelQueueManager) Subscribe(context.Context, string, string, string, string, string) error {
@@ -62,7 +77,7 @@ func (m *mockChannelQueueManager) Reject(context.Context, string, string, string
 
 func (m *mockChannelQueueManager) CreateQueue(_ context.Context, cfg qtypes.QueueConfig) error {
 	m.createdQueues = append(m.createdQueues, cfg)
-	return nil
+	return m.createQueueErr
 }
 
 func (m *mockChannelQueueManager) GetQueue(context.Context, string) (*qtypes.QueueConfig, error) {
@@ -71,7 +86,7 @@ func (m *mockChannelQueueManager) GetQueue(context.Context, string) (*qtypes.Que
 
 func (m *mockChannelQueueManager) UpdateQueue(_ context.Context, cfg qtypes.QueueConfig) error {
 	m.updatedQueues = append(m.updatedQueues, cfg)
-	return nil
+	return m.updateQueueErr
 }
 
 func (m *mockChannelQueueManager) CommitOffset(context.Context, string, string, uint64) error {
@@ -771,6 +786,48 @@ func TestQueueDeclareStreamWithTTL(t *testing.T) {
 	}
 	if cfg.Retention.RetentionTime != 7*24*time.Hour {
 		t.Fatalf("expected RetentionTime=7d, got %v", cfg.Retention.RetentionTime)
+	}
+}
+
+func TestQueueRedeclareProtectedQueueClosesChannel(t *testing.T) {
+	ch, buf := newTestChannel(t)
+	existing := qtypes.DefaultQueueConfig("atom-audit", "$queue/atom-audit/#")
+	existing.Type = qtypes.QueueTypeStream
+	existing.Reserved = true
+	mockQM := &mockChannelQueueManager{
+		queueCfg:       &existing,
+		createQueueErr: qstorage.ErrQueueAlreadyExists,
+		updateQueueErr: queuepkg.ErrProtectedQueueMutation,
+	}
+	ch.conn.broker.queueManager = mockQM
+
+	if err := ch.handleQueueDeclare(&codec.QueueDeclare{
+		Queue:   existing.Name,
+		Durable: true,
+		Arguments: map[string]any{
+			"x-queue-type": "classic",
+		},
+	}); err != nil {
+		t.Fatalf("handleQueueDeclare() error = %v", err)
+	}
+
+	frames := readFramesFrom(t, buf, 0)
+	if len(frames) != 1 {
+		t.Fatalf("frames = %d, want one ChannelClose", len(frames))
+	}
+	decoded, err := frames[0].Decode()
+	if err != nil {
+		t.Fatalf("Decode() error = %v", err)
+	}
+	closeMessage, ok := decoded.(*codec.ChannelClose)
+	if !ok {
+		t.Fatalf("method = %T, want *codec.ChannelClose", decoded)
+	}
+	if closeMessage.ReplyCode != codec.PreconditionFailed {
+		t.Fatalf("reply code = %d, want %d", closeMessage.ReplyCode, codec.PreconditionFailed)
+	}
+	if closeMessage.ClassID != codec.ClassQueue || closeMessage.MethodID != codec.MethodQueueDeclare {
+		t.Fatalf("close method = %d/%d, want queue.declare", closeMessage.ClassID, closeMessage.MethodID)
 	}
 }
 

--- a/amqp/broker/channel_test.go
+++ b/amqp/broker/channel_test.go
@@ -30,6 +30,7 @@ type mockChannelQueueManager struct {
 	exactPublish      qtypes.PublishRequest
 	exactPublishCalls int
 	exactPublishErr   error
+	exactPublishCtx   context.Context
 	queueCfg          *qtypes.QueueConfig
 	createdQueues     []qtypes.QueueConfig
 	updatedQueues     []qtypes.QueueConfig
@@ -43,10 +44,14 @@ func (m *mockChannelQueueManager) Publish(_ context.Context, publish qtypes.Publ
 	return nil
 }
 
-func (m *mockChannelQueueManager) PublishToDurableStream(_ context.Context, queueName string, publish qtypes.PublishRequest) error {
+func (m *mockChannelQueueManager) PublishToDurableStream(ctx context.Context, queueName string, publish qtypes.PublishRequest) error {
 	m.exactStreamName = queueName
 	m.exactPublish = publish
+	m.exactPublishCtx = ctx
 	m.exactPublishCalls++
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	return m.exactPublishErr
 }
 

--- a/amqp/broker/connection.go
+++ b/amqp/broker/connection.go
@@ -35,6 +35,8 @@ const (
 	// clusterOpTimeout prevents a slow/partitioned peer from blocking setup or shutdown.
 	clusterOpTimeout       = 5 * time.Second
 	disconnectWriteTimeout = time.Second
+	saslMechanismPlain     = "PLAIN"
+	saslMechanismAMQPlain  = "AMQPLAIN"
 )
 
 // Connection represents a single AMQP 0.9.1 client connection.
@@ -69,9 +71,6 @@ type Connection struct {
 }
 
 func newConnection(ctx context.Context, b *Broker, netConn net.Conn, policy *ConnectionPolicy) *Connection {
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	c := &Connection{
 		broker:     b,
 		conn:       netConn,
@@ -260,7 +259,7 @@ func (c *Connection) connectionHandshake() error {
 				"connection.blocked":         true,
 			},
 		},
-		Mechanisms: "PLAIN",
+		Mechanisms: saslMechanismPlain,
 		Locales:    "en_US",
 	}
 	if err := c.writeMethod(0, start); err != nil {
@@ -350,7 +349,7 @@ func (c *Connection) authenticate(start *codec.ConnectionStartOk) error {
 
 	mechanism := strings.ToUpper(strings.TrimSpace(start.Mechanism))
 	switch mechanism {
-	case "PLAIN", "AMQPLAIN":
+	case saslMechanismPlain, saslMechanismAMQPlain:
 		_, username, password, err := sasl.ParsePLAIN([]byte(start.Response))
 		if err != nil {
 			if policy.mode == ConnectionPolicyLocalPublishOnly {
@@ -379,7 +378,7 @@ func (c *Connection) authenticateCredentials(mechanism, username, password strin
 			_ = c.sendConnectionClose(codec.AccessRefused, "authentication failed", codec.ClassConnection, codec.MethodConnectionStartOk)
 			return fmt.Errorf("%s local auth unavailable", mechanism)
 		}
-		principalID, credentialFingerprint, certificateURI, ok, err := policy.localAuth.AuthenticateLocal(
+		principalID, credentialFingerprint, permissionsFingerprint, certificateURI, ok, err := policy.localAuth.AuthenticateLocal(
 			c.ctx, clientID, username, password, c.peer,
 		)
 		if err != nil {
@@ -392,7 +391,7 @@ func (c *Connection) authenticateCredentials(mechanism, username, password strin
 			_ = c.sendConnectionClose(codec.AccessRefused, "authentication failed", codec.ClassConnection, codec.MethodConnectionStartOk)
 			return fmt.Errorf("%s local auth rejected for user %q", mechanism, username)
 		}
-		if principalID == "" || credentialFingerprint == "" || certificateURI == "" ||
+		if principalID == "" || credentialFingerprint == "" || permissionsFingerprint == "" || certificateURI == "" ||
 			c.peer.CertificateFingerprint == "" || !containsURISAN(c.peer, certificateURI) {
 			c.recordLocalAuthFailure("identity_binding_rejected")
 			_ = c.sendConnectionClose(codec.AccessRefused, "authentication failed", codec.ClassConnection, codec.MethodConnectionStartOk)
@@ -401,6 +400,7 @@ func (c *Connection) authenticateCredentials(mechanism, username, password strin
 		c.localIdentity = &LocalSessionIdentity{
 			PrincipalID:            principalID,
 			CredentialFingerprint:  credentialFingerprint,
+			PermissionsFingerprint: permissionsFingerprint,
 			CertificateURI:         certificateURI,
 			CertificateFingerprint: c.peer.CertificateFingerprint,
 		}

--- a/amqp/broker/connection.go
+++ b/amqp/broker/connection.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"log/slog"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/absmach/fluxmq/amqp/codec"
 	"github.com/absmach/fluxmq/amqp1/sasl"
+	corebroker "github.com/absmach/fluxmq/broker"
 	"github.com/absmach/fluxmq/internal/bufpool"
 )
 
@@ -28,9 +30,11 @@ const (
 	defaultFrameMax   = uint32(131072)
 	defaultChannelMax = uint16(2047)
 	defaultHeartbeat  = uint16(60)
+	frameOverhead     = uint64(8)
 
 	// clusterOpTimeout prevents a slow/partitioned peer from blocking setup or shutdown.
-	clusterOpTimeout = 5 * time.Second
+	clusterOpTimeout       = 5 * time.Second
+	disconnectWriteTimeout = time.Second
 )
 
 // Connection represents a single AMQP 0.9.1 client connection.
@@ -39,9 +43,14 @@ type Connection struct {
 	conn   net.Conn
 	reader *bufio.Reader
 	writer *bufio.Writer
+	ctx    context.Context
+	policy *ConnectionPolicy
+	peer   VerifiedPeerIdentity
 
 	connID         string
 	connectionName string // human-readable label from AMQP ClientProperties "connection_name"
+	localIdentity  *LocalSessionIdentity
+	registered     bool
 	frameMax       uint32
 	channelMax     uint16
 	heartbeat      uint16
@@ -59,12 +68,17 @@ type Connection struct {
 	logger *slog.Logger
 }
 
-func newConnection(b *Broker, netConn net.Conn) *Connection {
-	return &Connection{
+func newConnection(ctx context.Context, b *Broker, netConn net.Conn, policy *ConnectionPolicy) *Connection {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	c := &Connection{
 		broker:     b,
 		conn:       netConn,
 		reader:     bufio.NewReaderSize(netConn, 65536),
 		writer:     bufio.NewWriterSize(netConn, 65536),
+		ctx:        ctx,
+		policy:     policy,
 		frameMax:   defaultFrameMax,
 		channelMax: defaultChannelMax,
 		heartbeat:  defaultHeartbeat,
@@ -72,6 +86,95 @@ func newConnection(b *Broker, netConn net.Conn) *Connection {
 		closeCh:    make(chan struct{}),
 		logger:     b.logger,
 	}
+	c.connID = b.nextConnectionID(netConn.RemoteAddr())
+	if policy != nil && policy.mode == ConnectionPolicyLocalPublishOnly {
+		if tlsConn, ok := netConn.(*tls.Conn); ok {
+			c.peer = verifiedPeerIdentity(tlsConn)
+		}
+	}
+	return c
+}
+
+func (c *Connection) connectionPolicy() *ConnectionPolicy {
+	if c.policy != nil {
+		return c.policy
+	}
+	// A nil per-connection policy is the compatibility path used by existing
+	// embedded callers and tests. Listener-aware servers always pass a policy.
+	return &ConnectionPolicy{
+		mode:         ConnectionPolicyExternal,
+		externalAuth: c.broker.auth,
+		hooks:        c.broker.hooks,
+	}
+}
+
+func (c *Connection) externalID(clientID string) string {
+	if c.localIdentity != nil {
+		return c.localIdentity.PrincipalID
+	}
+	auth := c.connectionPolicy().externalAuth
+	if auth == nil {
+		return ""
+	}
+	return auth.ExternalID(clientID)
+}
+
+func (c *Connection) applyHook(ctx context.Context, req corebroker.BlockingHookRequest) (corebroker.BlockingHookRequest, bool) {
+	hooks := c.connectionPolicy().hooks
+	if hooks == nil {
+		return req, true
+	}
+	req.Protocol = corebroker.HookProtocolAMQP091
+	return hooks.Handle(ctx, req)
+}
+
+func (c *Connection) localSessionIdentity() (LocalSessionIdentity, bool) {
+	if c.localIdentity == nil {
+		return LocalSessionIdentity{}, false
+	}
+	return *c.localIdentity, true
+}
+
+func (c *Connection) canPublishLocal(exchange, routingKey string) bool {
+	policy := c.connectionPolicy()
+	if policy.mode != ConnectionPolicyLocalPublishOnly || policy.localAuthz == nil || c.localIdentity == nil {
+		return false
+	}
+	return policy.localAuthz.CanPublishLocal(*c.localIdentity, exchange, routingKey)
+}
+
+func (c *Connection) registerAndValidate() error {
+	c.broker.registerConnection(c.connID, c)
+	c.registered = true
+	c.broker.stats.IncrementConnections()
+
+	if c.connectionPolicy().mode != ConnectionPolicyLocalPublishOnly {
+		return nil
+	}
+	c.broker.stats.IncrementLocalConnections()
+	identity, bound := c.localSessionIdentity()
+	validator := c.connectionPolicy().localSessions
+	if !bound || validator == nil || !validator.IsSessionActive(identity) {
+		c.broker.stats.AddLocalForcedDisconnects(1)
+		c.logger.Warn("amqp091_local_connection",
+			"auth_mode", "local",
+			"outcome", "denied",
+			"reason", "credentials_retired_before_registration",
+			"principal_id", identity.PrincipalID)
+		c.disconnect(codec.AccessRefused, "local principal credentials revoked")
+		return fmt.Errorf("local principal session became inactive during handshake")
+	}
+	return nil
+}
+
+func (c *Connection) disconnect(code uint16, reason string) {
+	if c.closed.Load() {
+		return
+	}
+	_ = c.conn.SetWriteDeadline(time.Now().Add(disconnectWriteTimeout))
+	_ = c.sendConnectionClose(code, reason, codec.ClassConnection, codec.MethodConnectionClose)
+	c.close()
+	_ = c.conn.Close()
 }
 
 func (c *Connection) nextDeliveryTag() uint64 {
@@ -81,7 +184,6 @@ func (c *Connection) nextDeliveryTag() uint64 {
 // run executes the full connection lifecycle.
 func (c *Connection) run() error {
 	defer c.cleanup()
-	c.connID = c.conn.RemoteAddr().String()
 
 	if err := c.negotiateProtocol(); err != nil {
 		return fmt.Errorf("protocol negotiation: %w", err)
@@ -90,9 +192,20 @@ func (c *Connection) run() error {
 	if err := c.connectionHandshake(); err != nil {
 		return fmt.Errorf("connection handshake: %w", err)
 	}
+	if err := c.conn.SetDeadline(time.Time{}); err != nil {
+		return fmt.Errorf("clearing handshake deadline: %w", err)
+	}
 
-	c.broker.registerConnection(c.connID, c)
-	c.broker.stats.IncrementConnections()
+	if err := c.registerAndValidate(); err != nil {
+		return err
+	}
+	if c.localIdentity != nil {
+		c.logger.Info("amqp091_local_connection",
+			"auth_mode", "local",
+			"outcome", "opened",
+			"principal_id", c.localIdentity.PrincipalID,
+			"active_connections", c.broker.stats.GetLocalConnections())
+	}
 	if cl := c.broker.cluster; cl != nil {
 		clientID := PrefixedClientID(c.connID)
 		ctx, cancel := context.WithTimeout(context.Background(), clusterOpTimeout)
@@ -155,7 +268,7 @@ func (c *Connection) connectionHandshake() error {
 	}
 
 	// Read Connection.StartOk
-	frame, err := codec.ReadFrame(c.reader)
+	frame, err := c.readFrame()
 	if err != nil {
 		return err
 	}
@@ -185,7 +298,7 @@ func (c *Connection) connectionHandshake() error {
 	}
 
 	// Read Connection.TuneOk
-	frame, err = codec.ReadFrame(c.reader)
+	frame, err = c.readFrame()
 	if err != nil {
 		return err
 	}
@@ -210,7 +323,7 @@ func (c *Connection) connectionHandshake() error {
 	}
 
 	// Read Connection.Open
-	frame, err = codec.ReadFrame(c.reader)
+	frame, err = c.readFrame()
 	if err != nil {
 		return err
 	}
@@ -229,33 +342,96 @@ func (c *Connection) connectionHandshake() error {
 }
 
 func (c *Connection) authenticate(start *codec.ConnectionStartOk) error {
-	auth := c.broker.auth
-	if auth == nil {
+	policy := c.connectionPolicy()
+	if policy.mode == ConnectionPolicyExternal && policy.externalAuth == nil {
+		// Preserve the existing unauthenticated-listener behavior.
 		return nil
 	}
 
-	// Placeholder credential extraction for PLAIN/AMQPLAIN during migration.
-	// This will be replaced by SuperMQ-backed authenticator wiring.
 	mechanism := strings.ToUpper(strings.TrimSpace(start.Mechanism))
 	switch mechanism {
 	case "PLAIN", "AMQPLAIN":
 		_, username, password, err := sasl.ParsePLAIN([]byte(start.Response))
 		if err != nil {
+			if policy.mode == ConnectionPolicyLocalPublishOnly {
+				c.recordLocalAuthFailure("invalid_sasl_response")
+			}
 			_ = c.sendConnectionClose(codec.AccessRefused, "invalid auth response", codec.ClassConnection, codec.MethodConnectionStartOk)
 			return fmt.Errorf("invalid %s auth response: %w", mechanism, err)
 		}
 
-		clientID := PrefixedClientID(c.connID)
-		ok, _, err := auth.Authenticate(clientID, username, password)
-		if err != nil || !ok {
-			_ = c.sendConnectionClose(codec.AccessRefused, "authentication failed", codec.ClassConnection, codec.MethodConnectionStartOk)
-			return fmt.Errorf("%s auth rejected for user %q", mechanism, username)
-		}
-		return nil
+		return c.authenticateCredentials(mechanism, username, password)
 	default:
+		if policy.mode == ConnectionPolicyLocalPublishOnly {
+			c.recordLocalAuthFailure("unsupported_sasl_mechanism")
+		}
 		_ = c.sendConnectionClose(codec.CommandInvalid, "unsupported auth mechanism", codec.ClassConnection, codec.MethodConnectionStartOk)
 		return fmt.Errorf("unsupported auth mechanism %q", start.Mechanism)
 	}
+}
+
+func (c *Connection) authenticateCredentials(mechanism, username, password string) error {
+	policy := c.connectionPolicy()
+	clientID := PrefixedClientID(c.connID)
+	if policy.mode == ConnectionPolicyLocalPublishOnly {
+		if policy.localAuth == nil {
+			c.recordLocalAuthFailure("authenticator_unavailable")
+			_ = c.sendConnectionClose(codec.AccessRefused, "authentication failed", codec.ClassConnection, codec.MethodConnectionStartOk)
+			return fmt.Errorf("%s local auth unavailable", mechanism)
+		}
+		principalID, credentialFingerprint, certificateURI, ok, err := policy.localAuth.AuthenticateLocal(
+			c.ctx, clientID, username, password, c.peer,
+		)
+		if err != nil {
+			c.recordLocalAuthFailure("authenticator_error")
+			_ = c.sendConnectionClose(codec.AccessRefused, "authentication failed", codec.ClassConnection, codec.MethodConnectionStartOk)
+			return fmt.Errorf("%s local auth failed for user %q", mechanism, username)
+		}
+		if !ok {
+			c.recordLocalAuthFailure("credentials_rejected")
+			_ = c.sendConnectionClose(codec.AccessRefused, "authentication failed", codec.ClassConnection, codec.MethodConnectionStartOk)
+			return fmt.Errorf("%s local auth rejected for user %q", mechanism, username)
+		}
+		if principalID == "" || credentialFingerprint == "" || certificateURI == "" ||
+			c.peer.CertificateFingerprint == "" || !containsURISAN(c.peer, certificateURI) {
+			c.recordLocalAuthFailure("identity_binding_rejected")
+			_ = c.sendConnectionClose(codec.AccessRefused, "authentication failed", codec.ClassConnection, codec.MethodConnectionStartOk)
+			return fmt.Errorf("%s local auth rejected for user %q", mechanism, username)
+		}
+		c.localIdentity = &LocalSessionIdentity{
+			PrincipalID:            principalID,
+			CredentialFingerprint:  credentialFingerprint,
+			CertificateURI:         certificateURI,
+			CertificateFingerprint: c.peer.CertificateFingerprint,
+		}
+		c.broker.stats.IncrementLocalAuthSuccess()
+		c.logger.Info("amqp091_local_authentication",
+			"auth_mode", "local",
+			"outcome", "success",
+			"reason", "credentials_and_certificate_verified",
+			"client_id", clientID,
+			"principal_id", principalID)
+		return nil
+	}
+
+	if policy.externalAuth == nil {
+		return nil
+	}
+	ok, _, err := policy.externalAuth.Authenticate(clientID, username, password)
+	if err != nil || !ok {
+		_ = c.sendConnectionClose(codec.AccessRefused, "authentication failed", codec.ClassConnection, codec.MethodConnectionStartOk)
+		return fmt.Errorf("%s auth rejected for user %q", mechanism, username)
+	}
+	return nil
+}
+
+func (c *Connection) recordLocalAuthFailure(reason string) {
+	c.broker.stats.IncrementLocalAuthFailures()
+	c.logger.Warn("amqp091_local_authentication",
+		"auth_mode", "local",
+		"outcome", "failure",
+		"reason", reason,
+		"client_id", PrefixedClientID(c.connID))
 }
 
 // processFrames is the main frame processing loop.
@@ -272,7 +448,7 @@ func (c *Connection) processFrames() error {
 			c.conn.SetReadDeadline(deadline) //nolint:errcheck // fails only on closed connection
 		}
 
-		frame, err := codec.ReadFrame(c.reader)
+		frame, err := c.readFrame()
 		if err != nil {
 			if c.closed.Load() {
 				return nil
@@ -303,6 +479,39 @@ func (c *Connection) processFrames() error {
 			c.logger.Warn("unknown frame type", "type", frame.Type)
 		}
 	}
+}
+
+// readFrame enforces the negotiated frame maximum before allocating the frame
+// payload. codec.ReadFrame cannot apply a per-connection limit because it does
+// not know the AMQP tune result.
+func (c *Connection) readFrame() (*codec.Frame, error) {
+	frameType, err := codec.ReadOctet(c.reader)
+	if err != nil {
+		return nil, err
+	}
+	channel, err := codec.ReadShort(c.reader)
+	if err != nil {
+		return nil, err
+	}
+	size, err := codec.ReadLong(c.reader)
+	if err != nil {
+		return nil, err
+	}
+	if c.frameMax > 0 && uint64(size)+frameOverhead > uint64(c.frameMax) {
+		return nil, codec.NewErr(codec.FrameError, "frame exceeds negotiated maximum", nil)
+	}
+	payload := make([]byte, size)
+	if _, err := io.ReadFull(c.reader, payload); err != nil {
+		return nil, err
+	}
+	frameEnd, err := codec.ReadOctet(c.reader)
+	if err != nil {
+		return nil, err
+	}
+	if frameEnd != codec.FrameEnd {
+		return nil, codec.NewErr(codec.FrameError, "malformed frame: incorrect frame-end marker", nil)
+	}
+	return &codec.Frame{Type: frameType, Channel: channel, Payload: payload}, nil
 }
 
 func (c *Connection) handleMethodFrame(frame *codec.Frame) error {
@@ -344,6 +553,10 @@ func (c *Connection) handleChannelOpen(chID uint16) error {
 	c.channelsMu.Lock()
 	defer c.channelsMu.Unlock()
 
+	if chID == 0 || chID > c.channelMax {
+		return c.sendConnectionClose(codec.ChannelError,
+			fmt.Sprintf("channel %d exceeds negotiated channel maximum %d", chID, c.channelMax), 0, 0)
+	}
 	if uint16(len(c.channels)) >= c.channelMax {
 		return c.sendConnectionClose(codec.ChannelError, "channel limit exceeded", 0, 0)
 	}
@@ -523,10 +736,23 @@ func (c *Connection) cleanup() {
 		ch.cleanup()
 	}
 
-	c.broker.stats.DecrementConnections()
+	if c.registered {
+		c.broker.stats.DecrementConnections()
+		if c.localIdentity != nil {
+			c.broker.stats.DecrementLocalConnections()
+			c.logger.Info("amqp091_local_connection",
+				"auth_mode", "local",
+				"outcome", "closed",
+				"principal_id", c.localIdentity.PrincipalID,
+				"active_connections", c.broker.stats.GetLocalConnections())
+		}
+	}
 	if c.connID != "" {
+		clientID := PrefixedClientID(c.connID)
+		if auth := c.connectionPolicy().externalAuth; auth != nil {
+			auth.Forget(clientID)
+		}
 		if cl := c.broker.cluster; cl != nil {
-			clientID := PrefixedClientID(c.connID)
 			ctx, cancel := context.WithTimeout(context.Background(), clusterOpTimeout)
 			defer cancel()
 			if err := cl.RemoveAllSubscriptions(ctx, clientID); err != nil {

--- a/amqp/broker/connection.go
+++ b/amqp/broker/connection.go
@@ -33,7 +33,10 @@ const (
 	frameOverhead     = uint64(8)
 
 	// clusterOpTimeout prevents a slow/partitioned peer from blocking setup or shutdown.
-	clusterOpTimeout       = 5 * time.Second
+	clusterOpTimeout = 5 * time.Second
+	// localPublishTimeout bounds one exact durable-stream append and its fsync so
+	// a stalled disk cannot pin the connection goroutine past shutdown.
+	localPublishTimeout    = 10 * time.Second
 	disconnectWriteTimeout = time.Second
 	saslMechanismPlain     = "PLAIN"
 	saslMechanismAMQPlain  = "AMQPLAIN"
@@ -125,6 +128,16 @@ func (c *Connection) applyHook(ctx context.Context, req corebroker.BlockingHookR
 	}
 	req.Protocol = corebroker.HookProtocolAMQP091
 	return hooks.Handle(ctx, req)
+}
+
+// publishContext returns the context that bounds one publish. Embedded callers
+// may construct a connection without one, so fall back to a background context
+// rather than panicking on a nil parent.
+func (c *Connection) publishContext() context.Context {
+	if c.ctx == nil {
+		return context.Background()
+	}
+	return c.ctx
 }
 
 func (c *Connection) localSessionIdentity() (LocalSessionIdentity, bool) {

--- a/amqp/broker/connection.go
+++ b/amqp/broker/connection.go
@@ -26,6 +26,11 @@ import (
 // AMQP 0.9.1 protocol header: "AMQP" followed by 0, 0, 9, 1.
 var protocolHeader = []byte{'A', 'M', 'Q', 'P', 0, 0, 9, 1}
 
+// localPublishTimeout bounds how long a local publisher waits for one exact
+// durable-stream append and its fsync. It is a variable only so tests can
+// shorten it; production code must not reassign it.
+var localPublishTimeout = 10 * time.Second
+
 const (
 	defaultFrameMax   = uint32(131072)
 	defaultChannelMax = uint16(2047)
@@ -33,10 +38,7 @@ const (
 	frameOverhead     = uint64(8)
 
 	// clusterOpTimeout prevents a slow/partitioned peer from blocking setup or shutdown.
-	clusterOpTimeout = 5 * time.Second
-	// localPublishTimeout bounds one exact durable-stream append and its fsync so
-	// a stalled disk cannot pin the connection goroutine past shutdown.
-	localPublishTimeout    = 10 * time.Second
+	clusterOpTimeout       = 5 * time.Second
 	disconnectWriteTimeout = time.Second
 	saslMechanismPlain     = "PLAIN"
 	saslMechanismAMQPlain  = "AMQPLAIN"

--- a/amqp/broker/connection.go
+++ b/amqp/broker/connection.go
@@ -147,12 +147,15 @@ func (c *Connection) localSessionIdentity() (LocalSessionIdentity, bool) {
 	return *c.localIdentity, true
 }
 
+// canPublishLocal authorizes the exchange name the router will actually use.
+// Authorizing the raw wire value would let the ACL and the routing decision
+// disagree about which exchange a publication targets.
 func (c *Connection) canPublishLocal(exchange, routingKey string) bool {
 	policy := c.connectionPolicy()
 	if policy.mode != ConnectionPolicyLocalPublishOnly || policy.localAuthz == nil || c.localIdentity == nil {
 		return false
 	}
-	return policy.localAuthz.CanPublishLocal(*c.localIdentity, exchange, routingKey)
+	return policy.localAuthz.CanPublishLocal(*c.localIdentity, normalizeExchange(exchange), routingKey)
 }
 
 func (c *Connection) registerAndValidate() error {

--- a/amqp/broker/connection_cleanup_test.go
+++ b/amqp/broker/connection_cleanup_test.go
@@ -149,7 +149,7 @@ func newTestConnection(t *testing.T, b *Broker, serverConn net.Conn) *Connection
 		writer:   bufio.NewWriter(io.Discard),
 		closeCh:  make(chan struct{}),
 		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
-		connID:   "test-conn",
+		connID:   testConnectionID,
 		channels: make(map[uint16]*Channel),
 	}
 }

--- a/amqp/broker/durable_append.go
+++ b/amqp/broker/durable_append.go
@@ -1,0 +1,69 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import "sync"
+
+// maxOutstandingDurableAppends bounds how many durable appends may be waiting
+// on one stream's storage barrier at the same time.
+//
+// A publisher that times out is answered with a NACK, but the append it started
+// keeps running: an fsync cannot be cancelled. Without a bound, a publisher
+// retrying against permanently stalled storage would start a new barrier per
+// attempt, each holding its message payload and queueing behind the same
+// per-queue storage mutex, so a stall would turn into unbounded goroutine and
+// memory growth. The limit leaves room for genuinely concurrent publishers
+// while capping what one stalled stream can retain.
+//
+// It is a variable only so tests can lower it; production code must not
+// reassign it.
+var maxOutstandingDurableAppends = 16
+
+// durableAppendLimiter counts the durable appends currently running per queue.
+// Its zero value is ready for use.
+type durableAppendLimiter struct {
+	mu          sync.Mutex
+	outstanding map[string]int
+}
+
+// acquire reserves a slot for one durable append, reporting false when the
+// queue already has the maximum number of appends waiting on storage.
+func (l *durableAppendLimiter) acquire(queueName string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.outstanding == nil {
+		l.outstanding = make(map[string]int)
+	}
+	if l.outstanding[queueName] >= maxOutstandingDurableAppends {
+		return false
+	}
+	l.outstanding[queueName]++
+	return true
+}
+
+// release returns a slot once the append and its barrier have finished, which
+// may be long after the publisher was answered.
+func (l *durableAppendLimiter) release(queueName string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	count, ok := l.outstanding[queueName]
+	if !ok {
+		return
+	}
+	if count <= 1 {
+		delete(l.outstanding, queueName)
+		return
+	}
+	l.outstanding[queueName] = count - 1
+}
+
+// outstandingFor reports how many durable appends are in flight for a queue.
+func (l *durableAppendLimiter) outstandingFor(queueName string) int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return l.outstanding[queueName]
+}

--- a/amqp/broker/policy.go
+++ b/amqp/broker/policy.go
@@ -1,0 +1,134 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+
+	corebroker "github.com/absmach/fluxmq/broker"
+)
+
+// ConnectionPolicyMode selects the authentication and authorization boundary
+// for an AMQP 0.9.1 listener.
+type ConnectionPolicyMode uint8
+
+const (
+	// ConnectionPolicyExternal preserves the existing remote auth-callout and
+	// blocking-hook behavior.
+	ConnectionPolicyExternal ConnectionPolicyMode = iota
+	// ConnectionPolicyLocalPublishOnly enables local-principal authentication
+	// and restricts the connection to publisher lifecycle operations.
+	ConnectionPolicyLocalPublishOnly
+)
+
+// VerifiedPeerIdentity contains identity material from a TLS certificate chain
+// that was successfully verified by the listener. Unverified peer certificate
+// fields are deliberately never exposed to local authentication.
+type VerifiedPeerIdentity struct {
+	URISANs                []string
+	CertificateFingerprint string
+}
+
+// LocalPrincipalAuthenticator authenticates credentials against a verified TLS
+// peer identity. certificateURI must name the URI SAN selected from peer.URISANs.
+// credentialFingerprint is an opaque, non-secret identifier used to revoke
+// sessions after credential rotation.
+type LocalPrincipalAuthenticator interface {
+	AuthenticateLocal(ctx context.Context, clientID, username, secret string, peer VerifiedPeerIdentity) (principalID, credentialFingerprint, certificateURI string, authenticated bool, err error)
+}
+
+// LocalPrincipalAuthorizer makes exact AMQP publish decisions for a fully
+// authenticated local session. Implementations must validate both the bound
+// session credential and the target against one current policy snapshot.
+type LocalPrincipalAuthorizer interface {
+	CanPublishLocal(identity LocalSessionIdentity, exchange, routingKey string) bool
+}
+
+// LocalSessionValidator checks whether the immutable credential and certificate
+// binding established during authentication is still active in the current
+// local-principal snapshot. It closes the authenticate-before-register reload
+// race; publish authorization remains a separate per-method check.
+type LocalSessionValidator interface {
+	IsSessionActive(identity LocalSessionIdentity) bool
+}
+
+// LocalSessionIdentity is the immutable security identity bound to a local
+// AMQP connection after authentication.
+type LocalSessionIdentity struct {
+	PrincipalID            string
+	CredentialFingerprint  string
+	CertificateURI         string
+	CertificateFingerprint string
+}
+
+// ConnectionPolicy is an immutable listener-scoped AMQP security policy.
+// Construct policies with NewExternalConnectionPolicy or
+// NewLocalPublishOnlyConnectionPolicy and do not mutate them after serving.
+type ConnectionPolicy struct {
+	mode           ConnectionPolicyMode
+	externalAuth   *corebroker.AuthEngine
+	hooks          *corebroker.BlockingHookEngine
+	localAuth      LocalPrincipalAuthenticator
+	localAuthz     LocalPrincipalAuthorizer
+	localSessions  LocalSessionValidator
+	maxMessageSize uint64
+}
+
+// NewExternalConnectionPolicy constructs a policy using only the existing
+// external auth engine and blocking hooks.
+func NewExternalConnectionPolicy(auth *corebroker.AuthEngine, hooks *corebroker.BlockingHookEngine, maxMessageSize uint64) *ConnectionPolicy {
+	return &ConnectionPolicy{
+		mode:           ConnectionPolicyExternal,
+		externalAuth:   auth,
+		hooks:          hooks,
+		maxMessageSize: maxMessageSize,
+	}
+}
+
+// NewLocalPublishOnlyConnectionPolicy constructs a fail-closed local-principal
+// policy. It never invokes an external auth engine or blocking hook.
+func NewLocalPublishOnlyConnectionPolicy(
+	auth LocalPrincipalAuthenticator,
+	authz LocalPrincipalAuthorizer,
+	sessions LocalSessionValidator,
+	maxMessageSize uint64,
+) *ConnectionPolicy {
+	return &ConnectionPolicy{
+		mode:           ConnectionPolicyLocalPublishOnly,
+		localAuth:      auth,
+		localAuthz:     authz,
+		localSessions:  sessions,
+		maxMessageSize: maxMessageSize,
+	}
+}
+
+func verifiedPeerIdentity(conn *tls.Conn) VerifiedPeerIdentity {
+	state := conn.ConnectionState()
+	if len(state.VerifiedChains) == 0 || len(state.VerifiedChains[0]) == 0 {
+		return VerifiedPeerIdentity{}
+	}
+
+	leaf := state.VerifiedChains[0][0]
+	uriSANs := make([]string, 0, len(leaf.URIs))
+	for _, uri := range leaf.URIs {
+		uriSANs = append(uriSANs, uri.String())
+	}
+	fingerprint := sha256.Sum256(leaf.Raw)
+	return VerifiedPeerIdentity{
+		URISANs:                uriSANs,
+		CertificateFingerprint: hex.EncodeToString(fingerprint[:]),
+	}
+}
+
+func containsURISAN(peer VerifiedPeerIdentity, uri string) bool {
+	for _, candidate := range peer.URISANs {
+		if candidate == uri {
+			return true
+		}
+	}
+	return false
+}

--- a/amqp/broker/policy.go
+++ b/amqp/broker/policy.go
@@ -35,10 +35,10 @@ type VerifiedPeerIdentity struct {
 
 // LocalPrincipalAuthenticator authenticates credentials against a verified TLS
 // peer identity. certificateURI must name the URI SAN selected from peer.URISANs.
-// credentialFingerprint is an opaque, non-secret identifier used to revoke
-// sessions after credential rotation.
+// credentialFingerprint and permissionsFingerprint are opaque, non-secret
+// identifiers used to revoke sessions after credential or publish-ACL changes.
 type LocalPrincipalAuthenticator interface {
-	AuthenticateLocal(ctx context.Context, clientID, username, secret string, peer VerifiedPeerIdentity) (principalID, credentialFingerprint, certificateURI string, authenticated bool, err error)
+	AuthenticateLocal(ctx context.Context, clientID, username, secret string, peer VerifiedPeerIdentity) (principalID, credentialFingerprint, permissionsFingerprint, certificateURI string, authenticated bool, err error)
 }
 
 // LocalPrincipalAuthorizer makes exact AMQP publish decisions for a fully
@@ -48,10 +48,11 @@ type LocalPrincipalAuthorizer interface {
 	CanPublishLocal(identity LocalSessionIdentity, exchange, routingKey string) bool
 }
 
-// LocalSessionValidator checks whether the immutable credential and certificate
-// binding established during authentication is still active in the current
-// local-principal snapshot. It closes the authenticate-before-register reload
-// race; publish authorization remains a separate per-method check.
+// LocalSessionValidator checks whether the immutable credential, permissions,
+// and certificate binding established during authentication is still active in
+// the current local-principal snapshot. It closes the
+// authenticate-before-register reload race; publish authorization remains a
+// separate per-method check.
 type LocalSessionValidator interface {
 	IsSessionActive(identity LocalSessionIdentity) bool
 }
@@ -61,6 +62,7 @@ type LocalSessionValidator interface {
 type LocalSessionIdentity struct {
 	PrincipalID            string
 	CredentialFingerprint  string
+	PermissionsFingerprint string
 	CertificateURI         string
 	CertificateFingerprint string
 }

--- a/amqp/broker/policy_test.go
+++ b/amqp/broker/policy_test.go
@@ -25,7 +25,10 @@ import (
 const (
 	testLocalPrincipal = "atom-audit-publisher"
 	testCredentialFP   = "credential-fingerprint"
+	testPermissionsFP  = "permissions-fingerprint"
 	testCertificateURI = "spiffe://absmach/atom/audit-publisher"
+	testConnectionID   = "test-conn"
+	testAuditQueue     = "atom-audit"
 )
 
 type localAuthenticatorStub struct {
@@ -37,12 +40,13 @@ type localAuthenticatorStub struct {
 	peer           VerifiedPeerIdentity
 	principalID    string
 	credentialFP   string
+	permissionsFP  string
 	certificateURI string
 	authenticated  bool
 	err            error
 }
 
-func (s *localAuthenticatorStub) AuthenticateLocal(_ context.Context, clientID, username, secret string, peer VerifiedPeerIdentity) (string, string, string, bool, error) {
+func (s *localAuthenticatorStub) AuthenticateLocal(_ context.Context, clientID, username, secret string, peer VerifiedPeerIdentity) (string, string, string, string, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.calls++
@@ -50,7 +54,7 @@ func (s *localAuthenticatorStub) AuthenticateLocal(_ context.Context, clientID, 
 	s.username = username
 	s.secret = secret
 	s.peer = peer
-	return s.principalID, s.credentialFP, s.certificateURI, s.authenticated, s.err
+	return s.principalID, s.credentialFP, s.permissionsFP, s.certificateURI, s.authenticated, s.err
 }
 
 type localAuthorizerStub struct {
@@ -119,7 +123,7 @@ func newPolicyTestConnection(t *testing.T, policy *ConnectionPolicy) (*Connectio
 		writer:   bufio.NewWriter(buf),
 		frameMax: defaultFrameMax,
 		logger:   logger,
-		connID:   "test-conn",
+		connID:   testConnectionID,
 		channels: make(map[uint16]*Channel),
 		peer: VerifiedPeerIdentity{
 			URISANs:                []string{testCertificateURI},
@@ -132,6 +136,7 @@ func bindLocalIdentity(conn *Connection) {
 	conn.localIdentity = &LocalSessionIdentity{
 		PrincipalID:            testLocalPrincipal,
 		CredentialFingerprint:  testCredentialFP,
+		PermissionsFingerprint: testPermissionsFP,
 		CertificateURI:         testCertificateURI,
 		CertificateFingerprint: "certificate-fingerprint",
 	}
@@ -158,6 +163,7 @@ func TestLocalAuthenticationBindsVerifiedIdentity(t *testing.T) {
 	authn := &localAuthenticatorStub{
 		principalID:    testLocalPrincipal,
 		credentialFP:   testCredentialFP,
+		permissionsFP:  testPermissionsFP,
 		certificateURI: testCertificateURI,
 		authenticated:  true,
 	}
@@ -165,7 +171,7 @@ func TestLocalAuthenticationBindsVerifiedIdentity(t *testing.T) {
 	conn, _ := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(authn, authz, authz, 0))
 	globalExternal := &externalAuthenticatorStub{}
 	conn.broker.SetAuthEngine(corebroker.NewAuthEngine(globalExternal, nil))
-	start := &codec.ConnectionStartOk{Mechanism: "PLAIN", Response: "\x00atom-audit-publisher\x00secret"}
+	start := &codec.ConnectionStartOk{Mechanism: saslMechanismPlain, Response: "\x00atom-audit-publisher\x00secret"}
 	if err := conn.authenticate(start); err != nil {
 		t.Fatalf("authenticate failed: %v", err)
 	}
@@ -185,7 +191,7 @@ func TestLocalAuthenticationBindsVerifiedIdentity(t *testing.T) {
 	if !ok {
 		t.Fatal("expected local session identity")
 	}
-	if identity.PrincipalID != testLocalPrincipal || identity.CredentialFingerprint != testCredentialFP || identity.CertificateURI != testCertificateURI {
+	if identity.PrincipalID != testLocalPrincipal || identity.CredentialFingerprint != testCredentialFP || identity.PermissionsFingerprint != testPermissionsFP || identity.CertificateURI != testCertificateURI {
 		t.Fatalf("unexpected identity: %+v", identity)
 	}
 }
@@ -194,12 +200,13 @@ func TestLocalAuthenticationRejectsUnverifiedSelectedURI(t *testing.T) {
 	authn := &localAuthenticatorStub{
 		principalID:    testLocalPrincipal,
 		credentialFP:   testCredentialFP,
+		permissionsFP:  testPermissionsFP,
 		certificateURI: "spiffe://attacker.invalid/publisher",
 		authenticated:  true,
 	}
 	authz := &localAuthorizerStub{}
 	conn, _ := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(authn, authz, authz, 0))
-	start := &codec.ConnectionStartOk{Mechanism: "PLAIN", Response: "\x00atom-audit-publisher\x00secret"}
+	start := &codec.ConnectionStartOk{Mechanism: saslMechanismPlain, Response: "\x00atom-audit-publisher\x00secret"}
 	if err := conn.authenticate(start); err == nil {
 		t.Fatal("expected authentication rejection")
 	}
@@ -217,7 +224,7 @@ func TestExternalPolicyUsesOnlyExternalAuth(t *testing.T) {
 	conn, _ := newPolicyTestConnection(t, NewExternalConnectionPolicy(engine, nil, 0))
 	globalExternal := &externalAuthenticatorStub{}
 	conn.broker.SetAuthEngine(corebroker.NewAuthEngine(globalExternal, nil))
-	start := &codec.ConnectionStartOk{Mechanism: "PLAIN", Response: "\x00remote-user\x00remote-secret"}
+	start := &codec.ConnectionStartOk{Mechanism: saslMechanismPlain, Response: "\x00remote-user\x00remote-secret"}
 	if err := conn.authenticate(start); err != nil {
 		t.Fatalf("external authentication failed: %v", err)
 	}
@@ -240,12 +247,12 @@ func TestLocalPublishOnlyMethodAllowlist(t *testing.T) {
 		id     uint16
 	}{
 		{"exchange declare", &codec.ExchangeDeclare{Exchange: "events"}, codec.ClassExchange, codec.MethodExchangeDeclare},
-		{"queue declare", &codec.QueueDeclare{Queue: "atom-audit"}, codec.ClassQueue, codec.MethodQueueDeclare},
-		{"consume", &codec.BasicConsume{Queue: "atom-audit"}, codec.ClassBasic, codec.MethodBasicConsume},
-		{"get", &codec.BasicGet{Queue: "atom-audit"}, codec.ClassBasic, codec.MethodBasicGet},
+		{"queue declare", &codec.QueueDeclare{Queue: testAuditQueue}, codec.ClassQueue, codec.MethodQueueDeclare},
+		{"consume", &codec.BasicConsume{Queue: testAuditQueue}, codec.ClassBasic, codec.MethodBasicConsume},
+		{"get", &codec.BasicGet{Queue: testAuditQueue}, codec.ClassBasic, codec.MethodBasicGet},
 		{"transaction", &codec.TxSelect{}, codec.ClassTx, codec.MethodTxSelect},
 	}
-	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
 	for _, tc := range denied {
 		t.Run(tc.name, func(t *testing.T) {
 			conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
@@ -266,18 +273,18 @@ func TestLocalPublishOnlyMethodAllowlist(t *testing.T) {
 }
 
 func TestServerClosedChannelIgnoresPublishAfterDeniedMethod(t *testing.T) {
-	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
 	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
 	ch := newChannel(conn, 1)
 
-	if err := ch.handleMethod(&codec.QueueDeclare{Queue: "atom-audit"}); err != nil {
+	if err := ch.handleMethod(&codec.QueueDeclare{Queue: testAuditQueue}); err != nil {
 		t.Fatalf("deny queue declare: %v", err)
 	}
 	if !ch.serverClosing.Load() {
 		t.Fatal("channel did not enter server-closing state after denial")
 	}
-	if err := ch.handleMethod(&codec.BasicPublish{RoutingKey: "atom-audit"}); err != nil {
+	if err := ch.handleMethod(&codec.BasicPublish{RoutingKey: testAuditQueue}); err != nil {
 		t.Fatalf("publish while closing: %v", err)
 	}
 	if ch.pendingMethod != nil {
@@ -298,17 +305,17 @@ func TestServerClosedChannelIgnoresPublishAfterDeniedMethod(t *testing.T) {
 }
 
 func TestLocalPublishRequiresExactExchangeAndRoutingKey(t *testing.T) {
-	authz := &localAuthorizerStub{allowExchange: "", allowRoutingKey: "atom-audit"}
+	authz := &localAuthorizerStub{allowExchange: "", allowRoutingKey: testAuditQueue}
 	tests := []struct {
 		name       string
 		exchange   string
 		routingKey string
 		allowed    bool
 	}{
-		{"exact target", "", "atom-audit", true},
-		{"explicit default alias is not exact", "amq.default", "atom-audit", false},
+		{"exact target", "", testAuditQueue, true},
+		{"explicit default alias is not exact", "amq.default", testAuditQueue, false},
 		{"wrong routing key", "", "other", false},
-		{"wrong exchange", "events", "atom-audit", false},
+		{"wrong exchange", "events", testAuditQueue, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -336,16 +343,16 @@ func TestLocalPublishRequiresExactExchangeAndRoutingKey(t *testing.T) {
 }
 
 func TestLocalPolicyBypassesBrokerGlobalHooks(t *testing.T) {
-	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
 	conn, _ := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
 	hook := &hookCounter{}
 	conn.broker.SetBlockingHooks(corebroker.NewBlockingHookEngine(hook, corebroker.HookFailDeny, nil, nil, nil))
-	qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: "atom-audit", Type: qtypes.QueueTypeStream}}
+	qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: testAuditQueue, Type: qtypes.QueueTypeStream}}
 	conn.broker.queueManager = qm
 
 	ch := newChannel(conn, 1)
-	ch.pendingMethod = &codec.BasicPublish{RoutingKey: "atom-audit"}
+	ch.pendingMethod = &codec.BasicPublish{RoutingKey: testAuditQueue}
 	ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
 	ch.pendingBody = []byte("{}")
 	ch.completePublish()
@@ -356,26 +363,26 @@ func TestLocalPolicyBypassesBrokerGlobalHooks(t *testing.T) {
 	if qm.publishCalls != 0 {
 		t.Fatalf("general queue publish calls = %d, want 0", qm.publishCalls)
 	}
-	if qm.exactPublishCalls != 1 || qm.exactStreamName != "atom-audit" || qm.exactPublish.Topic != "$queue/atom-audit" {
+	if qm.exactPublishCalls != 1 || qm.exactStreamName != testAuditQueue || qm.exactPublish.Topic != "$queue/atom-audit" {
 		t.Fatalf("unexpected exact stream publish: calls=%d queue=%q request=%+v", qm.exactPublishCalls, qm.exactStreamName, qm.exactPublish)
 	}
 }
 
 func TestLocalDurableStreamAppendFailureNacksConfirm(t *testing.T) {
-	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
 	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
 	qm := &mockChannelQueueManager{exactPublishErr: errors.New("disk full")}
 	conn.broker.queueManager = qm
 	ch := newChannel(conn, 1)
 	ch.confirmMode = true
-	ch.pendingMethod = &codec.BasicPublish{RoutingKey: "atom-audit"}
+	ch.pendingMethod = &codec.BasicPublish{RoutingKey: testAuditQueue}
 	ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
 	ch.pendingBody = []byte("{}")
 
 	ch.completePublish()
 
-	if qm.publishCalls != 0 || qm.exactPublishCalls != 1 || qm.exactStreamName != "atom-audit" {
+	if qm.publishCalls != 0 || qm.exactPublishCalls != 1 || qm.exactStreamName != testAuditQueue {
 		t.Fatalf("unexpected routing: general=%d exact=%d queue=%q", qm.publishCalls, qm.exactPublishCalls, qm.exactStreamName)
 	}
 	frames := readFramesFrom(t, buf, 0)
@@ -392,20 +399,20 @@ func TestLocalDurableStreamAppendFailureNacksConfirm(t *testing.T) {
 }
 
 func TestLocalDurableStreamOversizeFailureNacksConfirm(t *testing.T) {
-	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
 	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
 	qm := &mockChannelQueueManager{exactPublishErr: queue.ErrQueueMessageTooLarge}
 	conn.broker.queueManager = qm
 	ch := newChannel(conn, 1)
 	ch.confirmMode = true
-	ch.pendingMethod = &codec.BasicPublish{RoutingKey: "atom-audit"}
+	ch.pendingMethod = &codec.BasicPublish{RoutingKey: testAuditQueue}
 	ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
 	ch.pendingBody = []byte("{}")
 
 	ch.completePublish()
 
-	if qm.publishCalls != 0 || qm.exactPublishCalls != 1 || qm.exactStreamName != "atom-audit" {
+	if qm.publishCalls != 0 || qm.exactPublishCalls != 1 || qm.exactStreamName != testAuditQueue {
 		t.Fatalf("unexpected routing: general=%d exact=%d queue=%q", qm.publishCalls, qm.exactPublishCalls, qm.exactStreamName)
 	}
 	frames := readFramesFrom(t, buf, 0)
@@ -422,20 +429,20 @@ func TestLocalDurableStreamOversizeFailureNacksConfirm(t *testing.T) {
 }
 
 func TestLocalDurableStreamSuccessAcksExactQueueOnly(t *testing.T) {
-	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
 	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
 	qm := &mockChannelQueueManager{}
 	conn.broker.queueManager = qm
 	ch := newChannel(conn, 1)
 	ch.confirmMode = true
-	ch.pendingMethod = &codec.BasicPublish{RoutingKey: "atom-audit"}
+	ch.pendingMethod = &codec.BasicPublish{RoutingKey: testAuditQueue}
 	ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
 	ch.pendingBody = []byte("{}")
 
 	ch.completePublish()
 
-	if qm.publishCalls != 0 || qm.exactPublishCalls != 1 || qm.exactStreamName != "atom-audit" {
+	if qm.publishCalls != 0 || qm.exactPublishCalls != 1 || qm.exactStreamName != testAuditQueue {
 		t.Fatalf("unexpected routing: general=%d exact=%d queue=%q", qm.publishCalls, qm.exactPublishCalls, qm.exactStreamName)
 	}
 	frames := readFramesFrom(t, buf, 0)
@@ -452,13 +459,13 @@ func TestLocalDurableStreamSuccessAcksExactQueueOnly(t *testing.T) {
 }
 
 func TestLocalPublishRechecksAuthorizationAfterContent(t *testing.T) {
-	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
 	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
-	qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: "atom-audit", Type: qtypes.QueueTypeStream}}
+	qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: testAuditQueue, Type: qtypes.QueueTypeStream}}
 	conn.broker.queueManager = qm
 	ch := newChannel(conn, 1)
-	if err := ch.handleMethod(&codec.BasicPublish{RoutingKey: "atom-audit"}); err != nil {
+	if err := ch.handleMethod(&codec.BasicPublish{RoutingKey: testAuditQueue}); err != nil {
 		t.Fatalf("start publish: %v", err)
 	}
 	authz.allowRoutingKey = "revoked"
@@ -478,16 +485,17 @@ func TestLocalCredentialRetiredBeforeRegistrationIsUnregistered(t *testing.T) {
 	authn := &localAuthenticatorStub{
 		principalID:    testLocalPrincipal,
 		credentialFP:   testCredentialFP,
+		permissionsFP:  testPermissionsFP,
 		certificateURI: testCertificateURI,
 		authenticated:  true,
 	}
-	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
 	conn, _ := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(authn, authz, authz, 0))
 	transport := &memoryConn{}
 	conn.conn = transport
 	conn.writer = bufio.NewWriter(transport)
 	conn.closeCh = make(chan struct{})
-	start := &codec.ConnectionStartOk{Mechanism: "PLAIN", Response: "\x00atom-audit-publisher\x00old-secret"}
+	start := &codec.ConnectionStartOk{Mechanism: saslMechanismPlain, Response: "\x00atom-audit-publisher\x00old-secret"}
 	if err := conn.authenticate(start); err != nil {
 		t.Fatalf("authenticate before reload: %v", err)
 	}
@@ -526,13 +534,13 @@ func TestLocalCredentialRetiredBeforeRegistrationIsUnregistered(t *testing.T) {
 }
 
 func TestLocalPublishRejectsCredentialRetiredDuringContent(t *testing.T) {
-	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
 	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
-	qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: "atom-audit", Type: qtypes.QueueTypeStream}}
+	qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: testAuditQueue, Type: qtypes.QueueTypeStream}}
 	conn.broker.queueManager = qm
 	ch := newChannel(conn, 1)
-	if err := ch.handleMethod(&codec.BasicPublish{RoutingKey: "atom-audit"}); err != nil {
+	if err := ch.handleMethod(&codec.BasicPublish{RoutingKey: testAuditQueue}); err != nil {
 		t.Fatalf("start publish: %v", err)
 	}
 
@@ -557,12 +565,12 @@ func TestExplicitExternalPolicyBypassesBrokerGlobalHooks(t *testing.T) {
 	conn.broker.SetCrossDeliver(func(context.Context, string, string, []byte, byte, map[string]string) {
 		delivered++
 	})
-	if err := conn.broker.router.Subscribe("mqtt-client", "atom-audit", 1, storage.SubscribeOptions{}); err != nil {
+	if err := conn.broker.router.Subscribe("mqtt-client", testAuditQueue, 1, storage.SubscribeOptions{}); err != nil {
 		t.Fatalf("subscribe test route: %v", err)
 	}
 
 	ch := newChannel(conn, 1)
-	ch.pendingMethod = &codec.BasicPublish{RoutingKey: "atom-audit"}
+	ch.pendingMethod = &codec.BasicPublish{RoutingKey: testAuditQueue}
 	ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
 	ch.pendingBody = []byte("{}")
 	ch.completePublish()
@@ -579,7 +587,7 @@ func TestMessageSizeRejectedBeforeBodyAllocation(t *testing.T) {
 	policy := NewExternalConnectionPolicy(nil, nil, 1024)
 	conn, buf := newPolicyTestConnection(t, policy)
 	ch := newChannel(conn, 1)
-	ch.pendingMethod = &codec.BasicPublish{RoutingKey: "atom-audit"}
+	ch.pendingMethod = &codec.BasicPublish{RoutingKey: testAuditQueue}
 	header := &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 1025}
 	var payload bytes.Buffer
 	if err := header.WriteContentHeader(&payload); err != nil {
@@ -637,9 +645,9 @@ func TestChannelIDCannotExceedNegotiatedMaximum(t *testing.T) {
 func TestPreconfiguredStreamDetectedThroughQueueManager(t *testing.T) {
 	conn, _ := newPolicyTestConnection(t, NewExternalConnectionPolicy(nil, nil, 0))
 	conn.broker.queueManager = &mockChannelQueueManager{
-		queueCfg: &qtypes.QueueConfig{Name: "atom-audit", Type: qtypes.QueueTypeStream},
+		queueCfg: &qtypes.QueueConfig{Name: testAuditQueue, Type: qtypes.QueueTypeStream},
 	}
-	if !newChannel(conn, 1).isStreamQueue("atom-audit") {
+	if !newChannel(conn, 1).isStreamQueue(testAuditQueue) {
 		t.Fatal("expected globally preconfigured stream to be detected")
 	}
 }

--- a/amqp/broker/policy_test.go
+++ b/amqp/broker/policy_test.go
@@ -425,6 +425,75 @@ func TestLocalDurableStreamPublishIsBounded(t *testing.T) {
 	}
 }
 
+// blockingStreamQueueManager stalls inside the durable append the way an
+// unresponsive disk does: the barrier cannot be interrupted, so the deadline
+// has to be enforced by the caller waiting on it.
+type blockingStreamQueueManager struct {
+	mockChannelQueueManager
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (m *blockingStreamQueueManager) PublishToDurableStream(_ context.Context, _ string, _ qtypes.PublishRequest) error {
+	close(m.entered)
+	<-m.release
+	return nil
+}
+
+func TestLocalDurableStreamPublishNacksWhenBarrierStalls(t *testing.T) {
+	previousTimeout := localPublishTimeout
+	localPublishTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { localPublishTimeout = previousTimeout })
+
+	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
+	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	bindLocalIdentity(conn)
+	qm := &blockingStreamQueueManager{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	t.Cleanup(func() { close(qm.release) })
+	conn.broker.queueManager = qm
+
+	ch := newChannel(conn, 1)
+	ch.confirmMode = true
+	ch.pendingMethod = &codec.BasicPublish{RoutingKey: testAuditQueue}
+	ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
+	ch.pendingBody = []byte("{}")
+
+	completed := make(chan struct{})
+	go func() {
+		ch.completePublish()
+		close(completed)
+	}()
+
+	select {
+	case <-qm.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("durable append was never entered")
+	}
+	select {
+	case <-completed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("publish did not return while the durable barrier was stalled")
+	}
+
+	frames := readFramesFrom(t, buf, 0)
+	if len(frames) != 1 {
+		t.Fatalf("frames = %d, want 1", len(frames))
+	}
+	decoded, err := frames[0].Decode()
+	if err != nil {
+		t.Fatalf("decode publisher response: %v", err)
+	}
+	if _, ok := decoded.(*codec.BasicNack); !ok {
+		t.Fatalf("response = %T, want BasicNack", decoded)
+	}
+	if count := conn.broker.stats.GetLocalPublishTimeouts(); count != 1 {
+		t.Fatalf("publish timeouts = %d, want 1", count)
+	}
+}
+
 func TestLocalDurableStreamPublishNacksOnConnectionShutdown(t *testing.T) {
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
 	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))

--- a/amqp/broker/policy_test.go
+++ b/amqp/broker/policy_test.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -440,6 +441,155 @@ func (m *blockingStreamQueueManager) PublishToDurableStream(_ context.Context, _
 	return nil
 }
 
+// stalledStreamQueueManager never completes an append, the way storage that has
+// stopped responding behaves, and records how many appends were running at once.
+type stalledStreamQueueManager struct {
+	mockChannelQueueManager
+	release  chan struct{}
+	entered  chan struct{}
+	current  atomic.Int64
+	peak     atomic.Int64
+	attempts atomic.Int64
+}
+
+func (m *stalledStreamQueueManager) PublishToDurableStream(_ context.Context, _ string, _ qtypes.PublishRequest) error {
+	m.attempts.Add(1)
+	running := m.current.Add(1)
+	for {
+		peak := m.peak.Load()
+		if running <= peak || m.peak.CompareAndSwap(peak, running) {
+			break
+		}
+	}
+	select {
+	case m.entered <- struct{}{}:
+	default:
+	}
+	<-m.release
+	m.current.Add(-1)
+	return nil
+}
+
+// assertAbandonedPublishResponse checks the response to a publication FluxMQ
+// stopped waiting for: a NACK, then a channel close so the publisher cannot
+// keep retrying into storage that has not recovered.
+func assertAbandonedPublishResponse(t *testing.T, buf *bytes.Buffer) {
+	t.Helper()
+	frames := readFramesFrom(t, buf, 0)
+	if len(frames) != 2 {
+		t.Fatalf("frames = %d, want 2 (nack and channel close)", len(frames))
+	}
+	nack, err := frames[0].Decode()
+	if err != nil {
+		t.Fatalf("decode publisher response: %v", err)
+	}
+	if _, ok := nack.(*codec.BasicNack); !ok {
+		t.Fatalf("first response = %T, want BasicNack", nack)
+	}
+	closeMethod, err := frames[1].Decode()
+	if err != nil {
+		t.Fatalf("decode channel close: %v", err)
+	}
+	if _, ok := closeMethod.(*codec.ChannelClose); !ok {
+		t.Fatalf("second response = %T, want ChannelClose", closeMethod)
+	}
+}
+
+func TestLocalDurableStreamPublishBoundsAbandonedAppends(t *testing.T) {
+	previousTimeout := localPublishTimeout
+	previousLimit := maxOutstandingDurableAppends
+	localPublishTimeout = 20 * time.Millisecond
+	maxOutstandingDurableAppends = 2
+	t.Cleanup(func() {
+		localPublishTimeout = previousTimeout
+		maxOutstandingDurableAppends = previousLimit
+	})
+
+	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
+	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	bindLocalIdentity(conn)
+	qm := &stalledStreamQueueManager{
+		release: make(chan struct{}),
+		entered: make(chan struct{}, 1),
+	}
+	releaseOnce := sync.Once{}
+	release := func() { releaseOnce.Do(func() { close(qm.release) }) }
+	t.Cleanup(release)
+	conn.broker.queueManager = qm
+
+	// A publisher that keeps retrying against storage that never recovers must
+	// not be able to accumulate barriers, each holding its payload.
+	const attempts = 8
+	for i := range attempts {
+		ch := newChannel(conn, uint16(i+1))
+		ch.confirmMode = true
+		ch.pendingMethod = &codec.BasicPublish{RoutingKey: testAuditQueue}
+		ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
+		ch.pendingBody = []byte("{}")
+		ch.completePublish()
+	}
+
+	if peak := qm.peak.Load(); peak > int64(maxOutstandingDurableAppends) {
+		t.Fatalf("concurrent durable appends peaked at %d, want at most %d", peak, maxOutstandingDurableAppends)
+	}
+	if started := qm.attempts.Load(); started != int64(maxOutstandingDurableAppends) {
+		t.Fatalf("started appends = %d, want %d; later attempts must be refused before starting work", started, maxOutstandingDurableAppends)
+	}
+	if outstanding := conn.broker.durableAppends.outstandingFor(testAuditQueue); outstanding != maxOutstandingDurableAppends {
+		t.Fatalf("outstanding appends = %d, want %d", outstanding, maxOutstandingDurableAppends)
+	}
+	if timeouts := conn.broker.stats.GetLocalPublishTimeouts(); timeouts != uint64(maxOutstandingDurableAppends) {
+		t.Fatalf("publish timeouts = %d, want %d", timeouts, maxOutstandingDurableAppends)
+	}
+	if rejections := conn.broker.stats.GetLocalPublishRejections(); rejections != attempts-uint64(maxOutstandingDurableAppends) {
+		t.Fatalf("publish rejections = %d, want %d", rejections, attempts-maxOutstandingDurableAppends)
+	}
+
+	// Every attempt is answered, and each channel is closed so the publisher
+	// cannot keep retrying into storage that has not recovered.
+	nacks, closes := 0, 0
+	for _, frame := range readFramesFrom(t, buf, 0) {
+		decoded, err := frame.Decode()
+		if err != nil {
+			t.Fatalf("decode publisher response: %v", err)
+		}
+		switch decoded.(type) {
+		case *codec.BasicNack:
+			nacks++
+		case *codec.ChannelClose:
+			closes++
+		default:
+			t.Fatalf("unexpected response %T", decoded)
+		}
+	}
+	if nacks != attempts || closes != attempts {
+		t.Fatalf("nacks = %d, channel closes = %d, want %d of each", nacks, closes, attempts)
+	}
+
+	// Once storage recovers, the slots are returned and publishing resumes.
+	release()
+	deadline := time.After(5 * time.Second)
+	for conn.broker.durableAppends.outstandingFor(testAuditQueue) != 0 {
+		select {
+		case <-deadline:
+			t.Fatal("durable append slots were not released after storage recovered")
+		default:
+		}
+	}
+
+	localPublishTimeout = previousTimeout
+	healthy := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: testAuditQueue, Type: qtypes.QueueTypeStream}}
+	conn.broker.queueManager = healthy
+	ch := newChannel(conn, attempts+1)
+	ch.pendingMethod = &codec.BasicPublish{RoutingKey: testAuditQueue}
+	ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
+	ch.pendingBody = []byte("{}")
+	ch.completePublish()
+	if healthy.exactPublishCalls != 1 {
+		t.Fatalf("publish calls after recovery = %d, want 1", healthy.exactPublishCalls)
+	}
+}
+
 func TestLocalDurableStreamPublishNacksWhenBarrierStalls(t *testing.T) {
 	previousTimeout := localPublishTimeout
 	localPublishTimeout = 50 * time.Millisecond
@@ -478,17 +628,7 @@ func TestLocalDurableStreamPublishNacksWhenBarrierStalls(t *testing.T) {
 		t.Fatal("publish did not return while the durable barrier was stalled")
 	}
 
-	frames := readFramesFrom(t, buf, 0)
-	if len(frames) != 1 {
-		t.Fatalf("frames = %d, want 1", len(frames))
-	}
-	decoded, err := frames[0].Decode()
-	if err != nil {
-		t.Fatalf("decode publisher response: %v", err)
-	}
-	if _, ok := decoded.(*codec.BasicNack); !ok {
-		t.Fatalf("response = %T, want BasicNack", decoded)
-	}
+	assertAbandonedPublishResponse(t, buf)
 	if count := conn.broker.stats.GetLocalPublishTimeouts(); count != 1 {
 		t.Fatalf("publish timeouts = %d, want 1", count)
 	}
@@ -511,17 +651,7 @@ func TestLocalDurableStreamPublishNacksOnConnectionShutdown(t *testing.T) {
 	ch.pendingBody = []byte("{}")
 	ch.completePublish()
 
-	frames := readFramesFrom(t, buf, 0)
-	if len(frames) != 1 {
-		t.Fatalf("frames = %d, want 1", len(frames))
-	}
-	decoded, err := frames[0].Decode()
-	if err != nil {
-		t.Fatalf("decode publisher response: %v", err)
-	}
-	if _, ok := decoded.(*codec.BasicNack); !ok {
-		t.Fatalf("response = %T, want BasicNack", decoded)
-	}
+	assertAbandonedPublishResponse(t, buf)
 }
 
 func TestLocalDurableStreamOversizeFailureNacksConfirm(t *testing.T) {

--- a/amqp/broker/policy_test.go
+++ b/amqp/broker/policy_test.go
@@ -398,6 +398,61 @@ func TestLocalDurableStreamAppendFailureNacksConfirm(t *testing.T) {
 	}
 }
 
+func TestLocalDurableStreamPublishIsBounded(t *testing.T) {
+	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
+	conn, _ := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	bindLocalIdentity(conn)
+	qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: testAuditQueue, Type: qtypes.QueueTypeStream}}
+	conn.broker.queueManager = qm
+
+	ch := newChannel(conn, 1)
+	ch.pendingMethod = &codec.BasicPublish{RoutingKey: testAuditQueue}
+	ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
+	ch.pendingBody = []byte("{}")
+	ch.completePublish()
+
+	if qm.exactPublishCtx == nil {
+		t.Fatal("durable stream publish did not receive a context")
+	}
+	deadline, ok := qm.exactPublishCtx.Deadline()
+	if !ok {
+		t.Fatal("durable stream publish context has no deadline; a stalled disk would pin the connection goroutine")
+	}
+	if remaining := time.Until(deadline); remaining > localPublishTimeout {
+		t.Fatalf("deadline in %v, want at most %v", remaining, localPublishTimeout)
+	}
+}
+
+func TestLocalDurableStreamPublishNacksOnConnectionShutdown(t *testing.T) {
+	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
+	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	bindLocalIdentity(conn)
+	ctx, cancel := context.WithCancel(context.Background())
+	conn.ctx = ctx
+	cancel()
+	qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: testAuditQueue, Type: qtypes.QueueTypeStream}}
+	conn.broker.queueManager = qm
+
+	ch := newChannel(conn, 1)
+	ch.confirmMode = true
+	ch.pendingMethod = &codec.BasicPublish{RoutingKey: testAuditQueue}
+	ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
+	ch.pendingBody = []byte("{}")
+	ch.completePublish()
+
+	frames := readFramesFrom(t, buf, 0)
+	if len(frames) != 1 {
+		t.Fatalf("frames = %d, want 1", len(frames))
+	}
+	decoded, err := frames[0].Decode()
+	if err != nil {
+		t.Fatalf("decode publisher response: %v", err)
+	}
+	if _, ok := decoded.(*codec.BasicNack); !ok {
+		t.Fatalf("response = %T, want BasicNack", decoded)
+	}
+}
+
 func TestLocalDurableStreamOversizeFailureNacksConfirm(t *testing.T) {
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
 	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))

--- a/amqp/broker/policy_test.go
+++ b/amqp/broker/policy_test.go
@@ -313,7 +313,9 @@ func TestLocalPublishRequiresExactExchangeAndRoutingKey(t *testing.T) {
 		allowed    bool
 	}{
 		{"exact target", "", testAuditQueue, true},
-		{"explicit default alias is not exact", "amq.default", testAuditQueue, false},
+		// amq.default names the same default exchange the router resolves "" to,
+		// so the ACL must reach the same decision for both spellings.
+		{"explicit default alias", "amq.default", testAuditQueue, true},
 		{"wrong routing key", "", "other", false},
 		{"wrong exchange", "events", testAuditQueue, false},
 	}

--- a/amqp/broker/policy_test.go
+++ b/amqp/broker/policy_test.go
@@ -1,0 +1,697 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/absmach/fluxmq/amqp/codec"
+	corebroker "github.com/absmach/fluxmq/broker"
+	"github.com/absmach/fluxmq/queue"
+	qtypes "github.com/absmach/fluxmq/queue/types"
+	"github.com/absmach/fluxmq/storage"
+)
+
+const (
+	testLocalPrincipal = "atom-audit-publisher"
+	testCredentialFP   = "credential-fingerprint"
+	testCertificateURI = "spiffe://absmach/atom/audit-publisher"
+)
+
+type localAuthenticatorStub struct {
+	mu             sync.Mutex
+	calls          int
+	clientID       string
+	username       string
+	secret         string
+	peer           VerifiedPeerIdentity
+	principalID    string
+	credentialFP   string
+	certificateURI string
+	authenticated  bool
+	err            error
+}
+
+func (s *localAuthenticatorStub) AuthenticateLocal(_ context.Context, clientID, username, secret string, peer VerifiedPeerIdentity) (string, string, string, bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls++
+	s.clientID = clientID
+	s.username = username
+	s.secret = secret
+	s.peer = peer
+	return s.principalID, s.credentialFP, s.certificateURI, s.authenticated, s.err
+}
+
+type localAuthorizerStub struct {
+	allowExchange   string
+	allowRoutingKey string
+	retired         bool
+	lastIdentity    LocalSessionIdentity
+	calls           int
+}
+
+func (s *localAuthorizerStub) CanPublishLocal(identity LocalSessionIdentity, exchange, routingKey string) bool {
+	s.calls++
+	s.lastIdentity = identity
+	return !s.retired && exchange == s.allowExchange && routingKey == s.allowRoutingKey
+}
+
+func (s *localAuthorizerStub) IsSessionActive(identity LocalSessionIdentity) bool {
+	s.lastIdentity = identity
+	return !s.retired
+}
+
+type externalAuthenticatorStub struct {
+	calls int
+}
+
+func (s *externalAuthenticatorStub) Authenticate(_, _, _ string) (*corebroker.AuthnResult, error) {
+	s.calls++
+	return &corebroker.AuthnResult{Authenticated: true, ID: "external-principal"}, nil
+}
+
+type hookCounter struct {
+	calls int
+}
+
+func (h *hookCounter) HandleHook(_ context.Context, _ corebroker.BlockingHookRequest) (corebroker.BlockingHookResult, error) {
+	h.calls++
+	return corebroker.BlockingHookResult{Allowed: true}, nil
+}
+
+type memoryConn struct {
+	bytes.Buffer
+	closed bool
+}
+
+func (c *memoryConn) Read([]byte) (int, error)         { return 0, io.EOF }
+func (c *memoryConn) Close() error                     { c.closed = true; return nil }
+func (c *memoryConn) LocalAddr() net.Addr              { return testAddr("local") }
+func (c *memoryConn) RemoteAddr() net.Addr             { return testAddr("remote") }
+func (c *memoryConn) SetDeadline(time.Time) error      { return nil }
+func (c *memoryConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *memoryConn) SetWriteDeadline(time.Time) error { return nil }
+
+type testAddr string
+
+func (a testAddr) Network() string { return "test" }
+func (a testAddr) String() string  { return string(a) }
+
+func newPolicyTestConnection(t *testing.T, policy *ConnectionPolicy) (*Connection, *bytes.Buffer) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return &Connection{
+		broker:   New(nil, logger),
+		ctx:      context.Background(),
+		policy:   policy,
+		writer:   bufio.NewWriter(buf),
+		frameMax: defaultFrameMax,
+		logger:   logger,
+		connID:   "test-conn",
+		channels: make(map[uint16]*Channel),
+		peer: VerifiedPeerIdentity{
+			URISANs:                []string{testCertificateURI},
+			CertificateFingerprint: "certificate-fingerprint",
+		},
+	}, buf
+}
+
+func bindLocalIdentity(conn *Connection) {
+	conn.localIdentity = &LocalSessionIdentity{
+		PrincipalID:            testLocalPrincipal,
+		CredentialFingerprint:  testCredentialFP,
+		CertificateURI:         testCertificateURI,
+		CertificateFingerprint: "certificate-fingerprint",
+	}
+}
+
+func decodeSingleChannelClose(t *testing.T, buf *bytes.Buffer) *codec.ChannelClose {
+	t.Helper()
+	frames := readFramesFrom(t, buf, 0)
+	if len(frames) != 1 {
+		t.Fatalf("expected one frame, got %d", len(frames))
+	}
+	decoded, err := frames[0].Decode()
+	if err != nil {
+		t.Fatalf("decode channel close: %v", err)
+	}
+	closeMethod, ok := decoded.(*codec.ChannelClose)
+	if !ok {
+		t.Fatalf("expected ChannelClose, got %T", decoded)
+	}
+	return closeMethod
+}
+
+func TestLocalAuthenticationBindsVerifiedIdentity(t *testing.T) {
+	authn := &localAuthenticatorStub{
+		principalID:    testLocalPrincipal,
+		credentialFP:   testCredentialFP,
+		certificateURI: testCertificateURI,
+		authenticated:  true,
+	}
+	authz := &localAuthorizerStub{}
+	conn, _ := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(authn, authz, authz, 0))
+	globalExternal := &externalAuthenticatorStub{}
+	conn.broker.SetAuthEngine(corebroker.NewAuthEngine(globalExternal, nil))
+	start := &codec.ConnectionStartOk{Mechanism: "PLAIN", Response: "\x00atom-audit-publisher\x00secret"}
+	if err := conn.authenticate(start); err != nil {
+		t.Fatalf("authenticate failed: %v", err)
+	}
+	if authn.calls != 1 || authn.username != testLocalPrincipal || authn.secret != "secret" {
+		t.Fatalf("unexpected local auth call: %+v", authn)
+	}
+	if globalExternal.calls != 0 {
+		t.Fatalf("global external authenticator calls = %d, want 0", globalExternal.calls)
+	}
+	if got := conn.broker.stats.GetLocalAuthSuccess(); got != 1 {
+		t.Fatalf("local auth successes = %d, want 1", got)
+	}
+	if got := conn.broker.stats.GetLocalAuthFailures(); got != 0 {
+		t.Fatalf("local auth failures = %d, want 0", got)
+	}
+	identity, ok := conn.localSessionIdentity()
+	if !ok {
+		t.Fatal("expected local session identity")
+	}
+	if identity.PrincipalID != testLocalPrincipal || identity.CredentialFingerprint != testCredentialFP || identity.CertificateURI != testCertificateURI {
+		t.Fatalf("unexpected identity: %+v", identity)
+	}
+}
+
+func TestLocalAuthenticationRejectsUnverifiedSelectedURI(t *testing.T) {
+	authn := &localAuthenticatorStub{
+		principalID:    testLocalPrincipal,
+		credentialFP:   testCredentialFP,
+		certificateURI: "spiffe://attacker.invalid/publisher",
+		authenticated:  true,
+	}
+	authz := &localAuthorizerStub{}
+	conn, _ := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(authn, authz, authz, 0))
+	start := &codec.ConnectionStartOk{Mechanism: "PLAIN", Response: "\x00atom-audit-publisher\x00secret"}
+	if err := conn.authenticate(start); err == nil {
+		t.Fatal("expected authentication rejection")
+	}
+	if _, ok := conn.localSessionIdentity(); ok {
+		t.Fatal("rejected authentication must not bind an identity")
+	}
+	if got := conn.broker.stats.GetLocalAuthFailures(); got != 1 {
+		t.Fatalf("local auth failures = %d, want 1", got)
+	}
+}
+
+func TestExternalPolicyUsesOnlyExternalAuth(t *testing.T) {
+	external := &externalAuthenticatorStub{}
+	engine := corebroker.NewAuthEngine(external, nil)
+	conn, _ := newPolicyTestConnection(t, NewExternalConnectionPolicy(engine, nil, 0))
+	globalExternal := &externalAuthenticatorStub{}
+	conn.broker.SetAuthEngine(corebroker.NewAuthEngine(globalExternal, nil))
+	start := &codec.ConnectionStartOk{Mechanism: "PLAIN", Response: "\x00remote-user\x00remote-secret"}
+	if err := conn.authenticate(start); err != nil {
+		t.Fatalf("external authentication failed: %v", err)
+	}
+	if external.calls != 1 {
+		t.Fatalf("external authenticator calls = %d, want 1", external.calls)
+	}
+	if globalExternal.calls != 0 {
+		t.Fatalf("broker-global authenticator calls = %d, want 0", globalExternal.calls)
+	}
+	if _, ok := conn.localSessionIdentity(); ok {
+		t.Fatal("external policy must not bind a local identity")
+	}
+}
+
+func TestLocalPublishOnlyMethodAllowlist(t *testing.T) {
+	denied := []struct {
+		name   string
+		method any
+		class  uint16
+		id     uint16
+	}{
+		{"exchange declare", &codec.ExchangeDeclare{Exchange: "events"}, codec.ClassExchange, codec.MethodExchangeDeclare},
+		{"queue declare", &codec.QueueDeclare{Queue: "atom-audit"}, codec.ClassQueue, codec.MethodQueueDeclare},
+		{"consume", &codec.BasicConsume{Queue: "atom-audit"}, codec.ClassBasic, codec.MethodBasicConsume},
+		{"get", &codec.BasicGet{Queue: "atom-audit"}, codec.ClassBasic, codec.MethodBasicGet},
+		{"transaction", &codec.TxSelect{}, codec.ClassTx, codec.MethodTxSelect},
+	}
+	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	for _, tc := range denied {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+			bindLocalIdentity(conn)
+			ch := newChannel(conn, 1)
+			if err := ch.handleMethod(tc.method); err != nil {
+				t.Fatalf("handle method: %v", err)
+			}
+			got := decodeSingleChannelClose(t, buf)
+			if got.ReplyCode != codec.AccessRefused || got.ClassID != tc.class || got.MethodID != tc.id {
+				t.Fatalf("unexpected denial: %+v", got)
+			}
+			if count := conn.broker.stats.GetLocalOperationDenials(); count != 1 {
+				t.Fatalf("operation denials = %d, want 1", count)
+			}
+		})
+	}
+}
+
+func TestServerClosedChannelIgnoresPublishAfterDeniedMethod(t *testing.T) {
+	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	bindLocalIdentity(conn)
+	ch := newChannel(conn, 1)
+
+	if err := ch.handleMethod(&codec.QueueDeclare{Queue: "atom-audit"}); err != nil {
+		t.Fatalf("deny queue declare: %v", err)
+	}
+	if !ch.serverClosing.Load() {
+		t.Fatal("channel did not enter server-closing state after denial")
+	}
+	if err := ch.handleMethod(&codec.BasicPublish{RoutingKey: "atom-audit"}); err != nil {
+		t.Fatalf("publish while closing: %v", err)
+	}
+	if ch.pendingMethod != nil {
+		t.Fatal("publish entered content state after server sent Channel.Close")
+	}
+
+	frames := readFramesFrom(t, buf, 0)
+	if len(frames) != 1 {
+		t.Fatalf("frames = %d, want only the original Channel.Close", len(frames))
+	}
+	decoded, err := frames[0].Decode()
+	if err != nil {
+		t.Fatalf("decode channel close: %v", err)
+	}
+	if _, ok := decoded.(*codec.ChannelClose); !ok {
+		t.Fatalf("frame = %T, want ChannelClose", decoded)
+	}
+}
+
+func TestLocalPublishRequiresExactExchangeAndRoutingKey(t *testing.T) {
+	authz := &localAuthorizerStub{allowExchange: "", allowRoutingKey: "atom-audit"}
+	tests := []struct {
+		name       string
+		exchange   string
+		routingKey string
+		allowed    bool
+	}{
+		{"exact target", "", "atom-audit", true},
+		{"explicit default alias is not exact", "amq.default", "atom-audit", false},
+		{"wrong routing key", "", "other", false},
+		{"wrong exchange", "events", "atom-audit", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+			bindLocalIdentity(conn)
+			ch := newChannel(conn, 1)
+			err := ch.handleMethod(&codec.BasicPublish{Exchange: tc.exchange, RoutingKey: tc.routingKey})
+			if err != nil {
+				t.Fatalf("handle publish: %v", err)
+			}
+			if tc.allowed {
+				if ch.pendingMethod == nil || buf.Len() != 0 {
+					t.Fatal("expected publish to enter content state without denial")
+				}
+				return
+			}
+			if got := decodeSingleChannelClose(t, buf); got.ReplyCode != codec.AccessRefused {
+				t.Fatalf("reply code = %d, want %d", got.ReplyCode, codec.AccessRefused)
+			}
+			if count := conn.broker.stats.GetLocalPublishDenials(); count != 1 {
+				t.Fatalf("publish denials = %d, want 1", count)
+			}
+		})
+	}
+}
+
+func TestLocalPolicyBypassesBrokerGlobalHooks(t *testing.T) {
+	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	conn, _ := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	bindLocalIdentity(conn)
+	hook := &hookCounter{}
+	conn.broker.SetBlockingHooks(corebroker.NewBlockingHookEngine(hook, corebroker.HookFailDeny, nil, nil, nil))
+	qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: "atom-audit", Type: qtypes.QueueTypeStream}}
+	conn.broker.queueManager = qm
+
+	ch := newChannel(conn, 1)
+	ch.pendingMethod = &codec.BasicPublish{RoutingKey: "atom-audit"}
+	ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
+	ch.pendingBody = []byte("{}")
+	ch.completePublish()
+
+	if hook.calls != 0 {
+		t.Fatalf("global hook calls = %d, want 0", hook.calls)
+	}
+	if qm.publishCalls != 0 {
+		t.Fatalf("general queue publish calls = %d, want 0", qm.publishCalls)
+	}
+	if qm.exactPublishCalls != 1 || qm.exactStreamName != "atom-audit" || qm.exactPublish.Topic != "$queue/atom-audit" {
+		t.Fatalf("unexpected exact stream publish: calls=%d queue=%q request=%+v", qm.exactPublishCalls, qm.exactStreamName, qm.exactPublish)
+	}
+}
+
+func TestLocalDurableStreamAppendFailureNacksConfirm(t *testing.T) {
+	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	bindLocalIdentity(conn)
+	qm := &mockChannelQueueManager{exactPublishErr: errors.New("disk full")}
+	conn.broker.queueManager = qm
+	ch := newChannel(conn, 1)
+	ch.confirmMode = true
+	ch.pendingMethod = &codec.BasicPublish{RoutingKey: "atom-audit"}
+	ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
+	ch.pendingBody = []byte("{}")
+
+	ch.completePublish()
+
+	if qm.publishCalls != 0 || qm.exactPublishCalls != 1 || qm.exactStreamName != "atom-audit" {
+		t.Fatalf("unexpected routing: general=%d exact=%d queue=%q", qm.publishCalls, qm.exactPublishCalls, qm.exactStreamName)
+	}
+	frames := readFramesFrom(t, buf, 0)
+	if len(frames) != 1 {
+		t.Fatalf("frames = %d, want 1", len(frames))
+	}
+	decoded, err := frames[0].Decode()
+	if err != nil {
+		t.Fatalf("decode publisher response: %v", err)
+	}
+	if _, ok := decoded.(*codec.BasicNack); !ok {
+		t.Fatalf("response = %T, want BasicNack", decoded)
+	}
+}
+
+func TestLocalDurableStreamOversizeFailureNacksConfirm(t *testing.T) {
+	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	bindLocalIdentity(conn)
+	qm := &mockChannelQueueManager{exactPublishErr: queue.ErrQueueMessageTooLarge}
+	conn.broker.queueManager = qm
+	ch := newChannel(conn, 1)
+	ch.confirmMode = true
+	ch.pendingMethod = &codec.BasicPublish{RoutingKey: "atom-audit"}
+	ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
+	ch.pendingBody = []byte("{}")
+
+	ch.completePublish()
+
+	if qm.publishCalls != 0 || qm.exactPublishCalls != 1 || qm.exactStreamName != "atom-audit" {
+		t.Fatalf("unexpected routing: general=%d exact=%d queue=%q", qm.publishCalls, qm.exactPublishCalls, qm.exactStreamName)
+	}
+	frames := readFramesFrom(t, buf, 0)
+	if len(frames) != 1 {
+		t.Fatalf("frames = %d, want 1", len(frames))
+	}
+	decoded, err := frames[0].Decode()
+	if err != nil {
+		t.Fatalf("decode publisher response: %v", err)
+	}
+	if _, ok := decoded.(*codec.BasicNack); !ok {
+		t.Fatalf("response = %T, want BasicNack", decoded)
+	}
+}
+
+func TestLocalDurableStreamSuccessAcksExactQueueOnly(t *testing.T) {
+	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	bindLocalIdentity(conn)
+	qm := &mockChannelQueueManager{}
+	conn.broker.queueManager = qm
+	ch := newChannel(conn, 1)
+	ch.confirmMode = true
+	ch.pendingMethod = &codec.BasicPublish{RoutingKey: "atom-audit"}
+	ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
+	ch.pendingBody = []byte("{}")
+
+	ch.completePublish()
+
+	if qm.publishCalls != 0 || qm.exactPublishCalls != 1 || qm.exactStreamName != "atom-audit" {
+		t.Fatalf("unexpected routing: general=%d exact=%d queue=%q", qm.publishCalls, qm.exactPublishCalls, qm.exactStreamName)
+	}
+	frames := readFramesFrom(t, buf, 0)
+	if len(frames) != 1 {
+		t.Fatalf("frames = %d, want 1", len(frames))
+	}
+	decoded, err := frames[0].Decode()
+	if err != nil {
+		t.Fatalf("decode publisher response: %v", err)
+	}
+	if _, ok := decoded.(*codec.BasicAck); !ok {
+		t.Fatalf("response = %T, want BasicAck", decoded)
+	}
+}
+
+func TestLocalPublishRechecksAuthorizationAfterContent(t *testing.T) {
+	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	bindLocalIdentity(conn)
+	qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: "atom-audit", Type: qtypes.QueueTypeStream}}
+	conn.broker.queueManager = qm
+	ch := newChannel(conn, 1)
+	if err := ch.handleMethod(&codec.BasicPublish{RoutingKey: "atom-audit"}); err != nil {
+		t.Fatalf("start publish: %v", err)
+	}
+	authz.allowRoutingKey = "revoked"
+	ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
+	ch.pendingBody = []byte("{}")
+	ch.completePublish()
+
+	if qm.publishCalls != 0 {
+		t.Fatalf("publish calls = %d, want 0 after ACL revocation", qm.publishCalls)
+	}
+	if got := decodeSingleChannelClose(t, buf); got.ReplyCode != codec.AccessRefused {
+		t.Fatalf("reply code = %d, want %d", got.ReplyCode, codec.AccessRefused)
+	}
+}
+
+func TestLocalCredentialRetiredBeforeRegistrationIsUnregistered(t *testing.T) {
+	authn := &localAuthenticatorStub{
+		principalID:    testLocalPrincipal,
+		credentialFP:   testCredentialFP,
+		certificateURI: testCertificateURI,
+		authenticated:  true,
+	}
+	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	conn, _ := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(authn, authz, authz, 0))
+	transport := &memoryConn{}
+	conn.conn = transport
+	conn.writer = bufio.NewWriter(transport)
+	conn.closeCh = make(chan struct{})
+	start := &codec.ConnectionStartOk{Mechanism: "PLAIN", Response: "\x00atom-audit-publisher\x00old-secret"}
+	if err := conn.authenticate(start); err != nil {
+		t.Fatalf("authenticate before reload: %v", err)
+	}
+
+	// Model a reload after authentication but before run registers the connection.
+	// The registry scan cannot see this handshake.
+	authz.retired = true
+	if got := conn.broker.DisconnectInvalidLocalSessions(func(LocalSessionIdentity) bool { return false }); got != 0 {
+		t.Fatalf("pre-registration disconnect count = %d, want 0", got)
+	}
+	if err := conn.registerAndValidate(); err == nil {
+		t.Fatal("registerAndValidate() accepted a retired credential")
+	}
+	if !conn.broker.HasConnection(conn.connID) {
+		t.Fatal("test did not exercise the register-before-revalidate ordering")
+	}
+	conn.cleanup()
+	if conn.broker.HasConnection(conn.connID) {
+		t.Fatal("retired session remained registered after connection cleanup")
+	}
+	if got := conn.broker.stats.GetCurrentConnections(); got != 0 {
+		t.Fatalf("active connections = %d, want 0", got)
+	}
+	if got := conn.broker.stats.GetLocalConnections(); got != 0 {
+		t.Fatalf("active local connections = %d, want 0", got)
+	}
+	if got := conn.broker.stats.GetLocalForcedDisconnects(); got != 1 {
+		t.Fatalf("forced disconnects = %d, want 1", got)
+	}
+	if !transport.closed {
+		t.Fatal("retired session transport was not closed")
+	}
+	if authz.lastIdentity.CredentialFingerprint != testCredentialFP || authz.lastIdentity.CertificateURI != testCertificateURI {
+		t.Fatalf("session validator did not receive the full identity: %+v", authz.lastIdentity)
+	}
+}
+
+func TestLocalPublishRejectsCredentialRetiredDuringContent(t *testing.T) {
+	authz := &localAuthorizerStub{allowRoutingKey: "atom-audit"}
+	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	bindLocalIdentity(conn)
+	qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: "atom-audit", Type: qtypes.QueueTypeStream}}
+	conn.broker.queueManager = qm
+	ch := newChannel(conn, 1)
+	if err := ch.handleMethod(&codec.BasicPublish{RoutingKey: "atom-audit"}); err != nil {
+		t.Fatalf("start publish: %v", err)
+	}
+
+	authz.retired = true
+	ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
+	ch.pendingBody = []byte("{}")
+	ch.completePublish()
+
+	if qm.publishCalls != 0 {
+		t.Fatalf("publish calls = %d, want 0 after credential retirement", qm.publishCalls)
+	}
+	if got := decodeSingleChannelClose(t, buf); got.ReplyCode != codec.AccessRefused {
+		t.Fatalf("reply code = %d, want %d", got.ReplyCode, codec.AccessRefused)
+	}
+}
+
+func TestExplicitExternalPolicyBypassesBrokerGlobalHooks(t *testing.T) {
+	conn, _ := newPolicyTestConnection(t, NewExternalConnectionPolicy(nil, nil, 0))
+	hook := &hookCounter{}
+	conn.broker.SetBlockingHooks(corebroker.NewBlockingHookEngine(hook, corebroker.HookFailDeny, nil, nil, nil))
+	var delivered int
+	conn.broker.SetCrossDeliver(func(context.Context, string, string, []byte, byte, map[string]string) {
+		delivered++
+	})
+	if err := conn.broker.router.Subscribe("mqtt-client", "atom-audit", 1, storage.SubscribeOptions{}); err != nil {
+		t.Fatalf("subscribe test route: %v", err)
+	}
+
+	ch := newChannel(conn, 1)
+	ch.pendingMethod = &codec.BasicPublish{RoutingKey: "atom-audit"}
+	ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
+	ch.pendingBody = []byte("{}")
+	ch.completePublish()
+
+	if hook.calls != 0 {
+		t.Fatalf("broker-global hook calls = %d, want 0", hook.calls)
+	}
+	if delivered != 1 {
+		t.Fatalf("delivered = %d, want 1", delivered)
+	}
+}
+
+func TestMessageSizeRejectedBeforeBodyAllocation(t *testing.T) {
+	policy := NewExternalConnectionPolicy(nil, nil, 1024)
+	conn, buf := newPolicyTestConnection(t, policy)
+	ch := newChannel(conn, 1)
+	ch.pendingMethod = &codec.BasicPublish{RoutingKey: "atom-audit"}
+	header := &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 1025}
+	var payload bytes.Buffer
+	if err := header.WriteContentHeader(&payload); err != nil {
+		t.Fatalf("write content header: %v", err)
+	}
+	ch.handleHeaderFrame(&codec.Frame{Type: codec.FrameHeader, Channel: 1, Payload: payload.Bytes()})
+	if ch.pendingBody != nil || ch.pendingMethod != nil {
+		t.Fatal("oversized message must be reset before body allocation")
+	}
+	if got := decodeSingleChannelClose(t, buf); got.ReplyCode != codec.ContentTooLarge {
+		t.Fatalf("reply code = %d, want %d", got.ReplyCode, codec.ContentTooLarge)
+	}
+}
+
+func TestFrameLimitRejectedBeforePayloadRead(t *testing.T) {
+	var wire bytes.Buffer
+	if err := codec.WriteOctet(&wire, codec.FrameBody); err != nil {
+		t.Fatalf("write frame type: %v", err)
+	}
+	if err := codec.WriteShort(&wire, 1); err != nil {
+		t.Fatalf("write channel: %v", err)
+	}
+	if err := codec.WriteLong(&wire, defaultFrameMax); err != nil {
+		t.Fatalf("write payload size: %v", err)
+	}
+	conn := &Connection{reader: bufio.NewReader(&wire), frameMax: 4096}
+	if _, err := conn.readFrame(); err == nil {
+		t.Fatal("expected oversized frame rejection")
+	}
+}
+
+func TestChannelIDCannotExceedNegotiatedMaximum(t *testing.T) {
+	conn, buf := newPolicyTestConnection(t, NewExternalConnectionPolicy(nil, nil, 0))
+	conn.channelMax = 1
+	if err := conn.handleChannelOpen(2); err != nil {
+		t.Fatalf("handle channel open: %v", err)
+	}
+	frames := readFramesFrom(t, buf, 0)
+	if len(frames) != 1 {
+		t.Fatalf("connection-close frame count = %d, want 1", len(frames))
+	}
+	decoded, err := frames[0].Decode()
+	if err != nil {
+		t.Fatalf("decode connection close: %v", err)
+	}
+	closeMethod, ok := decoded.(*codec.ConnectionClose)
+	if !ok || closeMethod.ReplyCode != codec.ChannelError {
+		t.Fatalf("expected connection ChannelError, got %T %+v", decoded, decoded)
+	}
+	if len(conn.channels) != 0 {
+		t.Fatal("out-of-range channel was registered")
+	}
+}
+
+func TestPreconfiguredStreamDetectedThroughQueueManager(t *testing.T) {
+	conn, _ := newPolicyTestConnection(t, NewExternalConnectionPolicy(nil, nil, 0))
+	conn.broker.queueManager = &mockChannelQueueManager{
+		queueCfg: &qtypes.QueueConfig{Name: "atom-audit", Type: qtypes.QueueTypeStream},
+	}
+	if !newChannel(conn, 1).isStreamQueue("atom-audit") {
+		t.Fatal("expected globally preconfigured stream to be detected")
+	}
+}
+
+func TestDisconnectInvalidLocalSessions(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b := New(nil, logger)
+	newConn := func(id string, identity *LocalSessionIdentity) (*Connection, *memoryConn) {
+		transport := &memoryConn{}
+		conn := &Connection{
+			broker:        b,
+			conn:          transport,
+			writer:        bufio.NewWriter(transport),
+			logger:        logger,
+			connID:        id,
+			localIdentity: identity,
+			closeCh:       make(chan struct{}),
+			channels:      make(map[uint16]*Channel),
+		}
+		b.connections.Store(id, conn)
+		return conn, transport
+	}
+	valid, validTransport := newConn("valid", &LocalSessionIdentity{PrincipalID: "valid", CredentialFingerprint: "new"})
+	invalid, invalidTransport := newConn("invalid", &LocalSessionIdentity{PrincipalID: "invalid", CredentialFingerprint: "old"})
+	remote, remoteTransport := newConn("remote", nil)
+
+	got := b.DisconnectInvalidLocalSessions(func(identity LocalSessionIdentity) bool {
+		return identity.CredentialFingerprint == "new"
+	})
+	if got != 1 {
+		t.Fatalf("disconnected = %d, want 1", got)
+	}
+	if count := b.stats.GetLocalForcedDisconnects(); count != 1 {
+		t.Fatalf("forced disconnects = %d, want 1", count)
+	}
+	if !invalid.closed.Load() || !invalidTransport.closed {
+		t.Fatal("invalid local session was not disconnected")
+	}
+	if valid.closed.Load() || validTransport.closed || remote.closed.Load() || remoteTransport.closed {
+		t.Fatal("valid local and external sessions must remain connected")
+	}
+}
+
+func TestRecordLocalPrincipalReload(t *testing.T) {
+	b := New(nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	b.RecordLocalPrincipalReload(true)
+	b.RecordLocalPrincipalReload(true)
+	b.RecordLocalPrincipalReload(false)
+	if got := b.stats.GetLocalReloadSuccess(); got != 2 {
+		t.Fatalf("reload successes = %d, want 2", got)
+	}
+	if got := b.stats.GetLocalReloadFailures(); got != 1 {
+		t.Fatalf("reload failures = %d, want 1", got)
+	}
+}

--- a/amqp/broker/stats.go
+++ b/amqp/broker/stats.go
@@ -26,6 +26,15 @@ type Stats struct {
 	consumers       atomic.Uint64
 
 	protocolErrors atomic.Uint64
+
+	localAuthSuccess       atomic.Uint64
+	localAuthFailures      atomic.Uint64
+	localPublishDenials    atomic.Uint64
+	localOperationDenials  atomic.Uint64
+	localConnections       atomic.Uint64
+	localReloadSuccess     atomic.Uint64
+	localReloadFailures    atomic.Uint64
+	localForcedDisconnects atomic.Uint64
 }
 
 func NewStats() *Stats {
@@ -51,6 +60,27 @@ func (s *Stats) DecrementChannels()         { s.currentChannels.Add(^uint64(0)) 
 func (s *Stats) IncrementConsumers()        { s.consumers.Add(1) }
 func (s *Stats) DecrementConsumers()        { s.consumers.Add(^uint64(0)) }
 func (s *Stats) IncrementProtocolErrors()   { s.protocolErrors.Add(1) }
+func (s *Stats) IncrementLocalAuthSuccess() { s.localAuthSuccess.Add(1) }
+func (s *Stats) IncrementLocalAuthFailures() {
+	s.localAuthFailures.Add(1)
+}
+func (s *Stats) IncrementLocalPublishDenials() {
+	s.localPublishDenials.Add(1)
+}
+func (s *Stats) IncrementLocalOperationDenials() {
+	s.localOperationDenials.Add(1)
+}
+func (s *Stats) IncrementLocalConnections() { s.localConnections.Add(1) }
+func (s *Stats) DecrementLocalConnections() { s.localConnections.Add(^uint64(0)) }
+func (s *Stats) IncrementLocalReloadSuccess() {
+	s.localReloadSuccess.Add(1)
+}
+func (s *Stats) IncrementLocalReloadFailures() {
+	s.localReloadFailures.Add(1)
+}
+func (s *Stats) AddLocalForcedDisconnects(n uint64) {
+	s.localForcedDisconnects.Add(n)
+}
 
 func (s *Stats) GetTotalConnections() uint64   { return s.totalConnections.Load() }
 func (s *Stats) GetCurrentConnections() uint64 { return s.currentConnections.Load() }
@@ -62,4 +92,22 @@ func (s *Stats) GetBytesSent() uint64          { return s.bytesSent.Load() }
 func (s *Stats) GetCurrentChannels() uint64    { return s.currentChannels.Load() }
 func (s *Stats) GetConsumers() uint64          { return s.consumers.Load() }
 func (s *Stats) GetProtocolErrors() uint64     { return s.protocolErrors.Load() }
-func (s *Stats) GetUptime() time.Duration      { return time.Since(s.startTime) }
+func (s *Stats) GetLocalAuthSuccess() uint64   { return s.localAuthSuccess.Load() }
+func (s *Stats) GetLocalAuthFailures() uint64  { return s.localAuthFailures.Load() }
+func (s *Stats) GetLocalPublishDenials() uint64 {
+	return s.localPublishDenials.Load()
+}
+func (s *Stats) GetLocalOperationDenials() uint64 {
+	return s.localOperationDenials.Load()
+}
+func (s *Stats) GetLocalConnections() uint64 { return s.localConnections.Load() }
+func (s *Stats) GetLocalReloadSuccess() uint64 {
+	return s.localReloadSuccess.Load()
+}
+func (s *Stats) GetLocalReloadFailures() uint64 {
+	return s.localReloadFailures.Load()
+}
+func (s *Stats) GetLocalForcedDisconnects() uint64 {
+	return s.localForcedDisconnects.Load()
+}
+func (s *Stats) GetUptime() time.Duration { return time.Since(s.startTime) }

--- a/amqp/broker/stats.go
+++ b/amqp/broker/stats.go
@@ -36,6 +36,7 @@ type Stats struct {
 	localReloadFailures    atomic.Uint64
 	localForcedDisconnects atomic.Uint64
 	localPublishTimeouts   atomic.Uint64
+	localPublishRejections atomic.Uint64
 }
 
 func NewStats() *Stats {
@@ -87,6 +88,10 @@ func (s *Stats) IncrementLocalPublishTimeouts() {
 	s.localPublishTimeouts.Add(1)
 }
 
+func (s *Stats) IncrementLocalPublishRejections() {
+	s.localPublishRejections.Add(1)
+}
+
 func (s *Stats) AddLocalForcedDisconnects(n uint64) {
 	s.localForcedDisconnects.Add(n)
 }
@@ -121,6 +126,10 @@ func (s *Stats) GetLocalReloadFailures() uint64 {
 
 func (s *Stats) GetLocalPublishTimeouts() uint64 {
 	return s.localPublishTimeouts.Load()
+}
+
+func (s *Stats) GetLocalPublishRejections() uint64 {
+	return s.localPublishRejections.Load()
 }
 
 func (s *Stats) GetLocalForcedDisconnects() uint64 {

--- a/amqp/broker/stats.go
+++ b/amqp/broker/stats.go
@@ -64,9 +64,11 @@ func (s *Stats) IncrementLocalAuthSuccess() { s.localAuthSuccess.Add(1) }
 func (s *Stats) IncrementLocalAuthFailures() {
 	s.localAuthFailures.Add(1)
 }
+
 func (s *Stats) IncrementLocalPublishDenials() {
 	s.localPublishDenials.Add(1)
 }
+
 func (s *Stats) IncrementLocalOperationDenials() {
 	s.localOperationDenials.Add(1)
 }
@@ -75,9 +77,11 @@ func (s *Stats) DecrementLocalConnections() { s.localConnections.Add(^uint64(0))
 func (s *Stats) IncrementLocalReloadSuccess() {
 	s.localReloadSuccess.Add(1)
 }
+
 func (s *Stats) IncrementLocalReloadFailures() {
 	s.localReloadFailures.Add(1)
 }
+
 func (s *Stats) AddLocalForcedDisconnects(n uint64) {
 	s.localForcedDisconnects.Add(n)
 }
@@ -97,6 +101,7 @@ func (s *Stats) GetLocalAuthFailures() uint64  { return s.localAuthFailures.Load
 func (s *Stats) GetLocalPublishDenials() uint64 {
 	return s.localPublishDenials.Load()
 }
+
 func (s *Stats) GetLocalOperationDenials() uint64 {
 	return s.localOperationDenials.Load()
 }
@@ -104,9 +109,11 @@ func (s *Stats) GetLocalConnections() uint64 { return s.localConnections.Load() 
 func (s *Stats) GetLocalReloadSuccess() uint64 {
 	return s.localReloadSuccess.Load()
 }
+
 func (s *Stats) GetLocalReloadFailures() uint64 {
 	return s.localReloadFailures.Load()
 }
+
 func (s *Stats) GetLocalForcedDisconnects() uint64 {
 	return s.localForcedDisconnects.Load()
 }

--- a/amqp/broker/stats.go
+++ b/amqp/broker/stats.go
@@ -35,6 +35,7 @@ type Stats struct {
 	localReloadSuccess     atomic.Uint64
 	localReloadFailures    atomic.Uint64
 	localForcedDisconnects atomic.Uint64
+	localPublishTimeouts   atomic.Uint64
 }
 
 func NewStats() *Stats {
@@ -82,6 +83,10 @@ func (s *Stats) IncrementLocalReloadFailures() {
 	s.localReloadFailures.Add(1)
 }
 
+func (s *Stats) IncrementLocalPublishTimeouts() {
+	s.localPublishTimeouts.Add(1)
+}
+
 func (s *Stats) AddLocalForcedDisconnects(n uint64) {
 	s.localForcedDisconnects.Add(n)
 }
@@ -112,6 +117,10 @@ func (s *Stats) GetLocalReloadSuccess() uint64 {
 
 func (s *Stats) GetLocalReloadFailures() uint64 {
 	return s.localReloadFailures.Load()
+}
+
+func (s *Stats) GetLocalPublishTimeouts() uint64 {
+	return s.localPublishTimeouts.Load()
 }
 
 func (s *Stats) GetLocalForcedDisconnects() uint64 {

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -664,6 +664,10 @@ components:
           type: integer
           format: uint64
           description: Publications NACKed because the durable append did not complete in time
+        publish_rejections:
+          type: integer
+          format: uint64
+          description: Publications refused because the stream already had the maximum durable appends waiting on storage
         authentication:
           $ref: "#/components/schemas/AMQPLocalAuthenticationStats"
         authorization:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -660,6 +660,10 @@ components:
           type: integer
           format: uint64
           description: Active connections authenticated as local principals
+        publish_timeouts:
+          type: integer
+          format: uint64
+          description: Publications NACKed because the durable append did not complete in time
         authentication:
           $ref: "#/components/schemas/AMQPLocalAuthenticationStats"
         authorization:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -609,6 +609,63 @@ components:
           example: 15
         errors:
           $ref: "#/components/schemas/ErrorStats"
+        local_principals:
+          $ref: "#/components/schemas/AMQPLocalPrincipalStats"
+
+    AMQPLocalAuthenticationStats:
+      type: object
+      properties:
+        success:
+          type: integer
+          format: uint64
+          description: Successful local-principal authentications
+        failure:
+          type: integer
+          format: uint64
+          description: Failed local-principal authentications
+
+    AMQPLocalAuthorizationStats:
+      type: object
+      properties:
+        publish_denied:
+          type: integer
+          format: uint64
+          description: Local-principal publications denied by the exact-match ACL
+        operation_denied:
+          type: integer
+          format: uint64
+          description: Non-publish AMQP operations denied on the internal listener
+
+    AMQPLocalReloadStats:
+      type: object
+      properties:
+        success:
+          type: integer
+          format: uint64
+          description: Successful local-principal snapshot reloads
+        failure:
+          type: integer
+          format: uint64
+          description: Failed local-principal snapshot reloads
+        forced_disconnects:
+          type: integer
+          format: uint64
+          description: Sessions disconnected after principal, credential, or ACL revocation
+
+    AMQPLocalPrincipalStats:
+      type: object
+      description: Bounded internal-listener counters without principal-derived dimensions
+      properties:
+        active_connections:
+          type: integer
+          format: uint64
+          description: Active connections authenticated as local principals
+        authentication:
+          $ref: "#/components/schemas/AMQPLocalAuthenticationStats"
+        authorization:
+          $ref: "#/components/schemas/AMQPLocalAuthorizationStats"
+        reloads:
+          $ref: "#/components/schemas/AMQPLocalReloadStats"
 
     ByProtocolStats:
       type: object

--- a/broker/localauth/store.go
+++ b/broker/localauth/store.go
@@ -13,7 +13,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -183,35 +182,20 @@ func authenticationActive(current *snapshot, authentication Authentication) bool
 	return principal.previous != nil && subtle.ConstantTimeCompare(authentication.CredentialFingerprint[:], principal.previous[:]) == 1
 }
 
+// buildSnapshot turns validated configuration into the immutable runtime
+// snapshot. The declarative rules live in config.ValidateLocalPrincipals so the
+// startup check and this reload path cannot disagree about what is acceptable;
+// only the credential material that config deliberately does not retain is
+// loaded here.
 func buildSnapshot(configs []config.LocalPrincipalConfig, generation uint64) (*snapshot, error) {
+	if err := config.ValidateLocalPrincipals(configs); err != nil {
+		return nil, err
+	}
+
 	principals := make(map[string]*principal, len(configs))
-	uriSANs := make(map[string]struct{}, len(configs))
 
 	for i, principalConfig := range configs {
 		prefix := fmt.Sprintf("auth.local_principals[%d]", i)
-		name := strings.TrimSpace(principalConfig.Name)
-		if name == "" {
-			return nil, fmt.Errorf("%s.name cannot be empty", prefix)
-		}
-		if name != principalConfig.Name {
-			return nil, fmt.Errorf("%s.name cannot have leading or trailing whitespace", prefix)
-		}
-		if _, exists := principals[name]; exists {
-			return nil, fmt.Errorf("%s.name %q is duplicated", prefix, name)
-		}
-
-		uriSAN := strings.TrimSpace(principalConfig.CertificateURISAN)
-		parsedURI, err := url.Parse(uriSAN)
-		if uriSAN == "" || err != nil || parsedURI.Scheme == "" {
-			return nil, fmt.Errorf("%s.certificate_uri_san must be an absolute URI", prefix)
-		}
-		if uriSAN != principalConfig.CertificateURISAN {
-			return nil, fmt.Errorf("%s.certificate_uri_san cannot have leading or trailing whitespace", prefix)
-		}
-		if _, exists := uriSANs[uriSAN]; exists {
-			return nil, fmt.Errorf("%s.certificate_uri_san %q is duplicated", prefix, uriSAN)
-		}
-		uriSANs[uriSAN] = struct{}{}
 
 		current, err := loadFingerprint(prefix+".current_secret_file", principalConfig.CurrentSecretFile, true)
 		if err != nil {
@@ -226,30 +210,12 @@ func buildSnapshot(configs []config.LocalPrincipalConfig, generation uint64) (*s
 		}
 
 		publish := make(map[PublishTarget]struct{}, len(principalConfig.Permissions.Publish))
-		for j, permission := range principalConfig.Permissions.Publish {
-			permissionPrefix := fmt.Sprintf("%s.permissions.publish[%d]", prefix, j)
-			if permission.Exchange != "" {
-				return nil, fmt.Errorf("%s.exchange must be empty; local principals may publish only through the AMQP default exchange", permissionPrefix)
-			}
-			if permission.RoutingKey == "" {
-				return nil, fmt.Errorf("%s.routing_key cannot be empty", permissionPrefix)
-			}
-			if containsWildcard(permission.Exchange) || containsWildcard(permission.RoutingKey) {
-				return nil, fmt.Errorf("%s must use exact exchange and routing_key values without wildcards", permissionPrefix)
-			}
-			target := PublishTarget{Exchange: permission.Exchange, RoutingKey: permission.RoutingKey}
-			if _, exists := publish[target]; exists {
-				return nil, fmt.Errorf("%s duplicates an earlier publish permission", permissionPrefix)
-			}
-			publish[target] = struct{}{}
+		for _, permission := range principalConfig.Permissions.Publish {
+			publish[PublishTarget{Exchange: permission.Exchange, RoutingKey: permission.RoutingKey}] = struct{}{}
 		}
 
-		if len(principalConfig.Permissions.Subscribe) != 0 {
-			return nil, fmt.Errorf("%s.permissions.subscribe is unsupported; local principals are publish-only", prefix)
-		}
-
-		principals[name] = &principal{
-			certificateURISAN:  uriSAN,
+		principals[principalConfig.Name] = &principal{
+			certificateURISAN:  principalConfig.CertificateURISAN,
 			current:            current,
 			previous:           previous,
 			publish:            publish,
@@ -339,10 +305,6 @@ func loadFingerprint(field, filename string, required bool) (CredentialFingerpri
 	fingerprint := CredentialFingerprint(sha256.Sum256(secret))
 	clear(secret)
 	return fingerprint, nil
-}
-
-func containsWildcard(value string) bool {
-	return strings.ContainsAny(value, "#*+")
 }
 
 func fingerprintPublishPermissions(publish map[PublishTarget]struct{}) PermissionsFingerprint {

--- a/broker/localauth/store.go
+++ b/broker/localauth/store.go
@@ -10,10 +10,12 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -33,11 +35,16 @@ func (f CredentialFingerprint) String() string {
 	return hex.EncodeToString(f[:8])
 }
 
+// PermissionsFingerprint identifies the exact publish ACL bound to a session.
+// It is comparable and contains no credential material.
+type PermissionsFingerprint [sha256.Size]byte
+
 // Authentication describes a successfully authenticated local principal.
 type Authentication struct {
-	Principal             string
-	CertificateURISAN     string
-	CredentialFingerprint CredentialFingerprint
+	Principal                     string
+	CertificateURISAN             string
+	CredentialFingerprint         CredentialFingerprint
+	PublishPermissionsFingerprint PermissionsFingerprint
 }
 
 // PublishTarget is an exact AMQP exchange and routing-key pair.
@@ -58,10 +65,11 @@ type snapshot struct {
 }
 
 type principal struct {
-	certificateURISAN string
-	current           CredentialFingerprint
-	previous          *CredentialFingerprint
-	publish           map[PublishTarget]struct{}
+	certificateURISAN  string
+	current            CredentialFingerprint
+	previous           *CredentialFingerprint
+	publish            map[PublishTarget]struct{}
+	publishPermissions PermissionsFingerprint
 }
 
 // New loads and validates a local-principal snapshot.
@@ -130,15 +138,16 @@ func (s *Store) Authenticate(username, secret, certificateURISAN string) (Authen
 	}
 
 	return Authentication{
-		Principal:             username,
-		CertificateURISAN:     certificateURISAN,
-		CredentialFingerprint: candidate,
+		Principal:                     username,
+		CertificateURISAN:             certificateURISAN,
+		CredentialFingerprint:         candidate,
+		PublishPermissionsFingerprint: principal.publishPermissions,
 	}, true
 }
 
 // IsActive reports whether an authenticated session is still valid in the
-// latest snapshot. It detects removed principals, SAN changes, and retired
-// credentials.
+// latest snapshot. It detects removed principals, SAN or publish-permission
+// changes, and retired credentials.
 func (s *Store) IsActive(authentication Authentication) bool {
 	current := s.current.Load()
 	return authenticationActive(current, authentication)
@@ -163,6 +172,9 @@ func authenticationActive(current *snapshot, authentication Authentication) bool
 	}
 	principal, ok := current.principals[authentication.Principal]
 	if !ok || principal.certificateURISAN != authentication.CertificateURISAN {
+		return false
+	}
+	if subtle.ConstantTimeCompare(authentication.PublishPermissionsFingerprint[:], principal.publishPermissions[:]) != 1 {
 		return false
 	}
 	if subtle.ConstantTimeCompare(authentication.CredentialFingerprint[:], principal.current[:]) == 1 {
@@ -237,10 +249,11 @@ func buildSnapshot(configs []config.LocalPrincipalConfig, generation uint64) (*s
 		}
 
 		principals[name] = &principal{
-			certificateURISAN: uriSAN,
-			current:           current,
-			previous:          previous,
-			publish:           publish,
+			certificateURISAN:  uriSAN,
+			current:            current,
+			previous:           previous,
+			publish:            publish,
+			publishPermissions: fingerprintPublishPermissions(publish),
 		}
 	}
 
@@ -330,4 +343,29 @@ func loadFingerprint(field, filename string, required bool) (CredentialFingerpri
 
 func containsWildcard(value string) bool {
 	return strings.ContainsAny(value, "#*+")
+}
+
+func fingerprintPublishPermissions(publish map[PublishTarget]struct{}) PermissionsFingerprint {
+	targets := make([]PublishTarget, 0, len(publish))
+	for target := range publish {
+		targets = append(targets, target)
+	}
+	sort.Slice(targets, func(i, j int) bool {
+		if targets[i].Exchange == targets[j].Exchange {
+			return targets[i].RoutingKey < targets[j].RoutingKey
+		}
+		return targets[i].Exchange < targets[j].Exchange
+	})
+
+	serialized := make([]byte, 0)
+	for _, target := range targets {
+		serialized = appendLengthPrefixed(serialized, target.Exchange)
+		serialized = appendLengthPrefixed(serialized, target.RoutingKey)
+	}
+	return PermissionsFingerprint(sha256.Sum256(serialized))
+}
+
+func appendLengthPrefixed(destination []byte, value string) []byte {
+	destination = binary.BigEndian.AppendUint64(destination, uint64(len(value)))
+	return append(destination, value...)
 }

--- a/broker/localauth/store.go
+++ b/broker/localauth/store.go
@@ -1,0 +1,333 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+// Package localauth authenticates and authorizes principals configured locally
+// in FluxMQ. It never delegates an unknown or invalid principal to an external
+// authentication service.
+package localauth
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/absmach/fluxmq/config"
+)
+
+const minimumSecretBytes = 32
+
+// CredentialFingerprint identifies the exact local secret used by a session.
+// It is comparable, so connection registries can use it to revoke sessions
+// after a credential rotation.
+type CredentialFingerprint [sha256.Size]byte
+
+// String returns a short non-secret identifier suitable for diagnostics.
+func (f CredentialFingerprint) String() string {
+	return hex.EncodeToString(f[:8])
+}
+
+// Authentication describes a successfully authenticated local principal.
+type Authentication struct {
+	Principal             string
+	CertificateURISAN     string
+	CredentialFingerprint CredentialFingerprint
+}
+
+// PublishTarget is an exact AMQP exchange and routing-key pair.
+type PublishTarget struct {
+	Exchange   string
+	RoutingKey string
+}
+
+// Store holds an atomically replaceable local-principal snapshot.
+type Store struct {
+	reloadMu sync.Mutex
+	current  atomic.Pointer[snapshot]
+}
+
+type snapshot struct {
+	generation uint64
+	principals map[string]*principal
+}
+
+type principal struct {
+	certificateURISAN string
+	current           CredentialFingerprint
+	previous          *CredentialFingerprint
+	publish           map[PublishTarget]struct{}
+}
+
+// New loads and validates a local-principal snapshot.
+func New(configs []config.LocalPrincipalConfig) (*Store, error) {
+	store := &Store{}
+	if _, err := store.Reload(configs); err != nil {
+		return nil, err
+	}
+	return store, nil
+}
+
+// Reload builds and validates a complete replacement before atomically making
+// it visible. It reports false without swapping when the loaded credentials
+// and ACLs are semantically identical. If loading fails, the current snapshot
+// remains unchanged.
+func (s *Store) Reload(configs []config.LocalPrincipalConfig) (bool, error) {
+	s.reloadMu.Lock()
+	defer s.reloadMu.Unlock()
+
+	next, err := buildSnapshot(configs, 0)
+	if err != nil {
+		return false, err
+	}
+	current := s.current.Load()
+	if current != nil && snapshotsEqual(current, next) {
+		return false, nil
+	}
+	if current == nil {
+		next.generation = 1
+	} else {
+		next.generation = current.generation + 1
+	}
+	s.current.Store(next)
+	return true, nil
+}
+
+// Generation returns the active snapshot generation. Every successful reload
+// increments it; a failed reload leaves it unchanged.
+func (s *Store) Generation() uint64 {
+	current := s.current.Load()
+	if current == nil {
+		return 0
+	}
+	return current.generation
+}
+
+// Authenticate verifies username, SASL secret, and certificate URI SAN
+// together. The secret is checked in constant time against both rotation slots.
+func (s *Store) Authenticate(username, secret, certificateURISAN string) (Authentication, bool) {
+	current := s.current.Load()
+	if current == nil {
+		return Authentication{}, false
+	}
+	principal, ok := current.principals[username]
+	if !ok || principal.certificateURISAN != certificateURISAN {
+		return Authentication{}, false
+	}
+
+	candidate := CredentialFingerprint(sha256.Sum256([]byte(secret)))
+	matched := subtle.ConstantTimeCompare(candidate[:], principal.current[:])
+	if principal.previous != nil {
+		matched |= subtle.ConstantTimeCompare(candidate[:], principal.previous[:])
+	}
+	if matched != 1 {
+		return Authentication{}, false
+	}
+
+	return Authentication{
+		Principal:             username,
+		CertificateURISAN:     certificateURISAN,
+		CredentialFingerprint: candidate,
+	}, true
+}
+
+// IsActive reports whether an authenticated session is still valid in the
+// latest snapshot. It detects removed principals, SAN changes, and retired
+// credentials.
+func (s *Store) IsActive(authentication Authentication) bool {
+	current := s.current.Load()
+	return authenticationActive(current, authentication)
+}
+
+// CanPublishAuthenticated checks the session credential and exact publish ACL
+// against one immutable snapshot. Loading both independently would leave a
+// revocation race when a reload lands between the two checks.
+func (s *Store) CanPublishAuthenticated(authentication Authentication, exchange, routingKey string) bool {
+	current := s.current.Load()
+	if !authenticationActive(current, authentication) {
+		return false
+	}
+	principal := current.principals[authentication.Principal]
+	_, allowed := principal.publish[PublishTarget{Exchange: exchange, RoutingKey: routingKey}]
+	return allowed
+}
+
+func authenticationActive(current *snapshot, authentication Authentication) bool {
+	if current == nil {
+		return false
+	}
+	principal, ok := current.principals[authentication.Principal]
+	if !ok || principal.certificateURISAN != authentication.CertificateURISAN {
+		return false
+	}
+	if subtle.ConstantTimeCompare(authentication.CredentialFingerprint[:], principal.current[:]) == 1 {
+		return true
+	}
+	return principal.previous != nil && subtle.ConstantTimeCompare(authentication.CredentialFingerprint[:], principal.previous[:]) == 1
+}
+
+func buildSnapshot(configs []config.LocalPrincipalConfig, generation uint64) (*snapshot, error) {
+	principals := make(map[string]*principal, len(configs))
+	uriSANs := make(map[string]struct{}, len(configs))
+
+	for i, principalConfig := range configs {
+		prefix := fmt.Sprintf("auth.local_principals[%d]", i)
+		name := strings.TrimSpace(principalConfig.Name)
+		if name == "" {
+			return nil, fmt.Errorf("%s.name cannot be empty", prefix)
+		}
+		if name != principalConfig.Name {
+			return nil, fmt.Errorf("%s.name cannot have leading or trailing whitespace", prefix)
+		}
+		if _, exists := principals[name]; exists {
+			return nil, fmt.Errorf("%s.name %q is duplicated", prefix, name)
+		}
+
+		uriSAN := strings.TrimSpace(principalConfig.CertificateURISAN)
+		parsedURI, err := url.Parse(uriSAN)
+		if uriSAN == "" || err != nil || parsedURI.Scheme == "" {
+			return nil, fmt.Errorf("%s.certificate_uri_san must be an absolute URI", prefix)
+		}
+		if uriSAN != principalConfig.CertificateURISAN {
+			return nil, fmt.Errorf("%s.certificate_uri_san cannot have leading or trailing whitespace", prefix)
+		}
+		if _, exists := uriSANs[uriSAN]; exists {
+			return nil, fmt.Errorf("%s.certificate_uri_san %q is duplicated", prefix, uriSAN)
+		}
+		uriSANs[uriSAN] = struct{}{}
+
+		current, err := loadFingerprint(prefix+".current_secret_file", principalConfig.CurrentSecretFile, true)
+		if err != nil {
+			return nil, err
+		}
+		previous, err := loadOptionalFingerprint(prefix+".previous_secret_file", principalConfig.PreviousSecretFile)
+		if err != nil {
+			return nil, err
+		}
+		if previous != nil && subtle.ConstantTimeCompare(current[:], previous[:]) == 1 {
+			return nil, fmt.Errorf("%s.current_secret_file and previous_secret_file must contain different secrets", prefix)
+		}
+
+		publish := make(map[PublishTarget]struct{}, len(principalConfig.Permissions.Publish))
+		for j, permission := range principalConfig.Permissions.Publish {
+			permissionPrefix := fmt.Sprintf("%s.permissions.publish[%d]", prefix, j)
+			if permission.Exchange != "" {
+				return nil, fmt.Errorf("%s.exchange must be empty; local principals may publish only through the AMQP default exchange", permissionPrefix)
+			}
+			if permission.RoutingKey == "" {
+				return nil, fmt.Errorf("%s.routing_key cannot be empty", permissionPrefix)
+			}
+			if containsWildcard(permission.Exchange) || containsWildcard(permission.RoutingKey) {
+				return nil, fmt.Errorf("%s must use exact exchange and routing_key values without wildcards", permissionPrefix)
+			}
+			target := PublishTarget{Exchange: permission.Exchange, RoutingKey: permission.RoutingKey}
+			if _, exists := publish[target]; exists {
+				return nil, fmt.Errorf("%s duplicates an earlier publish permission", permissionPrefix)
+			}
+			publish[target] = struct{}{}
+		}
+
+		if len(principalConfig.Permissions.Subscribe) != 0 {
+			return nil, fmt.Errorf("%s.permissions.subscribe is unsupported; local principals are publish-only", prefix)
+		}
+
+		principals[name] = &principal{
+			certificateURISAN: uriSAN,
+			current:           current,
+			previous:          previous,
+			publish:           publish,
+		}
+	}
+
+	return &snapshot{generation: generation, principals: principals}, nil
+}
+
+func snapshotsEqual(left, right *snapshot) bool {
+	if len(left.principals) != len(right.principals) {
+		return false
+	}
+	for name, leftPrincipal := range left.principals {
+		rightPrincipal, ok := right.principals[name]
+		if !ok || !principalsEqual(leftPrincipal, rightPrincipal) {
+			return false
+		}
+	}
+	return true
+}
+
+func principalsEqual(left, right *principal) bool {
+	if left.certificateURISAN != right.certificateURISAN || left.current != right.current {
+		return false
+	}
+	if (left.previous == nil) != (right.previous == nil) {
+		return false
+	}
+	if left.previous != nil && *left.previous != *right.previous {
+		return false
+	}
+	if len(left.publish) != len(right.publish) {
+		return false
+	}
+	for target := range left.publish {
+		if _, ok := right.publish[target]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func loadOptionalFingerprint(field, filename string) (*CredentialFingerprint, error) {
+	if filename == "" {
+		return nil, nil
+	}
+	fingerprint, err := loadFingerprint(field, filename, false)
+	if err != nil {
+		return nil, err
+	}
+	return &fingerprint, nil
+}
+
+func loadFingerprint(field, filename string, required bool) (CredentialFingerprint, error) {
+	var zero CredentialFingerprint
+	if strings.TrimSpace(filename) == "" {
+		if required || filename != "" {
+			return zero, fmt.Errorf("%s cannot be empty", field)
+		}
+		return zero, nil
+	}
+
+	secret, err := os.ReadFile(filename)
+	if err != nil {
+		return zero, fmt.Errorf("%s: failed to read secret file: %w", field, err)
+	}
+	if len(secret) > 0 && secret[len(secret)-1] == '\n' {
+		secret = secret[:len(secret)-1]
+		if len(secret) > 0 && secret[len(secret)-1] == '\r' {
+			secret = secret[:len(secret)-1]
+		}
+	}
+	if bytes.ContainsAny(secret, "\r\n") {
+		clear(secret)
+		return zero, fmt.Errorf("%s: secret file may contain only one terminal newline", field)
+	}
+	if bytes.IndexByte(secret, 0) >= 0 {
+		clear(secret)
+		return zero, fmt.Errorf("%s: secret file must not contain NUL bytes", field)
+	}
+	if len(secret) < minimumSecretBytes {
+		clear(secret)
+		return zero, fmt.Errorf("%s must contain at least %d bytes", field, minimumSecretBytes)
+	}
+	fingerprint := CredentialFingerprint(sha256.Sum256(secret))
+	clear(secret)
+	return fingerprint, nil
+}
+
+func containsWildcard(value string) bool {
+	return strings.ContainsAny(value, "#*+")
+}

--- a/broker/localauth/store_test.go
+++ b/broker/localauth/store_test.go
@@ -1,0 +1,294 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package localauth
+
+import (
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/absmach/fluxmq/config"
+)
+
+const (
+	principalName  = "atom-audit-publisher"
+	principalSAN   = "spiffe://absmach/atom/audit-publisher"
+	currentSecret  = "0123456789abcdef0123456789abcdef"
+	previousSecret = "abcdef0123456789abcdef0123456789"
+	nextSecret     = "fedcba9876543210fedcba9876543210"
+)
+
+func TestAuthenticateAndAuthorize(t *testing.T) {
+	dir := t.TempDir()
+	current := writeSecret(t, dir, "current", currentSecret+"\n")
+	previous := writeSecret(t, dir, "previous", previousSecret+"\r\n")
+	store, err := New([]config.LocalPrincipalConfig{principalConfig(current, previous)})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	authentication, ok := store.Authenticate(principalName, currentSecret, principalSAN)
+	if !ok {
+		t.Fatal("current secret was rejected")
+	}
+	if authentication.Principal != principalName || authentication.CertificateURISAN != principalSAN {
+		t.Fatalf("unexpected authentication: %+v", authentication)
+	}
+	wantFingerprint := CredentialFingerprint(sha256.Sum256([]byte(currentSecret)))
+	if authentication.CredentialFingerprint != wantFingerprint {
+		t.Fatal("credential fingerprint did not identify the current secret")
+	}
+	if got := authentication.CredentialFingerprint.String(); len(got) != 16 || strings.Contains(got, currentSecret) {
+		t.Fatalf("unsafe or malformed diagnostic fingerprint %q", got)
+	}
+
+	if _, ok := store.Authenticate(principalName, previousSecret, principalSAN); !ok {
+		t.Fatal("previous secret was rejected during rotation overlap")
+	}
+	if _, ok := store.Authenticate(principalName, "wrong-secret-that-is-at-least-32-bytes", principalSAN); ok {
+		t.Fatal("wrong secret was accepted")
+	}
+	if _, ok := store.Authenticate("unknown", currentSecret, principalSAN); ok {
+		t.Fatal("unknown principal was accepted")
+	}
+	if _, ok := store.Authenticate(principalName, currentSecret, "spiffe://absmach/atom/other"); ok {
+		t.Fatal("wrong certificate URI SAN was accepted")
+	}
+
+	if !store.CanPublishAuthenticated(authentication, "", "atom-audit") {
+		t.Fatal("configured publish target was denied")
+	}
+	if store.CanPublishAuthenticated(authentication, "events", "atom-audit") {
+		t.Fatal("wrong exchange was allowed")
+	}
+	if store.CanPublishAuthenticated(authentication, "", "atom-audit.other") {
+		t.Fatal("prefix routing key was allowed")
+	}
+}
+
+func TestReloadIsAtomicAndRevokesRemovedCredentials(t *testing.T) {
+	dir := t.TempDir()
+	current := writeSecret(t, dir, "current", currentSecret)
+	previous := writeSecret(t, dir, "previous", previousSecret)
+	next := writeSecret(t, dir, "next", nextSecret)
+	store, err := New([]config.LocalPrincipalConfig{principalConfig(current, "")})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	oldAuthentication, ok := store.Authenticate(principalName, currentSecret, principalSAN)
+	if !ok {
+		t.Fatal("initial authentication failed")
+	}
+	if store.Generation() != 1 {
+		t.Fatalf("initial generation = %d, want 1", store.Generation())
+	}
+	sameSecretDifferentFile := writeSecret(t, dir, "current-copy", currentSecret+"\n")
+	changed, err := store.Reload([]config.LocalPrincipalConfig{principalConfig(sameSecretDifferentFile, "")})
+	if err != nil {
+		t.Fatalf("no-op Reload() error = %v", err)
+	}
+	if changed {
+		t.Fatal("semantically identical credentials were reported as changed")
+	}
+	if store.Generation() != 1 {
+		t.Fatalf("no-op reload changed generation to %d", store.Generation())
+	}
+
+	overlap := principalConfig(next, current)
+	changed, err = store.Reload([]config.LocalPrincipalConfig{overlap})
+	if err != nil {
+		t.Fatalf("overlap Reload() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("credential rotation was reported as unchanged")
+	}
+	if store.Generation() != 2 {
+		t.Fatalf("overlap generation = %d, want 2", store.Generation())
+	}
+	if !store.IsActive(oldAuthentication) {
+		t.Fatal("previous credential was revoked during overlap")
+	}
+	newAuthentication, ok := store.Authenticate(principalName, nextSecret, principalSAN)
+	if !ok {
+		t.Fatal("rotated current secret was rejected")
+	}
+
+	invalid := principalConfig(filepath.Join(dir, "missing"), previous)
+	if _, err := store.Reload([]config.LocalPrincipalConfig{invalid}); err == nil {
+		t.Fatal("invalid reload succeeded")
+	}
+	if store.Generation() != 2 {
+		t.Fatalf("failed reload changed generation to %d", store.Generation())
+	}
+	if !store.IsActive(oldAuthentication) || !store.IsActive(newAuthentication) {
+		t.Fatal("failed reload changed the active snapshot")
+	}
+
+	if _, err := store.Reload([]config.LocalPrincipalConfig{principalConfig(next, "")}); err != nil {
+		t.Fatalf("final Reload() error = %v", err)
+	}
+	if store.IsActive(oldAuthentication) {
+		t.Fatal("removed previous credential remains active")
+	}
+	if store.CanPublishAuthenticated(oldAuthentication, "", "atom-audit") {
+		t.Fatal("session authenticated before reload can still publish with a retired credential")
+	}
+	if !store.IsActive(newAuthentication) {
+		t.Fatal("current credential was unexpectedly revoked")
+	}
+
+	if _, err := store.Reload(nil); err != nil {
+		t.Fatalf("principal-removal Reload() error = %v", err)
+	}
+	if store.IsActive(newAuthentication) {
+		t.Fatal("removed principal remains active")
+	}
+}
+
+func TestStoreRejectsInvalidConfiguration(t *testing.T) {
+	dir := t.TempDir()
+	current := writeSecret(t, dir, "current", currentSecret)
+	weak := writeSecret(t, dir, "weak", strings.Repeat("x", 31))
+	nul := writeSecret(t, dir, "nul", strings.Repeat("x", 16)+"\x00"+strings.Repeat("x", 16))
+
+	tests := []struct {
+		name      string
+		configs   func() []config.LocalPrincipalConfig
+		wantError string
+	}{
+		{
+			name: "duplicate principal",
+			configs: func() []config.LocalPrincipalConfig {
+				first, second := principalConfig(current, ""), principalConfig(current, "")
+				second.CertificateURISAN = "spiffe://absmach/atom/other"
+				return []config.LocalPrincipalConfig{first, second}
+			},
+			wantError: "name \"atom-audit-publisher\" is duplicated",
+		},
+		{
+			name: "duplicate URI SAN",
+			configs: func() []config.LocalPrincipalConfig {
+				first, second := principalConfig(current, ""), principalConfig(current, "")
+				second.Name = "other"
+				return []config.LocalPrincipalConfig{first, second}
+			},
+			wantError: "certificate_uri_san \"spiffe://absmach/atom/audit-publisher\" is duplicated",
+		},
+		{
+			name: "weak secret",
+			configs: func() []config.LocalPrincipalConfig {
+				return []config.LocalPrincipalConfig{principalConfig(weak, "")}
+			},
+			wantError: "must contain at least 32 bytes",
+		},
+		{
+			name: "NUL byte in secret",
+			configs: func() []config.LocalPrincipalConfig {
+				return []config.LocalPrincipalConfig{principalConfig(nul, "")}
+			},
+			wantError: "secret file must not contain NUL bytes",
+		},
+		{
+			name: "same current and previous secret",
+			configs: func() []config.LocalPrincipalConfig {
+				return []config.LocalPrincipalConfig{principalConfig(current, current)}
+			},
+			wantError: "must contain different secrets",
+		},
+		{
+			name: "wildcard publish ACL",
+			configs: func() []config.LocalPrincipalConfig {
+				principal := principalConfig(current, "")
+				principal.Permissions.Publish[0].RoutingKey = "atom.#"
+				return []config.LocalPrincipalConfig{principal}
+			},
+			wantError: "without wildcards",
+		},
+		{
+			name: "non-default publish exchange",
+			configs: func() []config.LocalPrincipalConfig {
+				principal := principalConfig(current, "")
+				principal.Permissions.Publish[0].Exchange = "events"
+				return []config.LocalPrincipalConfig{principal}
+			},
+			wantError: "exchange must be empty; local principals may publish only through the AMQP default exchange",
+		},
+		{
+			name: "subscribe ACL is unsupported",
+			configs: func() []config.LocalPrincipalConfig {
+				principal := principalConfig(current, "")
+				principal.Permissions.Subscribe = []string{"atom-audit"}
+				return []config.LocalPrincipalConfig{principal}
+			},
+			wantError: "subscribe is unsupported; local principals are publish-only",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New(tt.configs())
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("New() error = %v, want it to contain %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestConcurrentAuthenticationAndReload(t *testing.T) {
+	dir := t.TempDir()
+	current := writeSecret(t, dir, "current", currentSecret)
+	next := writeSecret(t, dir, "next", nextSecret)
+	store, err := New([]config.LocalPrincipalConfig{principalConfig(current, next)})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	var workers sync.WaitGroup
+	for range 8 {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for range 500 {
+				authentication, ok := store.Authenticate(principalName, currentSecret, principalSAN)
+				if ok {
+					_ = store.CanPublishAuthenticated(authentication, "", "atom-audit")
+				}
+			}
+		}()
+	}
+	for i := range 100 {
+		principal := principalConfig(current, next)
+		if i%2 == 1 {
+			principal = principalConfig(next, current)
+		}
+		if _, err := store.Reload([]config.LocalPrincipalConfig{principal}); err != nil {
+			t.Fatalf("Reload() error = %v", err)
+		}
+	}
+	workers.Wait()
+}
+
+func principalConfig(current, previous string) config.LocalPrincipalConfig {
+	return config.LocalPrincipalConfig{
+		Name:               principalName,
+		CertificateURISAN:  principalSAN,
+		CurrentSecretFile:  current,
+		PreviousSecretFile: previous,
+		Permissions: config.LocalPermissionsConfig{
+			Publish: []config.LocalPublishPermission{{Exchange: "", RoutingKey: "atom-audit"}},
+		},
+	}
+}
+
+func writeSecret(t *testing.T, dir, name, contents string) string {
+	t.Helper()
+	filename := filepath.Join(dir, name)
+	if err := os.WriteFile(filename, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	return filename
+}

--- a/broker/localauth/store_test.go
+++ b/broker/localauth/store_test.go
@@ -149,6 +149,43 @@ func TestReloadIsAtomicAndRevokesRemovedCredentials(t *testing.T) {
 	}
 }
 
+func TestReloadRevokesChangedPublishPermissions(t *testing.T) {
+	dir := t.TempDir()
+	current := writeSecret(t, dir, "current", currentSecret)
+	principal := principalConfig(current, "")
+	store, err := New([]config.LocalPrincipalConfig{principal})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	authentication, ok := store.Authenticate(principalName, currentSecret, principalSAN)
+	if !ok {
+		t.Fatal("initial authentication failed")
+	}
+
+	principal.Permissions.Publish[0].RoutingKey = "atom-audit-v2"
+	changed, err := store.Reload([]config.LocalPrincipalConfig{principal})
+	if err != nil {
+		t.Fatalf("Reload() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("publish ACL replacement was reported as unchanged")
+	}
+	if store.IsActive(authentication) {
+		t.Fatal("session authenticated against the replaced publish ACL remains active")
+	}
+	if store.CanPublishAuthenticated(authentication, "", "atom-audit-v2") {
+		t.Fatal("session authenticated against the old ACL used the replacement ACL")
+	}
+
+	reauthenticated, ok := store.Authenticate(principalName, currentSecret, principalSAN)
+	if !ok {
+		t.Fatal("authentication against the replacement ACL failed")
+	}
+	if !store.IsActive(reauthenticated) || !store.CanPublishAuthenticated(reauthenticated, "", "atom-audit-v2") {
+		t.Fatal("session authenticated against the replacement ACL is not active")
+	}
+}
+
 func TestStoreRejectsInvalidConfiguration(t *testing.T) {
 	dir := t.TempDir()
 	current := writeSecret(t, dir, "current", currentSecret)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,10 +6,13 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"encoding/hex"
 	"flag"
+	"fmt"
 	"log/slog"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -20,6 +23,7 @@ import (
 	corebroker "github.com/absmach/fluxmq/broker"
 	"github.com/absmach/fluxmq/broker/authcallout"
 	"github.com/absmach/fluxmq/broker/hook"
+	"github.com/absmach/fluxmq/broker/localauth"
 	"github.com/absmach/fluxmq/broker/router"
 	"github.com/absmach/fluxmq/broker/webhook"
 	"github.com/absmach/fluxmq/cluster"
@@ -31,6 +35,7 @@ import (
 	mqtttls "github.com/absmach/fluxmq/pkg/tls"
 	"github.com/absmach/fluxmq/queue"
 	qraft "github.com/absmach/fluxmq/queue/raft"
+	queueStorage "github.com/absmach/fluxmq/queue/storage"
 	queueTypes "github.com/absmach/fluxmq/queue/types"
 	"github.com/absmach/fluxmq/ratelimit"
 	"github.com/absmach/fluxmq/reload"
@@ -73,6 +78,182 @@ type brokerDeliveryTarget struct {
 	mqtt    *broker.Broker
 	amqp    *amqp1broker.Broker
 	amqp091 *amqpbroker.Broker
+}
+
+type localAMQPPolicy struct {
+	store *localauth.Store
+}
+
+func (p *localAMQPPolicy) AuthenticateLocal(_ context.Context, _ string, username, secret string, peer amqpbroker.VerifiedPeerIdentity) (string, string, string, bool, error) {
+	if p == nil || p.store == nil {
+		return "", "", "", false, nil
+	}
+	for _, uriSAN := range peer.URISANs {
+		authentication, ok := p.store.Authenticate(username, secret, uriSAN)
+		if !ok {
+			continue
+		}
+		return authentication.Principal,
+			hex.EncodeToString(authentication.CredentialFingerprint[:]),
+			authentication.CertificateURISAN,
+			true,
+			nil
+	}
+	return "", "", "", false, nil
+}
+
+func (p *localAMQPPolicy) CanPublishLocal(identity amqpbroker.LocalSessionIdentity, exchange, routingKey string) bool {
+	authentication, ok := localAuthentication(identity)
+	return ok && p != nil && p.store != nil && p.store.CanPublishAuthenticated(authentication, exchange, routingKey)
+}
+
+func (p *localAMQPPolicy) IsSessionActive(identity amqpbroker.LocalSessionIdentity) bool {
+	if p == nil || p.store == nil {
+		return false
+	}
+	authentication, ok := localAuthentication(identity)
+	return ok && p.store.IsActive(authentication)
+}
+
+func localAuthentication(identity amqpbroker.LocalSessionIdentity) (localauth.Authentication, bool) {
+	rawFingerprint, err := hex.DecodeString(identity.CredentialFingerprint)
+	if err != nil || len(rawFingerprint) != len(localauth.CredentialFingerprint{}) {
+		return localauth.Authentication{}, false
+	}
+	var fingerprint localauth.CredentialFingerprint
+	copy(fingerprint[:], rawFingerprint)
+	return localauth.Authentication{
+		Principal:             identity.PrincipalID,
+		CertificateURISAN:     identity.CertificateURI,
+		CredentialFingerprint: fingerprint,
+	}, true
+}
+
+func reloadLocalPrincipals(
+	ctx context.Context,
+	store *localauth.Store,
+	principals []config.LocalPrincipalConfig,
+	configuredQueues []queueTypes.QueueConfig,
+	queueManager *queue.Manager,
+) (bool, error) {
+	if store == nil {
+		return false, fmt.Errorf("local principal store is not configured")
+	}
+	if queueManager == nil {
+		return false, fmt.Errorf("local principal queue manager is not configured")
+	}
+	contracts, err := localPrincipalPublishTargetContracts(principals, configuredQueues)
+	if err != nil {
+		return false, err
+	}
+	if err := validateLocalPrincipalPublishTargets(ctx, principals, configuredQueues, queueManager.QueueStore()); err != nil {
+		return false, err
+	}
+
+	previousContracts := queueManager.ProtectedQueueContracts()
+	unionContracts := mergeQueueContracts(previousContracts, contracts)
+	if err := queueManager.ReplaceProtectedQueueContracts(ctx, unionContracts); err != nil {
+		return false, err
+	}
+	changed, err := store.Reload(principals)
+	if err != nil {
+		if restoreErr := queueManager.ReplaceProtectedQueueContracts(ctx, previousContracts); restoreErr != nil {
+			return false, fmt.Errorf("reload local principals: %v; restore protected queue contracts: %w", err, restoreErr)
+		}
+		return false, err
+	}
+	if err := queueManager.NarrowProtectedQueueContracts(contracts); err != nil {
+		return false, fmt.Errorf("finalize protected queue contracts after local-principal reload: %w", err)
+	}
+	return changed, nil
+}
+
+func mergeQueueContracts(first, second []queueTypes.QueueConfig) []queueTypes.QueueConfig {
+	byName := make(map[string]queueTypes.QueueConfig, len(first)+len(second))
+	for _, contract := range first {
+		byName[contract.Name] = contract
+	}
+	for _, contract := range second {
+		byName[contract.Name] = contract
+	}
+	names := make([]string, 0, len(byName))
+	for name := range byName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	contracts := make([]queueTypes.QueueConfig, 0, len(names))
+	for _, name := range names {
+		contracts = append(contracts, byName[name])
+	}
+	return contracts
+}
+
+// validateLocalPrincipalPublishTargets verifies the persisted queue topology
+// after the queue manager has created its reserved queues. Local publishers do
+// not have topology permissions, so FluxMQ must fail startup instead of serving
+// a stale or unsafe target definition.
+func validateLocalPrincipalPublishTargets(
+	ctx context.Context,
+	principals []config.LocalPrincipalConfig,
+	configuredQueues []queueTypes.QueueConfig,
+	queueStore queueStorage.QueueStore,
+) error {
+	contracts, err := localPrincipalPublishTargetContracts(principals, configuredQueues)
+	if err != nil {
+		return err
+	}
+	if len(contracts) == 0 {
+		return nil
+	}
+	if queueStore == nil {
+		return fmt.Errorf("local principal publish targets require a queue store")
+	}
+	if _, ok := queueStore.(queueStorage.DurableQueueStore); !ok {
+		return fmt.Errorf("local principal publish targets require a queue store with durable sync support")
+	}
+
+	for _, expected := range contracts {
+		persisted, err := queueStore.GetQueue(ctx, expected.Name)
+		if err != nil {
+			return fmt.Errorf("load persisted local principal publish target %q: %w", expected.Name, err)
+		}
+		if persisted == nil {
+			return fmt.Errorf("load persisted local principal publish target %q: queue not found", expected.Name)
+		}
+		if err := queue.ValidateProtectedQueueContract(expected, *persisted); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func localPrincipalPublishTargetContracts(principals []config.LocalPrincipalConfig, configuredQueues []queueTypes.QueueConfig) ([]queueTypes.QueueConfig, error) {
+	targets := make(map[string]struct{})
+	for _, principal := range principals {
+		for _, permission := range principal.Permissions.Publish {
+			targets[permission.RoutingKey] = struct{}{}
+		}
+	}
+
+	configuredByName := make(map[string]queueTypes.QueueConfig, len(configuredQueues))
+	for _, queueConfig := range configuredQueues {
+		configuredByName[queueConfig.Name] = queueConfig
+	}
+	targetNames := make([]string, 0, len(targets))
+	for target := range targets {
+		targetNames = append(targetNames, target)
+	}
+	sort.Strings(targetNames)
+
+	contracts := make([]queueTypes.QueueConfig, 0, len(targetNames))
+	for _, target := range targetNames {
+		contract, ok := configuredByName[target]
+		if !ok {
+			return nil, fmt.Errorf("local principal publish target %q has no matching queues entry", target)
+		}
+		contracts = append(contracts, contract)
+	}
+	return contracts, nil
 }
 
 func (t *brokerDeliveryTarget) Deliver(ctx context.Context, clientID string, msg *storage.Message) error {
@@ -129,6 +310,13 @@ func main() {
 	logger := slog.New(handler).With("local_node_id", nodeID)
 	slog.SetDefault(logger)
 
+	localPrincipalStore, err := localauth.New(cfg.Auth.LocalPrincipals)
+	if err != nil {
+		slog.Error("Failed to initialize local principals", "error", err)
+		os.Exit(1)
+	}
+	localPolicyAdapter := &localAMQPPolicy{store: localPrincipalStore}
+
 	slog.Info("Starting MQTT broker", "version", "0.1.0")
 	slog.Info("Configuration loaded",
 		"tcp_v3_listener", cfg.Server.TCP.V3.Addr,
@@ -151,6 +339,7 @@ func main() {
 		"amqp091_plain_listener", cfg.Server.AMQP091.Plain.Addr,
 		"amqp091_tls_listener", cfg.Server.AMQP091.TLS.Addr,
 		"amqp091_mtls_listener", cfg.Server.AMQP091.MTLS.Addr,
+		"amqp091_internal_listener", cfg.Server.AMQP091.Internal.Addr,
 		"admin_api_addr", cfg.Server.AdminAPIAddr,
 		"health_enabled", cfg.Server.HealthEnabled,
 		"cluster_enabled", cfg.Cluster.Enabled,
@@ -340,17 +529,21 @@ func main() {
 	// Create AMQP 0.9.1 broker (needs queue manager set later)
 	amqp091Broker := amqpbroker.New(nil, logger)
 	defer amqp091Broker.Close()
+	var (
+		amqp091ExternalAuth  *corebroker.AuthEngine
+		amqp091ExternalHooks *corebroker.BlockingHookEngine
+	)
 
 	// Configure auth callout
-	if cfg.Auth.URL != "" {
-		transport := cfg.Auth.Transport
+	if cfg.Auth.External.URL != "" {
+		transport := cfg.Auth.External.Transport
 		if transport == "" {
 			transport = "grpc"
 		}
 
 		cb := authcallout.DefaultCircuitBreaker(logger)
 		sharedOpts := []authcallout.Option{
-			authcallout.WithTimeout(cfg.Auth.Timeout),
+			authcallout.WithTimeout(cfg.Auth.External.Timeout),
 			authcallout.WithLogger(logger),
 			authcallout.WithCircuitBreaker(cb),
 		}
@@ -359,19 +552,19 @@ func main() {
 			opts := append(sharedOpts, authcallout.WithProtocol(proto))
 			switch transport {
 			case "http":
-				c := authcallout.NewHTTPClient(nil, cfg.Auth.URL, opts...)
+				c := authcallout.NewHTTPClient(nil, cfg.Auth.External.URL, opts...)
 				return c, c
 			default:
-				c := authcallout.NewGRPCClient(nil, cfg.Auth.URL, opts...)
+				c := authcallout.NewGRPCClient(nil, cfg.Auth.External.URL, opts...)
 				return c, c
 			}
 		}
 
-		cacheSize := cfg.Auth.IdentityCacheSize
+		cacheSize := cfg.Auth.External.IdentityCacheSize
 		if cacheSize == 0 {
 			cacheSize = corebroker.DefaultIdentityCacheSize
 		}
-		cacheTTL := cfg.Auth.IdentityCacheTTL
+		cacheTTL := cfg.Auth.External.IdentityCacheTTL
 		if cacheTTL == 0 {
 			cacheTTL = corebroker.DefaultIdentityCacheTTL
 		}
@@ -379,29 +572,30 @@ func main() {
 			corebroker.WithIdentityCache(cacheSize, cacheTTL),
 		}
 
-		if cfg.Auth.AuthEnabledFor("mqtt") {
+		if cfg.Auth.External.EnabledFor("mqtt") {
 			mqttAuthn, mqttAuthz := newClient(authcallout.ProtocolMQTT)
 			b.SetAuthEngine(corebroker.NewAuthEngine(mqttAuthn, mqttAuthz, engineOpts...))
 			slog.Info("Auth callout enabled for mqtt")
 		}
 
-		if cfg.Auth.AuthEnabledFor("amqp") {
+		if cfg.Auth.External.EnabledFor("amqp") {
 			amqpAuthn, amqpAuthz := newClient(authcallout.ProtocolAMQP10)
 			amqpBroker.SetAuthEngine(corebroker.NewAuthEngine(amqpAuthn, amqpAuthz, engineOpts...))
 			slog.Info("Auth callout enabled for amqp")
 		}
 
-		if cfg.Auth.AuthEnabledFor("amqp091") {
+		if cfg.Auth.External.EnabledFor("amqp091") {
 			amqp091Authn, amqp091Authz := newClient(authcallout.ProtocolAMQP091)
-			amqp091Broker.SetAuthEngine(corebroker.NewAuthEngine(amqp091Authn, amqp091Authz, engineOpts...))
+			amqp091ExternalAuth = corebroker.NewAuthEngine(amqp091Authn, amqp091Authz, engineOpts...)
+			amqp091Broker.SetAuthEngine(amqp091ExternalAuth)
 			slog.Info("Auth callout enabled for amqp091")
 		}
 
 		slog.Info("Auth callout configured",
-			"url", cfg.Auth.URL,
+			"url", cfg.Auth.External.URL,
 			"transport", transport,
-			"timeout", cfg.Auth.Timeout,
-			"protocols", cfg.Auth.Protocols)
+			"timeout", cfg.Auth.External.Timeout,
+			"protocols", cfg.Auth.External.Protocols)
 	} else {
 		slog.Info("Auth callout disabled")
 	}
@@ -431,7 +625,8 @@ func main() {
 
 		b.SetBlockingHooks(newEngine())
 		amqpBroker.SetBlockingHooks(newEngine())
-		amqp091Broker.SetBlockingHooks(newEngine())
+		amqp091ExternalHooks = newEngine()
+		amqp091Broker.SetBlockingHooks(amqp091ExternalHooks)
 		slog.Info("Blocking hooks configured",
 			"url", cfg.Hooks.URL,
 			"transport", transport,
@@ -450,8 +645,9 @@ func main() {
 	amqpBroker.SetRouter(sharedRouter)
 
 	var (
-		qm            *queue.Manager
-		queueLogStore *logStorage.Adapter
+		qm                       *queue.Manager
+		queueLogStore            *logStorage.Adapter
+		configuredQueueContracts []queueTypes.QueueConfig
 	)
 
 	if metrics != nil {
@@ -566,6 +762,16 @@ func main() {
 				Replication: replication,
 			}))
 		}
+		configuredQueueContracts = append(configuredQueueContracts, queueCfg.QueueConfigs...)
+		protectedQueueContracts, err := localPrincipalPublishTargetContracts(
+			cfg.Auth.LocalPrincipals,
+			configuredQueueContracts,
+		)
+		if err != nil {
+			slog.Error("Invalid local principal publish target", "error", err)
+			os.Exit(1)
+		}
+		queueCfg.ProtectedQueueContracts = protectedQueueContracts
 
 		// Notify AMQP 0.9.1 clients when their consumers are removed by stale cleanup
 		queueCfg.OnConsumerRemoved = func(queueName, groupID string, consumerIDs []string) {
@@ -622,6 +828,15 @@ func main() {
 
 		if err := b.SetQueueManager(qm); err != nil {
 			slog.Error("Failed to set queue manager", "error", err)
+			os.Exit(1)
+		}
+		if err := validateLocalPrincipalPublishTargets(
+			context.Background(),
+			cfg.Auth.LocalPrincipals,
+			configuredQueueContracts,
+			qm.QueueStore(),
+		); err != nil {
+			slog.Error("Invalid local principal publish target", "error", err)
 			os.Exit(1)
 		}
 
@@ -896,16 +1111,36 @@ func main() {
 		}(slot.name, slot.cfg.Addr, amqpSrv)
 	}
 
-	// AMQP 0.9.1 servers
+	// AMQP 0.9.1 servers. The public listeners receive only the external
+	// callout policy; the internal listener receives only the local-principal
+	// policy. There is deliberately no fallback between these policies.
+	maxAMQP091MessageSize := uint64(0)
+	if cfg.Broker.MaxMessageSize > 0 {
+		maxAMQP091MessageSize = uint64(cfg.Broker.MaxMessageSize)
+	}
+	externalAMQP091Policy := amqpbroker.NewExternalConnectionPolicy(
+		amqp091ExternalAuth,
+		amqp091ExternalHooks,
+		maxAMQP091MessageSize,
+	)
+	internalAMQP091Policy := amqpbroker.NewLocalPublishOnlyConnectionPolicy(
+		localPolicyAdapter,
+		localPolicyAdapter,
+		localPolicyAdapter,
+		maxAMQP091MessageSize,
+	)
 	amqp091Slots := []struct {
-		name string
-		cfg  config.AMQP091ListenerConfig
+		name   string
+		cfg    config.AMQP091ListenerConfig
+		policy *amqpbroker.ConnectionPolicy
 	}{
-		{name: listenerPlain, cfg: cfg.Server.AMQP091.Plain},
-		{name: listenerTLS, cfg: cfg.Server.AMQP091.TLS},
-		{name: listenerMTLS, cfg: cfg.Server.AMQP091.MTLS},
+		{name: listenerPlain, cfg: cfg.Server.AMQP091.Plain, policy: externalAMQP091Policy},
+		{name: listenerTLS, cfg: cfg.Server.AMQP091.TLS, policy: externalAMQP091Policy},
+		{name: listenerMTLS, cfg: cfg.Server.AMQP091.MTLS, policy: externalAMQP091Policy},
+		{name: "internal", cfg: cfg.Server.AMQP091.Internal, policy: internalAMQP091Policy},
 	}
 
+	var amqp091Ready []<-chan struct{}
 	for _, slot := range amqp091Slots {
 		if strings.TrimSpace(slot.cfg.Addr) == "" {
 			continue
@@ -918,13 +1153,16 @@ func main() {
 		}
 
 		amqp091Cfg := amqpserver.Config{
-			Address:         slot.cfg.Addr,
-			TLSConfig:       tlsCfg,
-			ShutdownTimeout: cfg.Server.ShutdownTimeout,
-			MaxConnections:  slot.cfg.MaxConnections,
-			Logger:          logger,
+			Address:          slot.cfg.Addr,
+			TLSConfig:        tlsCfg,
+			HandshakeTimeout: 10 * time.Second,
+			ShutdownTimeout:  cfg.Server.ShutdownTimeout,
+			MaxConnections:   slot.cfg.MaxConnections,
+			ConnectionPolicy: slot.policy,
+			Logger:           logger,
 		}
 		amqp091Srv := amqpserver.New(amqp091Cfg, amqp091Broker)
+		amqp091Ready = append(amqp091Ready, amqp091Srv.Ready())
 
 		wg.Add(1)
 		go func(name, addr string, server *amqpserver.Server) {
@@ -934,6 +1172,18 @@ func main() {
 				serverErr <- err
 			}
 		}(slot.name, slot.cfg.Addr, amqp091Srv)
+	}
+
+	for _, ready := range amqp091Ready {
+		select {
+		case <-ready:
+		case err := <-serverErr:
+			slog.Error("AMQP 0.9.1 listener failed during startup", "error", err)
+			os.Exit(1)
+		case <-time.After(10 * time.Second):
+			slog.Error("Timed out waiting for AMQP 0.9.1 listener readiness")
+			os.Exit(1)
+		}
 	}
 
 	if cfg.Server.HealthEnabled {
@@ -960,6 +1210,32 @@ func main() {
 		reload.WithBroker(b),
 		reload.WithSessionTuner(b),
 		reload.WithWebhookTuner(webhookNotifier),
+		reload.WithLocalPrincipalsReloadFailure(func(error) {
+			amqp091Broker.RecordLocalPrincipalReload(false)
+		}),
+		reload.WithLocalPrincipalsReload(func(principals []config.LocalPrincipalConfig) (bool, error) {
+			changed, err := reloadLocalPrincipals(
+				context.Background(),
+				localPrincipalStore,
+				principals,
+				configuredQueueContracts,
+				qm,
+			)
+			if err != nil {
+				amqp091Broker.RecordLocalPrincipalReload(false)
+				return false, err
+			}
+			amqp091Broker.RecordLocalPrincipalReload(true)
+			if !changed {
+				return false, nil
+			}
+			disconnected := amqp091Broker.DisconnectInvalidLocalSessions(localPolicyAdapter.IsSessionActive)
+			slog.Info("Local principals reloaded",
+				"outcome", "success",
+				"generation", localPrincipalStore.Generation(),
+				"disconnected_sessions", disconnected)
+			return true, nil
+		}),
 	)
 
 	// Start Admin API server (HTTP + Connect/gRPC queue service)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -84,9 +84,9 @@ type localAMQPPolicy struct {
 	store *localauth.Store
 }
 
-func (p *localAMQPPolicy) AuthenticateLocal(_ context.Context, _ string, username, secret string, peer amqpbroker.VerifiedPeerIdentity) (string, string, string, bool, error) {
+func (p *localAMQPPolicy) AuthenticateLocal(_ context.Context, _ string, username, secret string, peer amqpbroker.VerifiedPeerIdentity) (string, string, string, string, bool, error) {
 	if p == nil || p.store == nil {
-		return "", "", "", false, nil
+		return "", "", "", "", false, nil
 	}
 	for _, uriSAN := range peer.URISANs {
 		authentication, ok := p.store.Authenticate(username, secret, uriSAN)
@@ -95,11 +95,12 @@ func (p *localAMQPPolicy) AuthenticateLocal(_ context.Context, _ string, usernam
 		}
 		return authentication.Principal,
 			hex.EncodeToString(authentication.CredentialFingerprint[:]),
+			hex.EncodeToString(authentication.PublishPermissionsFingerprint[:]),
 			authentication.CertificateURISAN,
 			true,
 			nil
 	}
-	return "", "", "", false, nil
+	return "", "", "", "", false, nil
 }
 
 func (p *localAMQPPolicy) CanPublishLocal(identity amqpbroker.LocalSessionIdentity, exchange, routingKey string) bool {
@@ -116,16 +117,23 @@ func (p *localAMQPPolicy) IsSessionActive(identity amqpbroker.LocalSessionIdenti
 }
 
 func localAuthentication(identity amqpbroker.LocalSessionIdentity) (localauth.Authentication, bool) {
-	rawFingerprint, err := hex.DecodeString(identity.CredentialFingerprint)
-	if err != nil || len(rawFingerprint) != len(localauth.CredentialFingerprint{}) {
+	rawCredentialFingerprint, err := hex.DecodeString(identity.CredentialFingerprint)
+	if err != nil || len(rawCredentialFingerprint) != len(localauth.CredentialFingerprint{}) {
 		return localauth.Authentication{}, false
 	}
-	var fingerprint localauth.CredentialFingerprint
-	copy(fingerprint[:], rawFingerprint)
+	rawPermissionsFingerprint, err := hex.DecodeString(identity.PermissionsFingerprint)
+	if err != nil || len(rawPermissionsFingerprint) != len(localauth.PermissionsFingerprint{}) {
+		return localauth.Authentication{}, false
+	}
+	var credentialFingerprint localauth.CredentialFingerprint
+	copy(credentialFingerprint[:], rawCredentialFingerprint)
+	var permissionsFingerprint localauth.PermissionsFingerprint
+	copy(permissionsFingerprint[:], rawPermissionsFingerprint)
 	return localauth.Authentication{
-		Principal:             identity.PrincipalID,
-		CertificateURISAN:     identity.CertificateURI,
-		CredentialFingerprint: fingerprint,
+		Principal:                     identity.PrincipalID,
+		CertificateURISAN:             identity.CertificateURI,
+		CredentialFingerprint:         credentialFingerprint,
+		PublishPermissionsFingerprint: permissionsFingerprint,
 	}, true
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -216,7 +216,8 @@ func validateLocalPrincipalPublishTargets(
 	if queueStore == nil {
 		return fmt.Errorf("local principal publish targets require a queue store")
 	}
-	if _, ok := queueStore.(queueStorage.DurableQueueStore); !ok {
+	durableStore, ok := queueStore.(queueStorage.DurableQueueStore)
+	if !ok || !durableStore.SupportsDurableSync() {
 		return fmt.Errorf("local principal publish targets require a queue store with durable sync support")
 	}
 

--- a/cmd/main_bench_test.go
+++ b/cmd/main_bench_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	amqpbroker "github.com/absmach/fluxmq/amqp/broker"
+	"github.com/absmach/fluxmq/broker/localauth"
+	"github.com/absmach/fluxmq/config"
+)
+
+// BenchmarkLocalAMQPPolicyCanPublish measures the per-publication authorization
+// cost of the local-principal listener, which decodes the session fingerprints
+// bound at authentication time.
+func BenchmarkLocalAMQPPolicyCanPublish(b *testing.B) {
+	dir := b.TempDir()
+	secretPath := filepath.Join(dir, "current")
+	if err := os.WriteFile(secretPath, []byte(testLocalSecret), 0o600); err != nil {
+		b.Fatal(err)
+	}
+	store, err := localauth.New([]config.LocalPrincipalConfig{{
+		Name:              testLocalPrincipal,
+		CertificateURISAN: testLocalSAN,
+		CurrentSecretFile: secretPath,
+		Permissions: config.LocalPermissionsConfig{
+			Publish: []config.LocalPublishPermission{{RoutingKey: testAuditQueue}},
+		},
+	}})
+	if err != nil {
+		b.Fatal(err)
+	}
+	adapter := &localAMQPPolicy{store: store}
+	principalID, credentialFingerprint, permissionsFingerprint, certificateURI, ok, err := adapter.AuthenticateLocal(
+		context.Background(),
+		"amqp091:client",
+		testLocalPrincipal,
+		testLocalSecret,
+		amqpbroker.VerifiedPeerIdentity{URISANs: []string{testLocalSAN}},
+	)
+	if err != nil || !ok {
+		b.Fatalf("AuthenticateLocal() authenticated=%v error=%v", ok, err)
+	}
+	identity := amqpbroker.LocalSessionIdentity{
+		PrincipalID:            principalID,
+		CredentialFingerprint:  credentialFingerprint,
+		PermissionsFingerprint: permissionsFingerprint,
+		CertificateURI:         certificateURI,
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if !adapter.CanPublishLocal(identity, "", testAuditQueue) {
+			b.Fatal("configured publish target was denied")
+		}
+	}
+}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -180,6 +180,19 @@ type queueStoreWithoutDurableSync struct {
 	queueStorage.QueueStore
 }
 
+// durableMemoryQueueStore presents the in-memory log as a crash-durable store.
+// The real deployment uses the file-based adapter; only the memory store's
+// missing fsync is being stubbed out here, not the append semantics.
+type durableMemoryQueueStore struct {
+	*memoryLog.Store
+}
+
+func (durableMemoryQueueStore) SupportsDurableSync() bool { return true }
+
+func newDurableTestQueueStore() durableMemoryQueueStore {
+	return durableMemoryQueueStore{Store: memoryLog.New()}
+}
+
 func TestValidateLocalPrincipalPublishTargets(t *testing.T) {
 	principal := config.LocalPrincipalConfig{
 		Name: testLocalPrincipal,
@@ -293,7 +306,7 @@ func TestValidateLocalPrincipalPublishTargets(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			store := memoryLog.New()
+			store := newDurableTestQueueStore()
 			if !tc.omitPersisted {
 				if err := store.CreateQueue(context.Background(), expected); err != nil {
 					t.Fatalf("CreateQueue() error = %v", err)
@@ -343,7 +356,7 @@ func TestValidateLocalPrincipalPublishTargetsSortsTargetErrors(t *testing.T) {
 		context.Background(),
 		[]config.LocalPrincipalConfig{principal},
 		nil,
-		memoryLog.New(),
+		newDurableTestQueueStore(),
 	)
 	if err == nil || !strings.Contains(err.Error(), `"a-target"`) {
 		t.Fatalf("validateLocalPrincipalPublishTargets() error = %v, want first sorted target", err)
@@ -381,7 +394,7 @@ func TestReloadLocalPrincipalsRejectsInvalidTargetBeforeSwap(t *testing.T) {
 	auditQueue := queueTypes.DefaultQueueConfig(testAuditQueue, "$queue/atom-audit/#")
 	auditQueue.Reserved = true
 	auditQueue.Type = queueTypes.QueueTypeStream
-	queueStore := memoryLog.New()
+	queueStore := newDurableTestQueueStore()
 	if err := queueStore.CreateQueue(context.Background(), auditQueue); err != nil {
 		t.Fatalf("CreateQueue() error = %v", err)
 	}
@@ -442,7 +455,7 @@ func TestReloadLocalPrincipalsReplacesProtectedTargets(t *testing.T) {
 	securityQueue.Reserved = true
 	securityQueue.Type = queueTypes.QueueTypeStream
 	configuredQueues := []queueTypes.QueueConfig{auditQueue, securityQueue}
-	queueStore := memoryLog.New()
+	queueStore := newDurableTestQueueStore()
 	for _, contract := range configuredQueues {
 		if err := queueStore.CreateQueue(ctx, contract); err != nil {
 			t.Fatalf("CreateQueue(%q) error = %v", contract.Name, err)
@@ -519,7 +532,7 @@ func TestReloadLocalPrincipalsRestoresProtectionWhenSecretLoadFails(t *testing.T
 	securityQueue.Reserved = true
 	securityQueue.Type = queueTypes.QueueTypeStream
 	configuredQueues := []queueTypes.QueueConfig{auditQueue, securityQueue}
-	queueStore := memoryLog.New()
+	queueStore := newDurableTestQueueStore()
 	for _, contract := range configuredQueues {
 		if err := queueStore.CreateQueue(ctx, contract); err != nil {
 			t.Fatalf("CreateQueue(%q) error = %v", contract.Name, err)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -27,6 +27,7 @@ const (
 	testLocalSAN       = "spiffe://absmach/atom/audit-publisher"
 	testLocalSecret    = "0123456789abcdef0123456789abcdef"
 	testNextSecret     = "abcdef0123456789abcdef0123456789"
+	testAuditQueue     = "atom-audit"
 )
 
 func TestLocalAMQPPolicyAdapter(t *testing.T) {
@@ -40,7 +41,7 @@ func TestLocalAMQPPolicyAdapter(t *testing.T) {
 		CertificateURISAN: testLocalSAN,
 		CurrentSecretFile: currentPath,
 		Permissions: config.LocalPermissionsConfig{
-			Publish: []config.LocalPublishPermission{{Exchange: "", RoutingKey: "atom-audit"}},
+			Publish: []config.LocalPublishPermission{{Exchange: "", RoutingKey: testAuditQueue}},
 		},
 	}
 	store, err := localauth.New([]config.LocalPrincipalConfig{principalConfig})
@@ -53,7 +54,7 @@ func TestLocalAMQPPolicyAdapter(t *testing.T) {
 		CertificateFingerprint: strings.Repeat("a", 64),
 	}
 
-	principalID, fingerprint, certificateURI, authenticated, err := adapter.AuthenticateLocal(
+	principalID, credentialFingerprint, permissionsFingerprint, certificateURI, authenticated, err := adapter.AuthenticateLocal(
 		context.Background(), "amqp091:client", testLocalPrincipal, testLocalSecret, peer,
 	)
 	if err != nil {
@@ -62,19 +63,24 @@ func TestLocalAMQPPolicyAdapter(t *testing.T) {
 	if !authenticated || principalID != testLocalPrincipal || certificateURI != testLocalSAN {
 		t.Fatalf("unexpected authentication result: principal=%q certificate_uri=%q authenticated=%v", principalID, certificateURI, authenticated)
 	}
-	decodedFingerprint, err := hex.DecodeString(fingerprint)
-	if err != nil || len(decodedFingerprint) != len(localauth.CredentialFingerprint{}) {
-		t.Fatalf("invalid credential fingerprint %q: %v", fingerprint, err)
+	decodedCredentialFingerprint, err := hex.DecodeString(credentialFingerprint)
+	if err != nil || len(decodedCredentialFingerprint) != len(localauth.CredentialFingerprint{}) {
+		t.Fatalf("invalid credential fingerprint %q: %v", credentialFingerprint, err)
+	}
+	decodedPermissionsFingerprint, err := hex.DecodeString(permissionsFingerprint)
+	if err != nil || len(decodedPermissionsFingerprint) != len(localauth.PermissionsFingerprint{}) {
+		t.Fatalf("invalid permissions fingerprint %q: %v", permissionsFingerprint, err)
 	}
 	identity := amqpbroker.LocalSessionIdentity{
-		PrincipalID:           principalID,
-		CredentialFingerprint: fingerprint,
-		CertificateURI:        certificateURI,
+		PrincipalID:            principalID,
+		CredentialFingerprint:  credentialFingerprint,
+		PermissionsFingerprint: permissionsFingerprint,
+		CertificateURI:         certificateURI,
 	}
-	if !adapter.CanPublishLocal(identity, "", "atom-audit") {
+	if !adapter.CanPublishLocal(identity, "", testAuditQueue) {
 		t.Fatal("exact configured publish target was denied")
 	}
-	if adapter.CanPublishLocal(identity, "events", "atom-audit") || adapter.CanPublishLocal(identity, "", "atom-audit.other") {
+	if adapter.CanPublishLocal(identity, "events", testAuditQueue) || adapter.CanPublishLocal(identity, "", "atom-audit.other") {
 		t.Fatal("non-exact publish target was allowed")
 	}
 
@@ -97,21 +103,76 @@ func TestLocalAMQPPolicyAdapter(t *testing.T) {
 	if adapter.IsSessionActive(identity) {
 		t.Fatal("session authenticated with the removed secret remains active")
 	}
-	if adapter.CanPublishLocal(identity, "", "atom-audit") {
+	if adapter.CanPublishLocal(identity, "", testAuditQueue) {
 		t.Fatal("session authenticated before reload can publish with the removed secret")
 	}
 }
 
 func TestLocalAMQPPolicyAdapterFailsClosed(t *testing.T) {
 	adapter := &localAMQPPolicy{}
-	if _, _, _, authenticated, err := adapter.AuthenticateLocal(context.Background(), "client", "user", "secret", amqpbroker.VerifiedPeerIdentity{}); err != nil || authenticated {
+	if _, _, _, _, authenticated, err := adapter.AuthenticateLocal(context.Background(), "client", "user", "secret", amqpbroker.VerifiedPeerIdentity{}); err != nil || authenticated {
 		t.Fatalf("nil local store must fail closed: authenticated=%v err=%v", authenticated, err)
 	}
-	if adapter.CanPublishLocal(amqpbroker.LocalSessionIdentity{PrincipalID: "principal"}, "", "atom-audit") {
+	if adapter.CanPublishLocal(amqpbroker.LocalSessionIdentity{PrincipalID: "principal"}, "", testAuditQueue) {
 		t.Fatal("nil local store authorized a publication")
 	}
 	if adapter.IsSessionActive(amqpbroker.LocalSessionIdentity{}) {
 		t.Fatal("nil local store reported an active session")
+	}
+}
+
+func TestLocalAMQPPolicyAdapterRevokesChangedPermissions(t *testing.T) {
+	dir := t.TempDir()
+	currentPath := filepath.Join(dir, "current")
+	if err := os.WriteFile(currentPath, []byte(testLocalSecret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	principalConfig := config.LocalPrincipalConfig{
+		Name:              testLocalPrincipal,
+		CertificateURISAN: testLocalSAN,
+		CurrentSecretFile: currentPath,
+		Permissions: config.LocalPermissionsConfig{
+			Publish: []config.LocalPublishPermission{{RoutingKey: testAuditQueue}},
+		},
+	}
+	store, err := localauth.New([]config.LocalPrincipalConfig{principalConfig})
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := &localAMQPPolicy{store: store}
+	principalID, credentialFingerprint, permissionsFingerprint, certificateURI, authenticated, err := adapter.AuthenticateLocal(
+		context.Background(),
+		"amqp091:client",
+		testLocalPrincipal,
+		testLocalSecret,
+		amqpbroker.VerifiedPeerIdentity{URISANs: []string{testLocalSAN}},
+	)
+	if err != nil || !authenticated {
+		t.Fatalf("AuthenticateLocal() authenticated=%v error=%v", authenticated, err)
+	}
+	identity := amqpbroker.LocalSessionIdentity{
+		PrincipalID:            principalID,
+		CredentialFingerprint:  credentialFingerprint,
+		PermissionsFingerprint: permissionsFingerprint,
+		CertificateURI:         certificateURI,
+	}
+	if !adapter.IsSessionActive(identity) {
+		t.Fatal("freshly authenticated session was not active")
+	}
+
+	principalConfig.Permissions.Publish[0].RoutingKey = "atom-audit-v2"
+	changed, err := store.Reload([]config.LocalPrincipalConfig{principalConfig})
+	if err != nil {
+		t.Fatalf("Reload() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("publish ACL replacement was reported as unchanged")
+	}
+	if adapter.IsSessionActive(identity) {
+		t.Fatal("session authenticated against the replaced publish ACL remains active")
+	}
+	if adapter.CanPublishLocal(identity, "", "atom-audit-v2") {
+		t.Fatal("session authenticated against the old ACL used the replacement ACL")
 	}
 }
 
@@ -123,10 +184,10 @@ func TestValidateLocalPrincipalPublishTargets(t *testing.T) {
 	principal := config.LocalPrincipalConfig{
 		Name: testLocalPrincipal,
 		Permissions: config.LocalPermissionsConfig{
-			Publish: []config.LocalPublishPermission{{RoutingKey: "atom-audit"}},
+			Publish: []config.LocalPublishPermission{{RoutingKey: testAuditQueue}},
 		},
 	}
-	expected := queueTypes.DefaultQueueConfig("atom-audit", "$queue/atom-audit/#")
+	expected := queueTypes.DefaultQueueConfig(testAuditQueue, "$queue/atom-audit/#")
 	expected.Reserved = true
 	expected.Type = queueTypes.QueueTypeStream
 	expected.Retention = queueTypes.RetentionPolicy{
@@ -305,7 +366,7 @@ func TestReloadLocalPrincipalsRejectsInvalidTargetBeforeSwap(t *testing.T) {
 		CertificateURISAN: testLocalSAN,
 		CurrentSecretFile: secretPath,
 		Permissions: config.LocalPermissionsConfig{
-			Publish: []config.LocalPublishPermission{{RoutingKey: "atom-audit"}},
+			Publish: []config.LocalPublishPermission{{RoutingKey: testAuditQueue}},
 		},
 	}
 	localStore, err := localauth.New([]config.LocalPrincipalConfig{principal})
@@ -317,7 +378,7 @@ func TestReloadLocalPrincipalsRejectsInvalidTargetBeforeSwap(t *testing.T) {
 		t.Fatal("initial principal did not authenticate")
 	}
 
-	auditQueue := queueTypes.DefaultQueueConfig("atom-audit", "$queue/atom-audit/#")
+	auditQueue := queueTypes.DefaultQueueConfig(testAuditQueue, "$queue/atom-audit/#")
 	auditQueue.Reserved = true
 	auditQueue.Type = queueTypes.QueueTypeStream
 	queueStore := memoryLog.New()
@@ -346,7 +407,7 @@ func TestReloadLocalPrincipalsRejectsInvalidTargetBeforeSwap(t *testing.T) {
 	if localStore.Generation() != generation {
 		t.Fatalf("generation changed after rejected reload: got %d, want %d", localStore.Generation(), generation)
 	}
-	if !localStore.CanPublishAuthenticated(authentication, "", "atom-audit") {
+	if !localStore.CanPublishAuthenticated(authentication, "", testAuditQueue) {
 		t.Fatal("rejected reload replaced the previous valid snapshot")
 	}
 }
@@ -362,7 +423,7 @@ func TestReloadLocalPrincipalsReplacesProtectedTargets(t *testing.T) {
 		CertificateURISAN: testLocalSAN,
 		CurrentSecretFile: secretPath,
 		Permissions: config.LocalPermissionsConfig{
-			Publish: []config.LocalPublishPermission{{RoutingKey: "atom-audit"}},
+			Publish: []config.LocalPublishPermission{{RoutingKey: testAuditQueue}},
 		},
 	}
 	localStore, err := localauth.New([]config.LocalPrincipalConfig{principal})
@@ -374,7 +435,7 @@ func TestReloadLocalPrincipalsReplacesProtectedTargets(t *testing.T) {
 		t.Fatal("initial principal did not authenticate")
 	}
 
-	auditQueue := queueTypes.DefaultQueueConfig("atom-audit", "$queue/atom-audit/#")
+	auditQueue := queueTypes.DefaultQueueConfig(testAuditQueue, "$queue/atom-audit/#")
 	auditQueue.Reserved = true
 	auditQueue.Type = queueTypes.QueueTypeStream
 	securityQueue := queueTypes.DefaultQueueConfig("atom-security", "$queue/atom-security/#")
@@ -413,7 +474,14 @@ func TestReloadLocalPrincipalsReplacesProtectedTargets(t *testing.T) {
 	if localStore.CanPublishAuthenticated(authentication, "", auditQueue.Name) {
 		t.Fatal("old publish target remained authorized")
 	}
-	if !localStore.CanPublishAuthenticated(authentication, "", securityQueue.Name) {
+	if localStore.IsActive(authentication) {
+		t.Fatal("session authenticated against the replaced publish ACL remains active")
+	}
+	reauthenticated, ok := localStore.Authenticate(testLocalPrincipal, testLocalSecret, testLocalSAN)
+	if !ok {
+		t.Fatal("principal did not reauthenticate against the replacement publish ACL")
+	}
+	if !localStore.CanPublishAuthenticated(reauthenticated, "", securityQueue.Name) {
 		t.Fatal("new publish target was not authorized")
 	}
 	if err := queueManager.PublishToDurableStream(ctx, auditQueue.Name, queueTypes.PublishRequest{Payload: []byte("{}")}); !errors.Is(err, queuepkg.ErrQueueNotProtected) {
@@ -436,7 +504,7 @@ func TestReloadLocalPrincipalsRestoresProtectionWhenSecretLoadFails(t *testing.T
 		CertificateURISAN: testLocalSAN,
 		CurrentSecretFile: secretPath,
 		Permissions: config.LocalPermissionsConfig{
-			Publish: []config.LocalPublishPermission{{RoutingKey: "atom-audit"}},
+			Publish: []config.LocalPublishPermission{{RoutingKey: testAuditQueue}},
 		},
 	}
 	localStore, err := localauth.New([]config.LocalPrincipalConfig{principal})
@@ -444,7 +512,7 @@ func TestReloadLocalPrincipalsRestoresProtectionWhenSecretLoadFails(t *testing.T
 		t.Fatalf("localauth.New() error = %v", err)
 	}
 
-	auditQueue := queueTypes.DefaultQueueConfig("atom-audit", "$queue/atom-audit/#")
+	auditQueue := queueTypes.DefaultQueueConfig(testAuditQueue, "$queue/atom-audit/#")
 	auditQueue.Reserved = true
 	auditQueue.Type = queueTypes.QueueTypeStream
 	securityQueue := queueTypes.DefaultQueueConfig("atom-security", "$queue/atom-security/#")

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -1,0 +1,482 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	amqpbroker "github.com/absmach/fluxmq/amqp/broker"
+	"github.com/absmach/fluxmq/broker/localauth"
+	"github.com/absmach/fluxmq/config"
+	queuepkg "github.com/absmach/fluxmq/queue"
+	queueStorage "github.com/absmach/fluxmq/queue/storage"
+	memoryLog "github.com/absmach/fluxmq/queue/storage/memory/log"
+	queueTypes "github.com/absmach/fluxmq/queue/types"
+)
+
+const (
+	testLocalPrincipal = "atom-audit-publisher"
+	testLocalSAN       = "spiffe://absmach/atom/audit-publisher"
+	testLocalSecret    = "0123456789abcdef0123456789abcdef"
+	testNextSecret     = "abcdef0123456789abcdef0123456789"
+)
+
+func TestLocalAMQPPolicyAdapter(t *testing.T) {
+	dir := t.TempDir()
+	currentPath := filepath.Join(dir, "current")
+	if err := os.WriteFile(currentPath, []byte(testLocalSecret+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	principalConfig := config.LocalPrincipalConfig{
+		Name:              testLocalPrincipal,
+		CertificateURISAN: testLocalSAN,
+		CurrentSecretFile: currentPath,
+		Permissions: config.LocalPermissionsConfig{
+			Publish: []config.LocalPublishPermission{{Exchange: "", RoutingKey: "atom-audit"}},
+		},
+	}
+	store, err := localauth.New([]config.LocalPrincipalConfig{principalConfig})
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapter := &localAMQPPolicy{store: store}
+	peer := amqpbroker.VerifiedPeerIdentity{
+		URISANs:                []string{"spiffe://unrelated/service", testLocalSAN},
+		CertificateFingerprint: strings.Repeat("a", 64),
+	}
+
+	principalID, fingerprint, certificateURI, authenticated, err := adapter.AuthenticateLocal(
+		context.Background(), "amqp091:client", testLocalPrincipal, testLocalSecret, peer,
+	)
+	if err != nil {
+		t.Fatalf("AuthenticateLocal() error = %v", err)
+	}
+	if !authenticated || principalID != testLocalPrincipal || certificateURI != testLocalSAN {
+		t.Fatalf("unexpected authentication result: principal=%q certificate_uri=%q authenticated=%v", principalID, certificateURI, authenticated)
+	}
+	decodedFingerprint, err := hex.DecodeString(fingerprint)
+	if err != nil || len(decodedFingerprint) != len(localauth.CredentialFingerprint{}) {
+		t.Fatalf("invalid credential fingerprint %q: %v", fingerprint, err)
+	}
+	identity := amqpbroker.LocalSessionIdentity{
+		PrincipalID:           principalID,
+		CredentialFingerprint: fingerprint,
+		CertificateURI:        certificateURI,
+	}
+	if !adapter.CanPublishLocal(identity, "", "atom-audit") {
+		t.Fatal("exact configured publish target was denied")
+	}
+	if adapter.CanPublishLocal(identity, "events", "atom-audit") || adapter.CanPublishLocal(identity, "", "atom-audit.other") {
+		t.Fatal("non-exact publish target was allowed")
+	}
+
+	if !adapter.IsSessionActive(identity) {
+		t.Fatal("freshly authenticated session was not active")
+	}
+
+	nextPath := filepath.Join(dir, "next")
+	if err := os.WriteFile(nextPath, []byte(testNextSecret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	principalConfig.CurrentSecretFile = nextPath
+	changed, err := store.Reload([]config.LocalPrincipalConfig{principalConfig})
+	if err != nil {
+		t.Fatalf("Reload() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("credential rotation was reported as unchanged")
+	}
+	if adapter.IsSessionActive(identity) {
+		t.Fatal("session authenticated with the removed secret remains active")
+	}
+	if adapter.CanPublishLocal(identity, "", "atom-audit") {
+		t.Fatal("session authenticated before reload can publish with the removed secret")
+	}
+}
+
+func TestLocalAMQPPolicyAdapterFailsClosed(t *testing.T) {
+	adapter := &localAMQPPolicy{}
+	if _, _, _, authenticated, err := adapter.AuthenticateLocal(context.Background(), "client", "user", "secret", amqpbroker.VerifiedPeerIdentity{}); err != nil || authenticated {
+		t.Fatalf("nil local store must fail closed: authenticated=%v err=%v", authenticated, err)
+	}
+	if adapter.CanPublishLocal(amqpbroker.LocalSessionIdentity{PrincipalID: "principal"}, "", "atom-audit") {
+		t.Fatal("nil local store authorized a publication")
+	}
+	if adapter.IsSessionActive(amqpbroker.LocalSessionIdentity{}) {
+		t.Fatal("nil local store reported an active session")
+	}
+}
+
+type queueStoreWithoutDurableSync struct {
+	queueStorage.QueueStore
+}
+
+func TestValidateLocalPrincipalPublishTargets(t *testing.T) {
+	principal := config.LocalPrincipalConfig{
+		Name: testLocalPrincipal,
+		Permissions: config.LocalPermissionsConfig{
+			Publish: []config.LocalPublishPermission{{RoutingKey: "atom-audit"}},
+		},
+	}
+	expected := queueTypes.DefaultQueueConfig("atom-audit", "$queue/atom-audit/#")
+	expected.Reserved = true
+	expected.Type = queueTypes.QueueTypeStream
+	expected.Retention = queueTypes.RetentionPolicy{
+		RetentionTime:     30 * 24 * time.Hour,
+		RetentionBytes:    10 * 1024 * 1024 * 1024,
+		RetentionMessages: 0,
+	}
+	expected.MaxMessageSize = 1024 * 1024
+
+	tests := []struct {
+		name               string
+		configured         []queueTypes.QueueConfig
+		mutatePersisted    func(*queueTypes.QueueConfig)
+		omitPersisted      bool
+		withoutDurableSync bool
+		wantError          string
+	}{
+		{name: "valid", configured: []queueTypes.QueueConfig{expected}},
+		{
+			name:               "durable sync unsupported",
+			configured:         []queueTypes.QueueConfig{expected},
+			withoutDurableSync: true,
+			wantError:          "durable sync support",
+		},
+		{
+			name:       "target absent from configured queues",
+			configured: nil,
+			wantError:  "has no matching queues entry",
+		},
+		{
+			name:          "target absent from persisted queues",
+			configured:    []queueTypes.QueueConfig{expected},
+			omitPersisted: true,
+			wantError:     "load persisted local principal publish target",
+		},
+		{
+			name:            "classic queue",
+			configured:      []queueTypes.QueueConfig{expected},
+			mutatePersisted: func(actual *queueTypes.QueueConfig) { actual.Type = queueTypes.QueueTypeClassic },
+			wantError:       "must be a stream",
+		},
+		{
+			name:            "ephemeral queue",
+			configured:      []queueTypes.QueueConfig{expected},
+			mutatePersisted: func(actual *queueTypes.QueueConfig) { actual.Durable = false },
+			wantError:       "must be durable",
+		},
+		{
+			name:            "mutable queue",
+			configured:      []queueTypes.QueueConfig{expected},
+			mutatePersisted: func(actual *queueTypes.QueueConfig) { actual.Reserved = false },
+			wantError:       "must be reserved",
+		},
+		{
+			name:       "replicated queue",
+			configured: []queueTypes.QueueConfig{expected},
+			mutatePersisted: func(actual *queueTypes.QueueConfig) {
+				actual.Replication.Enabled = true
+			},
+			wantError: "must not enable replication",
+		},
+		{
+			name:       "stale retention age",
+			configured: []queueTypes.QueueConfig{expected},
+			mutatePersisted: func(actual *queueTypes.QueueConfig) {
+				actual.Retention.RetentionTime = 24 * time.Hour
+			},
+			wantError: "retention.max_age",
+		},
+		{
+			name:       "stale retention bytes",
+			configured: []queueTypes.QueueConfig{expected},
+			mutatePersisted: func(actual *queueTypes.QueueConfig) {
+				actual.Retention.RetentionBytes--
+			},
+			wantError: "retention.max_length_bytes",
+		},
+		{
+			name:       "stale retention messages",
+			configured: []queueTypes.QueueConfig{expected},
+			mutatePersisted: func(actual *queueTypes.QueueConfig) {
+				actual.Retention.RetentionMessages = 1
+			},
+			wantError: "retention.max_length_messages",
+		},
+		{
+			name:       "stale maximum message size",
+			configured: []queueTypes.QueueConfig{expected},
+			mutatePersisted: func(actual *queueTypes.QueueConfig) {
+				actual.MaxMessageSize++
+			},
+			wantError: "limits.max_message_size",
+		},
+		{
+			name:       "stale message TTL",
+			configured: []queueTypes.QueueConfig{expected},
+			mutatePersisted: func(actual *queueTypes.QueueConfig) {
+				actual.MessageTTL++
+			},
+			wantError: "limits.message_ttl",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := memoryLog.New()
+			if !tc.omitPersisted {
+				if err := store.CreateQueue(context.Background(), expected); err != nil {
+					t.Fatalf("CreateQueue() error = %v", err)
+				}
+				if tc.mutatePersisted != nil {
+					actual := expected
+					tc.mutatePersisted(&actual)
+					if err := store.UpdateQueue(context.Background(), actual); err != nil {
+						t.Fatalf("UpdateQueue() error = %v", err)
+					}
+				}
+			}
+
+			var queueStore queueStorage.QueueStore = store
+			if tc.withoutDurableSync {
+				queueStore = queueStoreWithoutDurableSync{QueueStore: store}
+			}
+			err := validateLocalPrincipalPublishTargets(
+				context.Background(),
+				[]config.LocalPrincipalConfig{principal},
+				tc.configured,
+				queueStore,
+			)
+			if tc.wantError == "" {
+				if err != nil {
+					t.Fatalf("validateLocalPrincipalPublishTargets() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tc.wantError) {
+				t.Fatalf("validateLocalPrincipalPublishTargets() error = %v, want substring %q", err, tc.wantError)
+			}
+		})
+	}
+}
+
+func TestValidateLocalPrincipalPublishTargetsSortsTargetErrors(t *testing.T) {
+	principal := config.LocalPrincipalConfig{
+		Permissions: config.LocalPermissionsConfig{
+			Publish: []config.LocalPublishPermission{
+				{RoutingKey: "z-target"},
+				{RoutingKey: "a-target"},
+			},
+		},
+	}
+	err := validateLocalPrincipalPublishTargets(
+		context.Background(),
+		[]config.LocalPrincipalConfig{principal},
+		nil,
+		memoryLog.New(),
+	)
+	if err == nil || !strings.Contains(err.Error(), `"a-target"`) {
+		t.Fatalf("validateLocalPrincipalPublishTargets() error = %v, want first sorted target", err)
+	}
+}
+
+func TestValidateLocalPrincipalPublishTargetsDisabled(t *testing.T) {
+	if err := validateLocalPrincipalPublishTargets(context.Background(), nil, nil, nil); err != nil {
+		t.Fatalf("disabled local targets require no queue store: %v", err)
+	}
+}
+
+func TestReloadLocalPrincipalsRejectsInvalidTargetBeforeSwap(t *testing.T) {
+	secretPath := filepath.Join(t.TempDir(), "current")
+	if err := os.WriteFile(secretPath, []byte(testLocalSecret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	principal := config.LocalPrincipalConfig{
+		Name:              testLocalPrincipal,
+		CertificateURISAN: testLocalSAN,
+		CurrentSecretFile: secretPath,
+		Permissions: config.LocalPermissionsConfig{
+			Publish: []config.LocalPublishPermission{{RoutingKey: "atom-audit"}},
+		},
+	}
+	localStore, err := localauth.New([]config.LocalPrincipalConfig{principal})
+	if err != nil {
+		t.Fatalf("localauth.New() error = %v", err)
+	}
+	authentication, ok := localStore.Authenticate(testLocalPrincipal, testLocalSecret, testLocalSAN)
+	if !ok {
+		t.Fatal("initial principal did not authenticate")
+	}
+
+	auditQueue := queueTypes.DefaultQueueConfig("atom-audit", "$queue/atom-audit/#")
+	auditQueue.Reserved = true
+	auditQueue.Type = queueTypes.QueueTypeStream
+	queueStore := memoryLog.New()
+	if err := queueStore.CreateQueue(context.Background(), auditQueue); err != nil {
+		t.Fatalf("CreateQueue() error = %v", err)
+	}
+	managerConfig := queuepkg.DefaultConfig()
+	managerConfig.ProtectedQueueContracts = []queueTypes.QueueConfig{auditQueue}
+	queueManager := queuepkg.NewManager(queueStore, nil, nil, managerConfig, nil, nil)
+
+	generation := localStore.Generation()
+	principal.Permissions.Publish[0].RoutingKey = "unprovisioned-audit"
+	changed, err := reloadLocalPrincipals(
+		context.Background(),
+		localStore,
+		[]config.LocalPrincipalConfig{principal},
+		[]queueTypes.QueueConfig{auditQueue},
+		queueManager,
+	)
+	if err == nil || !strings.Contains(err.Error(), "has no matching queues entry") {
+		t.Fatalf("reloadLocalPrincipals() error = %v, want invalid target", err)
+	}
+	if changed {
+		t.Fatal("invalid local-principal reload reported a change")
+	}
+	if localStore.Generation() != generation {
+		t.Fatalf("generation changed after rejected reload: got %d, want %d", localStore.Generation(), generation)
+	}
+	if !localStore.CanPublishAuthenticated(authentication, "", "atom-audit") {
+		t.Fatal("rejected reload replaced the previous valid snapshot")
+	}
+}
+
+func TestReloadLocalPrincipalsReplacesProtectedTargets(t *testing.T) {
+	ctx := context.Background()
+	secretPath := filepath.Join(t.TempDir(), "current")
+	if err := os.WriteFile(secretPath, []byte(testLocalSecret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	principal := config.LocalPrincipalConfig{
+		Name:              testLocalPrincipal,
+		CertificateURISAN: testLocalSAN,
+		CurrentSecretFile: secretPath,
+		Permissions: config.LocalPermissionsConfig{
+			Publish: []config.LocalPublishPermission{{RoutingKey: "atom-audit"}},
+		},
+	}
+	localStore, err := localauth.New([]config.LocalPrincipalConfig{principal})
+	if err != nil {
+		t.Fatalf("localauth.New() error = %v", err)
+	}
+	authentication, ok := localStore.Authenticate(testLocalPrincipal, testLocalSecret, testLocalSAN)
+	if !ok {
+		t.Fatal("initial principal did not authenticate")
+	}
+
+	auditQueue := queueTypes.DefaultQueueConfig("atom-audit", "$queue/atom-audit/#")
+	auditQueue.Reserved = true
+	auditQueue.Type = queueTypes.QueueTypeStream
+	securityQueue := queueTypes.DefaultQueueConfig("atom-security", "$queue/atom-security/#")
+	securityQueue.Reserved = true
+	securityQueue.Type = queueTypes.QueueTypeStream
+	configuredQueues := []queueTypes.QueueConfig{auditQueue, securityQueue}
+	queueStore := memoryLog.New()
+	for _, contract := range configuredQueues {
+		if err := queueStore.CreateQueue(ctx, contract); err != nil {
+			t.Fatalf("CreateQueue(%q) error = %v", contract.Name, err)
+		}
+	}
+	managerConfig := queuepkg.DefaultConfig()
+	managerConfig.ProtectedQueueContracts = []queueTypes.QueueConfig{auditQueue}
+	queueManager := queuepkg.NewManager(queueStore, nil, nil, managerConfig, nil, nil)
+
+	next := principal
+	next.Permissions.Publish = []config.LocalPublishPermission{{RoutingKey: securityQueue.Name}}
+	changed, err := reloadLocalPrincipals(
+		ctx,
+		localStore,
+		[]config.LocalPrincipalConfig{next},
+		configuredQueues,
+		queueManager,
+	)
+	if err != nil {
+		t.Fatalf("reloadLocalPrincipals() error = %v", err)
+	}
+	if !changed {
+		t.Fatal("target replacement did not report a changed snapshot")
+	}
+	contracts := queueManager.ProtectedQueueContracts()
+	if len(contracts) != 1 || contracts[0].Name != securityQueue.Name {
+		t.Fatalf("protected contracts = %+v, want only %q", contracts, securityQueue.Name)
+	}
+	if localStore.CanPublishAuthenticated(authentication, "", auditQueue.Name) {
+		t.Fatal("old publish target remained authorized")
+	}
+	if !localStore.CanPublishAuthenticated(authentication, "", securityQueue.Name) {
+		t.Fatal("new publish target was not authorized")
+	}
+	if err := queueManager.PublishToDurableStream(ctx, auditQueue.Name, queueTypes.PublishRequest{Payload: []byte("{}")}); !errors.Is(err, queuepkg.ErrQueueNotProtected) {
+		t.Fatalf("old target publish error = %v, want ErrQueueNotProtected", err)
+	}
+	if err := queueManager.PublishToDurableStream(ctx, securityQueue.Name, queueTypes.PublishRequest{Payload: []byte("{}")}); err != nil {
+		t.Fatalf("new target publish error = %v", err)
+	}
+}
+
+func TestReloadLocalPrincipalsRestoresProtectionWhenSecretLoadFails(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "current")
+	if err := os.WriteFile(secretPath, []byte(testLocalSecret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	principal := config.LocalPrincipalConfig{
+		Name:              testLocalPrincipal,
+		CertificateURISAN: testLocalSAN,
+		CurrentSecretFile: secretPath,
+		Permissions: config.LocalPermissionsConfig{
+			Publish: []config.LocalPublishPermission{{RoutingKey: "atom-audit"}},
+		},
+	}
+	localStore, err := localauth.New([]config.LocalPrincipalConfig{principal})
+	if err != nil {
+		t.Fatalf("localauth.New() error = %v", err)
+	}
+
+	auditQueue := queueTypes.DefaultQueueConfig("atom-audit", "$queue/atom-audit/#")
+	auditQueue.Reserved = true
+	auditQueue.Type = queueTypes.QueueTypeStream
+	securityQueue := queueTypes.DefaultQueueConfig("atom-security", "$queue/atom-security/#")
+	securityQueue.Reserved = true
+	securityQueue.Type = queueTypes.QueueTypeStream
+	configuredQueues := []queueTypes.QueueConfig{auditQueue, securityQueue}
+	queueStore := memoryLog.New()
+	for _, contract := range configuredQueues {
+		if err := queueStore.CreateQueue(ctx, contract); err != nil {
+			t.Fatalf("CreateQueue(%q) error = %v", contract.Name, err)
+		}
+	}
+	managerConfig := queuepkg.DefaultConfig()
+	managerConfig.ProtectedQueueContracts = []queueTypes.QueueConfig{auditQueue}
+	queueManager := queuepkg.NewManager(queueStore, nil, nil, managerConfig, nil, nil)
+	generation := localStore.Generation()
+
+	next := principal
+	next.CurrentSecretFile = filepath.Join(dir, "missing")
+	next.Permissions.Publish = []config.LocalPublishPermission{{RoutingKey: securityQueue.Name}}
+	changed, err := reloadLocalPrincipals(ctx, localStore, []config.LocalPrincipalConfig{next}, configuredQueues, queueManager)
+	if err == nil {
+		t.Fatal("reloadLocalPrincipals() succeeded with a missing secret")
+	}
+	if changed {
+		t.Fatal("failed reload reported a changed snapshot")
+	}
+	if localStore.Generation() != generation {
+		t.Fatalf("generation = %d, want %d", localStore.Generation(), generation)
+	}
+	contracts := queueManager.ProtectedQueueContracts()
+	if len(contracts) != 1 || contracts[0].Name != auditQueue.Name {
+		t.Fatalf("protected contracts after rollback = %+v, want only %q", contracts, auditQueue.Name)
+	}
+}

--- a/config/auth_test.go
+++ b/config/auth_test.go
@@ -1,0 +1,373 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	testPrincipalName = "atom-audit-publisher"
+	testPrincipalSAN  = "spiffe://absmach/atom/audit-publisher"
+)
+
+func TestLoadNestedAuth(t *testing.T) {
+	dir := t.TempDir()
+	current := writeSecret(t, dir, "current", strings.Repeat("a", 32)+"\n")
+	previous := writeSecret(t, dir, "previous", strings.Repeat("b", 32)+"\r\n")
+	filename := filepath.Join(dir, "config.yaml")
+	contents := fmt.Sprintf(`
+auth:
+  external:
+    url: "http://auth.internal:8181"
+    transport: "http"
+    timeout: 2s
+    protocols:
+      amqp091: true
+    identity_cache_size: 123
+    identity_cache_ttl: 1h
+  local_principals:
+    - name: %q
+      certificate_uri_san: %q
+      current_secret_file: %q
+      previous_secret_file: %q
+      permissions:
+        publish:
+          - exchange: ""
+            routing_key: atom-audit
+        subscribe: []
+`, testPrincipalName, testPrincipalSAN, current, previous)
+	if err := os.WriteFile(filename, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(filename)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Auth.External.URL != "http://auth.internal:8181" {
+		t.Fatalf("external URL = %q", cfg.Auth.External.URL)
+	}
+	if cfg.Auth.External.Timeout != 2*time.Second {
+		t.Fatalf("external timeout = %v", cfg.Auth.External.Timeout)
+	}
+	if !cfg.Auth.External.EnabledFor(protocolAMQP091) {
+		t.Fatal("expected AMQP 0.9.1 external auth to be enabled")
+	}
+	if len(cfg.Auth.LocalPrincipals) != 1 {
+		t.Fatalf("local principal count = %d, want 1", len(cfg.Auth.LocalPrincipals))
+	}
+	principal := cfg.Auth.LocalPrincipals[0]
+	if principal.Name != testPrincipalName || principal.CertificateURISAN != testPrincipalSAN {
+		t.Fatalf("unexpected local principal: %+v", principal)
+	}
+	if len(principal.Permissions.Publish) != 1 || principal.Permissions.Publish[0].RoutingKey != "atom-audit" {
+		t.Fatalf("unexpected publish permissions: %+v", principal.Permissions.Publish)
+	}
+}
+
+func TestLoadRejectsLegacyAuthKeys(t *testing.T) {
+	tests := map[string]string{
+		"url":                 "auth.external.url",
+		"transport":           "auth.external.transport",
+		"timeout":             "auth.external.timeout",
+		"protocols":           "auth.external.protocols",
+		"identity_cache_size": "auth.external.identity_cache_size",
+		"identity_cache_ttl":  "auth.external.identity_cache_ttl",
+	}
+
+	for key, replacement := range tests {
+		t.Run(key, func(t *testing.T) {
+			filename := filepath.Join(t.TempDir(), "config.yaml")
+			contents := fmt.Sprintf("auth:\n  %s: value\n", key)
+			if err := os.WriteFile(filename, []byte(contents), 0o600); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			_, err := Load(filename)
+			if err == nil {
+				t.Fatal("Load() succeeded with a legacy auth key")
+			}
+			want := fmt.Sprintf("auth.%s is no longer supported; use %s", key, replacement)
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("Load() error = %q, want it to contain %q", err, want)
+			}
+		})
+	}
+}
+
+func TestLoadRejectsUnknownAuthFields(t *testing.T) {
+	filename := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(filename, []byte("auth:\n  external:\n    unsupported: true\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, err := Load(filename)
+	if err == nil || !strings.Contains(err.Error(), "field unsupported not found") {
+		t.Fatalf("Load() error = %v, want strict unknown-field error", err)
+	}
+}
+
+func TestValidateLocalPrincipals(t *testing.T) {
+	dir := t.TempDir()
+	current := writeSecret(t, dir, "current", strings.Repeat("a", 32)+"\n")
+	previous := writeSecret(t, dir, "previous", strings.Repeat("b", 32)+"\r\n")
+	weak := writeSecret(t, dir, "weak", strings.Repeat("c", 31)+"\n")
+	doubleNewline := writeSecret(t, dir, "double-newline", strings.Repeat("d", 32)+"\n\n")
+	nul := writeSecret(t, dir, "nul", strings.Repeat("e", 16)+"\x00"+strings.Repeat("e", 16))
+
+	valid := func() LocalPrincipalConfig {
+		return LocalPrincipalConfig{
+			Name:               testPrincipalName,
+			CertificateURISAN:  testPrincipalSAN,
+			CurrentSecretFile:  current,
+			PreviousSecretFile: previous,
+			Permissions: LocalPermissionsConfig{
+				Publish: []LocalPublishPermission{{Exchange: "", RoutingKey: "atom-audit"}},
+			},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		principals func() []LocalPrincipalConfig
+		wantError  string
+	}{
+		{
+			name:       "valid current and previous secret",
+			principals: func() []LocalPrincipalConfig { return []LocalPrincipalConfig{valid()} },
+		},
+		{
+			name: "duplicate name",
+			principals: func() []LocalPrincipalConfig {
+				first, second := valid(), valid()
+				second.CertificateURISAN = "spiffe://absmach/atom/other"
+				return []LocalPrincipalConfig{first, second}
+			},
+			wantError: ".name \"atom-audit-publisher\" is duplicated",
+		},
+		{
+			name: "duplicate URI SAN",
+			principals: func() []LocalPrincipalConfig {
+				first, second := valid(), valid()
+				second.Name = "other"
+				return []LocalPrincipalConfig{first, second}
+			},
+			wantError: ".certificate_uri_san \"spiffe://absmach/atom/audit-publisher\" is duplicated",
+		},
+		{
+			name: "missing current secret path",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.CurrentSecretFile = ""
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: ".current_secret_file cannot be empty",
+		},
+		{
+			name: "missing secret file",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.CurrentSecretFile = filepath.Join(dir, "missing")
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: "failed to read secret file",
+		},
+		{
+			name: "weak secret",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.CurrentSecretFile = weak
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: "must contain at least 32 bytes",
+		},
+		{
+			name: "more than one terminal newline",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.CurrentSecretFile = doubleNewline
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: "may contain only one terminal newline",
+		},
+		{
+			name: "NUL byte in secret",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.CurrentSecretFile = nul
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: "secret file must not contain NUL bytes",
+		},
+		{
+			name: "invalid URI SAN",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.CertificateURISAN = "not-an-absolute-uri"
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: "must be an absolute URI",
+		},
+		{
+			name: "publish wildcard",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.Permissions.Publish[0].RoutingKey = "atom-*"
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: "routing_key must be an exact value without wildcards",
+		},
+		{
+			name: "non-default publish exchange",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.Permissions.Publish[0].Exchange = "events"
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: "exchange must be empty; local principals may publish only through the AMQP default exchange",
+		},
+		{
+			name: "subscribe permissions are unsupported",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.Permissions.Subscribe = []string{"atom-audit"}
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: "subscribe is unsupported; local principals are publish-only",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Default()
+			cfg.Auth.LocalPrincipals = tt.principals()
+			err := cfg.Validate()
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("Validate() error = %v, want it to contain %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestValidateInternalAMQP091Listener(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*AMQP091ListenerConfig)
+		wantError string
+	}{
+		{
+			name:      "disabled by default",
+			configure: func(*AMQP091ListenerConfig) {},
+		},
+		{
+			name: "requires certificate",
+			configure: func(listener *AMQP091ListenerConfig) {
+				listener.Addr = ":5683"
+				listener.MaxConnections = 32
+			},
+			wantError: "server.amqp091.internal.cert_file required",
+		},
+		{
+			name: "requires client CA",
+			configure: func(listener *AMQP091ListenerConfig) {
+				listener.Addr = ":5683"
+				listener.MaxConnections = 32
+				listener.TLS.CertFile = "server.crt"
+				listener.TLS.KeyFile = "server.key"
+			},
+			wantError: "server.amqp091.internal.ca_file required",
+		},
+		{
+			name: "requires exact client auth mode",
+			configure: func(listener *AMQP091ListenerConfig) {
+				listener.Addr = ":5683"
+				listener.MaxConnections = 32
+				listener.TLS.CertFile = "server.crt"
+				listener.TLS.KeyFile = "server.key"
+				listener.TLS.ClientCAFile = "clients.crt"
+				listener.TLS.ClientAuth = "require-and-verify"
+			},
+			wantError: "server.amqp091.internal.client_auth must be \"require\"",
+		},
+		{
+			name: "requires a positive connection limit",
+			configure: func(listener *AMQP091ListenerConfig) {
+				listener.Addr = ":5683"
+				listener.TLS.CertFile = "server.crt"
+				listener.TLS.KeyFile = "server.key"
+				listener.TLS.ClientCAFile = "clients.crt"
+				listener.TLS.ClientAuth = "require"
+			},
+			wantError: "server.amqp091.internal.max_connections must be positive",
+		},
+		{
+			name: "requires a local principal",
+			configure: func(listener *AMQP091ListenerConfig) {
+				listener.Addr = ":5683"
+				listener.MaxConnections = 32
+				listener.TLS.CertFile = "server.crt"
+				listener.TLS.KeyFile = "server.key"
+				listener.TLS.ClientCAFile = "clients.crt"
+				listener.TLS.ClientAuth = "require"
+			},
+			wantError: "auth.local_principals must contain at least one principal",
+		},
+		{
+			name: "valid mandatory mTLS",
+			configure: func(listener *AMQP091ListenerConfig) {
+				listener.Addr = ":5683"
+				listener.MaxConnections = 32
+				listener.TLS.CertFile = "server.crt"
+				listener.TLS.KeyFile = "server.key"
+				listener.TLS.ClientCAFile = "clients.crt"
+				listener.TLS.ClientAuth = "require"
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Default()
+			tt.configure(&cfg.Server.AMQP091.Internal)
+			if tt.wantError == "" && cfg.Server.AMQP091.Internal.Addr != "" {
+				cfg.Auth.LocalPrincipals = []LocalPrincipalConfig{{
+					Name:              testPrincipalName,
+					CertificateURISAN: testPrincipalSAN,
+					CurrentSecretFile: writeSecret(t, t.TempDir(), "current", strings.Repeat("a", 32)),
+				}}
+			}
+			err := cfg.Validate()
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("Validate() error = %v, want it to contain %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func writeSecret(t *testing.T, dir, name, contents string) string {
+	t.Helper()
+	filename := filepath.Join(dir, name)
+	if err := os.WriteFile(filename, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+	return filename
+}

--- a/config/auth_test.go
+++ b/config/auth_test.go
@@ -269,9 +269,10 @@ func TestValidateLocalPrincipals(t *testing.T) {
 
 func TestValidateInternalAMQP091Listener(t *testing.T) {
 	tests := []struct {
-		name      string
-		configure func(*AMQP091ListenerConfig)
-		wantError string
+		name           string
+		configure      func(*AMQP091ListenerConfig)
+		clusterEnabled bool
+		wantError      string
 	}{
 		{
 			name:      "disabled by default",
@@ -331,6 +332,19 @@ func TestValidateInternalAMQP091Listener(t *testing.T) {
 			wantError: "auth.local_principals must contain at least one principal",
 		},
 		{
+			name: "rejects clustering",
+			configure: func(listener *AMQP091ListenerConfig) {
+				listener.Addr = testInternalAddr
+				listener.MaxConnections = 32
+				listener.TLS.CertFile = testServerCert
+				listener.TLS.KeyFile = testServerKey
+				listener.TLS.ClientCAFile = testClientCA
+				listener.TLS.ClientAuth = clientAuthRequire
+			},
+			clusterEnabled: true,
+			wantError:      "cannot be combined with cluster.enabled",
+		},
+		{
 			name: "valid mandatory mTLS",
 			configure: func(listener *AMQP091ListenerConfig) {
 				listener.Addr = testInternalAddr
@@ -346,8 +360,12 @@ func TestValidateInternalAMQP091Listener(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := Default()
+			// Local principals are a single-node feature, so these cases
+			// configure clustering explicitly rather than inheriting the
+			// clustered default.
+			cfg.Cluster.Enabled = tt.clusterEnabled
 			tt.configure(&cfg.Server.AMQP091.Internal)
-			if tt.wantError == "" && cfg.Server.AMQP091.Internal.Addr != "" {
+			if (tt.wantError == "" || tt.clusterEnabled) && cfg.Server.AMQP091.Internal.Addr != "" {
 				cfg.Auth.LocalPrincipals = []LocalPrincipalConfig{{
 					Name:              testPrincipalName,
 					CertificateURISAN: testPrincipalSAN,

--- a/config/auth_test.go
+++ b/config/auth_test.go
@@ -15,6 +15,11 @@ import (
 const (
 	testPrincipalName = "atom-audit-publisher"
 	testPrincipalSAN  = "spiffe://absmach/atom/audit-publisher"
+	testAuditQueue    = "atom-audit"
+	testInternalAddr  = ":5683"
+	testServerCert    = "server.crt"
+	testServerKey     = "server.key"
+	testClientCA      = "clients.crt"
 )
 
 func TestLoadNestedAuth(t *testing.T) {
@@ -67,19 +72,19 @@ auth:
 	if principal.Name != testPrincipalName || principal.CertificateURISAN != testPrincipalSAN {
 		t.Fatalf("unexpected local principal: %+v", principal)
 	}
-	if len(principal.Permissions.Publish) != 1 || principal.Permissions.Publish[0].RoutingKey != "atom-audit" {
+	if len(principal.Permissions.Publish) != 1 || principal.Permissions.Publish[0].RoutingKey != testAuditQueue {
 		t.Fatalf("unexpected publish permissions: %+v", principal.Permissions.Publish)
 	}
 }
 
 func TestLoadRejectsLegacyAuthKeys(t *testing.T) {
 	tests := map[string]string{
-		"url":                 "auth.external.url",
-		"transport":           "auth.external.transport",
-		"timeout":             "auth.external.timeout",
-		"protocols":           "auth.external.protocols",
-		"identity_cache_size": "auth.external.identity_cache_size",
-		"identity_cache_ttl":  "auth.external.identity_cache_ttl",
+		authURLField:               "auth.external.url",
+		authTransportField:         "auth.external.transport",
+		authTimeoutField:           "auth.external.timeout",
+		authProtocolsField:         "auth.external.protocols",
+		authIdentityCacheSizeField: "auth.external.identity_cache_size",
+		authIdentityCacheTTLField:  "auth.external.identity_cache_ttl",
 	}
 
 	for key, replacement := range tests {
@@ -129,7 +134,7 @@ func TestValidateLocalPrincipals(t *testing.T) {
 			CurrentSecretFile:  current,
 			PreviousSecretFile: previous,
 			Permissions: LocalPermissionsConfig{
-				Publish: []LocalPublishPermission{{Exchange: "", RoutingKey: "atom-audit"}},
+				Publish: []LocalPublishPermission{{Exchange: "", RoutingKey: testAuditQueue}},
 			},
 		}
 	}
@@ -237,7 +242,7 @@ func TestValidateLocalPrincipals(t *testing.T) {
 			name: "subscribe permissions are unsupported",
 			principals: func() []LocalPrincipalConfig {
 				principal := valid()
-				principal.Permissions.Subscribe = []string{"atom-audit"}
+				principal.Permissions.Subscribe = []string{testAuditQueue}
 				return []LocalPrincipalConfig{principal}
 			},
 			wantError: "subscribe is unsupported; local principals are publish-only",
@@ -275,7 +280,7 @@ func TestValidateInternalAMQP091Listener(t *testing.T) {
 		{
 			name: "requires certificate",
 			configure: func(listener *AMQP091ListenerConfig) {
-				listener.Addr = ":5683"
+				listener.Addr = testInternalAddr
 				listener.MaxConnections = 32
 			},
 			wantError: "server.amqp091.internal.cert_file required",
@@ -283,21 +288,21 @@ func TestValidateInternalAMQP091Listener(t *testing.T) {
 		{
 			name: "requires client CA",
 			configure: func(listener *AMQP091ListenerConfig) {
-				listener.Addr = ":5683"
+				listener.Addr = testInternalAddr
 				listener.MaxConnections = 32
-				listener.TLS.CertFile = "server.crt"
-				listener.TLS.KeyFile = "server.key"
+				listener.TLS.CertFile = testServerCert
+				listener.TLS.KeyFile = testServerKey
 			},
 			wantError: "server.amqp091.internal.ca_file required",
 		},
 		{
 			name: "requires exact client auth mode",
 			configure: func(listener *AMQP091ListenerConfig) {
-				listener.Addr = ":5683"
+				listener.Addr = testInternalAddr
 				listener.MaxConnections = 32
-				listener.TLS.CertFile = "server.crt"
-				listener.TLS.KeyFile = "server.key"
-				listener.TLS.ClientCAFile = "clients.crt"
+				listener.TLS.CertFile = testServerCert
+				listener.TLS.KeyFile = testServerKey
+				listener.TLS.ClientCAFile = testClientCA
 				listener.TLS.ClientAuth = "require-and-verify"
 			},
 			wantError: "server.amqp091.internal.client_auth must be \"require\"",
@@ -305,35 +310,35 @@ func TestValidateInternalAMQP091Listener(t *testing.T) {
 		{
 			name: "requires a positive connection limit",
 			configure: func(listener *AMQP091ListenerConfig) {
-				listener.Addr = ":5683"
-				listener.TLS.CertFile = "server.crt"
-				listener.TLS.KeyFile = "server.key"
-				listener.TLS.ClientCAFile = "clients.crt"
-				listener.TLS.ClientAuth = "require"
+				listener.Addr = testInternalAddr
+				listener.TLS.CertFile = testServerCert
+				listener.TLS.KeyFile = testServerKey
+				listener.TLS.ClientCAFile = testClientCA
+				listener.TLS.ClientAuth = clientAuthRequire
 			},
 			wantError: "server.amqp091.internal.max_connections must be positive",
 		},
 		{
 			name: "requires a local principal",
 			configure: func(listener *AMQP091ListenerConfig) {
-				listener.Addr = ":5683"
+				listener.Addr = testInternalAddr
 				listener.MaxConnections = 32
-				listener.TLS.CertFile = "server.crt"
-				listener.TLS.KeyFile = "server.key"
-				listener.TLS.ClientCAFile = "clients.crt"
-				listener.TLS.ClientAuth = "require"
+				listener.TLS.CertFile = testServerCert
+				listener.TLS.KeyFile = testServerKey
+				listener.TLS.ClientCAFile = testClientCA
+				listener.TLS.ClientAuth = clientAuthRequire
 			},
 			wantError: "auth.local_principals must contain at least one principal",
 		},
 		{
 			name: "valid mandatory mTLS",
 			configure: func(listener *AMQP091ListenerConfig) {
-				listener.Addr = ":5683"
+				listener.Addr = testInternalAddr
 				listener.MaxConnections = 32
-				listener.TLS.CertFile = "server.crt"
-				listener.TLS.KeyFile = "server.key"
-				listener.TLS.ClientCAFile = "clients.crt"
-				listener.TLS.ClientAuth = "require"
+				listener.TLS.CertFile = testServerCert
+				listener.TLS.KeyFile = testServerKey
+				listener.TLS.ClientCAFile = testClientCA
+				listener.TLS.ClientAuth = clientAuthRequire
 			},
 		},
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,9 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -22,8 +24,9 @@ const (
 	listenerNamePlain = "plain"
 	raftGroupDefault  = "default"
 
-	listenerNameTLS  = "tls"
-	listenerNameMTLS = "mtls"
+	listenerNameTLS      = "tls"
+	listenerNameMTLS     = "mtls"
+	listenerNameInternal = "internal"
 
 	protocolMQTT    = "mqtt"
 	protocolAMQP    = "amqp"
@@ -61,8 +64,14 @@ type Config struct {
 	Hooks        HooksConfig        `yaml:"hooks"`
 }
 
-// AuthConfig configures the external authentication/authorization callout.
+// AuthConfig configures external callouts and broker-local principals.
 type AuthConfig struct {
+	External        ExternalAuthConfig     `yaml:"external"`
+	LocalPrincipals []LocalPrincipalConfig `yaml:"local_principals"`
+}
+
+// ExternalAuthConfig configures the external authentication/authorization callout.
+type ExternalAuthConfig struct {
 	// URL is the auth service address (e.g. "http://localhost:9090").
 	// When empty, auth callout is disabled.
 	URL string `yaml:"url"`
@@ -81,6 +90,124 @@ type AuthConfig struct {
 	// IdentityCacheTTL bounds how long a cached identity may live without re-auth.
 	// Zero or negative disables TTL eviction.
 	IdentityCacheTTL time.Duration `yaml:"identity_cache_ttl"`
+}
+
+// LocalPrincipalConfig configures a principal authenticated by FluxMQ itself.
+type LocalPrincipalConfig struct {
+	Name               string                 `yaml:"name"`
+	CertificateURISAN  string                 `yaml:"certificate_uri_san"`
+	CurrentSecretFile  string                 `yaml:"current_secret_file"`
+	PreviousSecretFile string                 `yaml:"previous_secret_file,omitempty"`
+	Permissions        LocalPermissionsConfig `yaml:"permissions"`
+}
+
+// LocalPermissionsConfig contains exact-match publish and subscribe ACLs.
+type LocalPermissionsConfig struct {
+	Publish   []LocalPublishPermission `yaml:"publish"`
+	Subscribe []string                 `yaml:"subscribe"`
+}
+
+// LocalPublishPermission grants publish access to one exact AMQP target.
+type LocalPublishPermission struct {
+	Exchange   string `yaml:"exchange"`
+	RoutingKey string `yaml:"routing_key"`
+}
+
+// UnmarshalYAML keeps the auth subtree strict without changing the historical
+// permissive decoding behavior of unrelated configuration sections.
+func (a *AuthConfig) UnmarshalYAML(node *yaml.Node) error {
+	if err := validateAuthYAML(node); err != nil {
+		return err
+	}
+	type plainAuthConfig AuthConfig
+	var decoded plainAuthConfig
+	if err := node.Decode(&decoded); err != nil {
+		return err
+	}
+	*a = AuthConfig(decoded)
+	return nil
+}
+
+func validateAuthYAML(node *yaml.Node) error {
+	return validateYAMLMapping(node, "auth", map[string]func(*yaml.Node) error{
+		"external": func(external *yaml.Node) error {
+			return validateYAMLMapping(external, "auth.external", map[string]func(*yaml.Node) error{
+				"url":                 nil,
+				"transport":           nil,
+				"timeout":             nil,
+				"protocols":           nil,
+				"identity_cache_size": nil,
+				"identity_cache_ttl":  nil,
+			})
+		},
+		"local_principals": func(principals *yaml.Node) error {
+			return validateYAMLSequence(principals, "auth.local_principals", validateLocalPrincipalYAML)
+		},
+	})
+}
+
+func validateLocalPrincipalYAML(node *yaml.Node, path string) error {
+	return validateYAMLMapping(node, path, map[string]func(*yaml.Node) error{
+		"name":                 nil,
+		"certificate_uri_san":  nil,
+		"current_secret_file":  nil,
+		"previous_secret_file": nil,
+		"permissions": func(permissions *yaml.Node) error {
+			return validateYAMLMapping(permissions, path+".permissions", map[string]func(*yaml.Node) error{
+				"publish": func(publish *yaml.Node) error {
+					return validateYAMLSequence(publish, path+".permissions.publish", func(entry *yaml.Node, entryPath string) error {
+						return validateYAMLMapping(entry, entryPath, map[string]func(*yaml.Node) error{
+							"exchange":    nil,
+							"routing_key": nil,
+						})
+					})
+				},
+				"subscribe": func(subscribe *yaml.Node) error {
+					return validateYAMLSequence(subscribe, path+".permissions.subscribe", nil)
+				},
+			})
+		},
+	})
+}
+
+func validateYAMLMapping(node *yaml.Node, path string, fields map[string]func(*yaml.Node) error) error {
+	if node.Tag == "!!null" {
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("%s must be a mapping", path)
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		name := node.Content[i].Value
+		validate, ok := fields[name]
+		if !ok {
+			return fmt.Errorf("%s: field %s not found", path, name)
+		}
+		if validate != nil {
+			if err := validate(node.Content[i+1]); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func validateYAMLSequence(node *yaml.Node, path string, validate func(*yaml.Node, string) error) error {
+	if node.Tag == "!!null" {
+		return nil
+	}
+	if node.Kind != yaml.SequenceNode {
+		return fmt.Errorf("%s must be a sequence", path)
+	}
+	if validate == nil {
+		return nil
+	}
+	for i, entry := range node.Content {
+		if err := validate(entry, fmt.Sprintf("%s[%d]", path, i)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // HooksConfig configures the optional blocking hook callout.
@@ -114,10 +241,10 @@ var knownBlockingHooks = map[string]bool{
 	"auth_on_unsubscribe": true,
 }
 
-// AuthEnabledFor reports whether auth callout is enabled for the given protocol.
+// EnabledFor reports whether the external auth callout is enabled for the given protocol.
 // Returns true when auth is globally enabled (URL is set) and either no per-protocol
 // filter is configured or the protocol is explicitly set to true.
-func (a AuthConfig) AuthEnabledFor(protocol string) bool {
+func (a ExternalAuthConfig) EnabledFor(protocol string) bool {
 	if a.URL == "" {
 		return false
 	}
@@ -351,9 +478,10 @@ type AMQP091ListenerConfig struct {
 
 // AMQP091Config groups AMQP 0.9.1 listeners by mode.
 type AMQP091Config struct {
-	Plain AMQP091ListenerConfig `yaml:"plain"`
-	TLS   AMQP091ListenerConfig `yaml:"tls"`
-	MTLS  AMQP091ListenerConfig `yaml:"mtls"`
+	Plain    AMQP091ListenerConfig `yaml:"plain"`
+	TLS      AMQP091ListenerConfig `yaml:"tls"`
+	MTLS     AMQP091ListenerConfig `yaml:"mtls"`
+	Internal AMQP091ListenerConfig `yaml:"internal"`
 }
 
 // DefaultMaxInflightMessages is the fallback for Session.MaxInflightMessages
@@ -703,6 +831,7 @@ func Default() *Config {
 				MTLS: AMQP091ListenerConfig{
 					MaxConnections: 10000,
 				},
+				Internal: AMQP091ListenerConfig{},
 			},
 			HealthAddr:      ":8081",
 			HealthEnabled:   true,
@@ -873,6 +1002,10 @@ func Load(filename string) (*Config, error) {
 	}
 
 	cfg := Default()
+	if err := rejectLegacyAuthKeys(data); err != nil {
+		return nil, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
 	if err := yaml.Unmarshal(data, cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
@@ -882,6 +1015,47 @@ func Load(filename string) (*Config, error) {
 	}
 
 	return cfg, nil
+}
+
+var legacyAuthKeys = map[string]string{
+	"url":                 "auth.external.url",
+	"transport":           "auth.external.transport",
+	"timeout":             "auth.external.timeout",
+	"protocols":           "auth.external.protocols",
+	"identity_cache_size": "auth.external.identity_cache_size",
+	"identity_cache_ttl":  "auth.external.identity_cache_ttl",
+}
+
+func rejectLegacyAuthKeys(data []byte) error {
+	var document yaml.Node
+	if err := yaml.Unmarshal(data, &document); err != nil {
+		return err
+	}
+	if len(document.Content) == 0 {
+		return nil
+	}
+
+	root := document.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value != "auth" {
+			continue
+		}
+		auth := root.Content[i+1]
+		if auth.Kind != yaml.MappingNode {
+			return nil
+		}
+		for j := 0; j+1 < len(auth.Content); j += 2 {
+			key := auth.Content[j].Value
+			if replacement, ok := legacyAuthKeys[key]; ok {
+				return fmt.Errorf("auth.%s is no longer supported; use %s", key, replacement)
+			}
+		}
+		return nil
+	}
+	return nil
 }
 
 // Validate checks if the configuration is valid.
@@ -922,7 +1096,7 @@ func (c *Config) Validate() error {
 		{name: listenerNameMTLS, cfg: c.Server.HTTP.MTLS, requireClientAuth: true},
 	}
 
-	hasMQTTListener := false
+	hasMessagingListener := false
 
 	for _, slot := range tcpSlots {
 		if err := validateListenerProtocol("server.tcp."+slot.name+".protocol", slot.cfg.Protocol); err != nil {
@@ -939,7 +1113,7 @@ func (c *Config) Validate() error {
 			continue
 		}
 
-		hasMQTTListener = true
+		hasMessagingListener = true
 		if slot.cfg.MaxConnections < 0 {
 			return fmt.Errorf("server.tcp.%s.max_connections cannot be negative", slot.name)
 		}
@@ -967,7 +1141,7 @@ func (c *Config) Validate() error {
 			continue
 		}
 
-		hasMQTTListener = true
+		hasMessagingListener = true
 		if slot.requireTLS {
 			if err := validateListenerTLS("server.websocket."+slot.name, slot.cfg.TLS, slot.requireClientAuth); err != nil {
 				return err
@@ -975,10 +1149,6 @@ func (c *Config) Validate() error {
 		} else if tlsConfigured(slot.cfg.TLS) {
 			return fmt.Errorf("server.websocket.%s TLS fields are not supported for non-TLS listeners", slot.name)
 		}
-	}
-
-	if !hasMQTTListener {
-		return fmt.Errorf("at least one TCP or WebSocket listener must be configured")
 	}
 
 	c.Server.AdminAPIAddr = strings.TrimSpace(c.Server.AdminAPIAddr)
@@ -993,6 +1163,7 @@ func (c *Config) Validate() error {
 			}
 			continue
 		}
+		hasMessagingListener = true
 
 		if slot.name == listenerNamePlain && tlsConfigured(slot.cfg.TLS) {
 			return fmt.Errorf("server.http.%s TLS fields are not supported for plain listeners", slot.name)
@@ -1021,6 +1192,7 @@ func (c *Config) Validate() error {
 			}
 			continue
 		}
+		hasMessagingListener = true
 
 		if slot.name == listenerNamePlain && tlsConfigured(slot.cfg.TLS) {
 			return fmt.Errorf("server.coap.%s TLS fields are not supported for plain listeners", slot.name)
@@ -1050,6 +1222,7 @@ func (c *Config) Validate() error {
 			}
 			continue
 		}
+		hasMessagingListener = true
 
 		if slot.cfg.MaxConnections < 0 {
 			return fmt.Errorf("server.amqp.%s.max_connections cannot be negative", slot.name)
@@ -1066,13 +1239,15 @@ func (c *Config) Validate() error {
 
 	// AMQP 0.9.1 validation
 	amqp091Slots := []struct {
-		name              string
-		cfg               AMQP091ListenerConfig
-		requireClientAuth bool
+		name                   string
+		cfg                    AMQP091ListenerConfig
+		requireClientAuth      bool
+		requireExactClientAuth bool
 	}{
 		{name: listenerNamePlain, cfg: c.Server.AMQP091.Plain, requireClientAuth: false},
 		{name: listenerNameTLS, cfg: c.Server.AMQP091.TLS, requireClientAuth: false},
 		{name: listenerNameMTLS, cfg: c.Server.AMQP091.MTLS, requireClientAuth: true},
+		{name: listenerNameInternal, cfg: c.Server.AMQP091.Internal, requireClientAuth: true, requireExactClientAuth: true},
 	}
 
 	for _, slot := range amqp091Slots {
@@ -1082,7 +1257,11 @@ func (c *Config) Validate() error {
 			}
 			continue
 		}
+		hasMessagingListener = true
 
+		if slot.name == listenerNameInternal && slot.cfg.MaxConnections <= 0 {
+			return fmt.Errorf("server.amqp091.%s.max_connections must be positive", slot.name)
+		}
 		if slot.cfg.MaxConnections < 0 {
 			return fmt.Errorf("server.amqp091.%s.max_connections cannot be negative", slot.name)
 		}
@@ -1093,13 +1272,25 @@ func (c *Config) Validate() error {
 			if err := validateListenerTLS("server.amqp091."+slot.name, slot.cfg.TLS, slot.requireClientAuth); err != nil {
 				return err
 			}
+			if slot.requireExactClientAuth && strings.ToLower(strings.TrimSpace(slot.cfg.TLS.ClientAuth)) != "require" {
+				return fmt.Errorf("server.amqp091.%s.client_auth must be \"require\"", slot.name)
+			}
 		}
 	}
+	if !hasMessagingListener {
+		return fmt.Errorf("at least one messaging listener must be configured")
+	}
 
-	for proto := range c.Auth.Protocols {
+	for proto := range c.Auth.External.Protocols {
 		if !knownAuthProtocols[proto] {
-			return fmt.Errorf("auth.protocols: unknown protocol %q (valid: mqtt, amqp, amqp091, http, coap)", proto)
+			return fmt.Errorf("auth.external.protocols: unknown protocol %q (valid: mqtt, amqp, amqp091, http, coap)", proto)
 		}
+	}
+	if err := validateLocalPrincipals(c.Auth.LocalPrincipals); err != nil {
+		return err
+	}
+	if hasAddr(c.Server.AMQP091.Internal.Addr) && len(c.Auth.LocalPrincipals) == 0 {
+		return fmt.Errorf("auth.local_principals must contain at least one principal when server.amqp091.internal.addr is configured")
 	}
 	for proto := range c.Hooks.Protocols {
 		if !knownAuthProtocols[proto] {
@@ -1392,6 +1583,120 @@ func validateListenerTLS(prefix string, cfg mqtttls.Config, requireCA bool) erro
 		return fmt.Errorf("%s.ca_file required", prefix)
 	}
 	return nil
+}
+
+func validateLocalPrincipals(principals []LocalPrincipalConfig) error {
+	names := make(map[string]struct{}, len(principals))
+	uriSANs := make(map[string]struct{}, len(principals))
+
+	for i, principal := range principals {
+		prefix := fmt.Sprintf("auth.local_principals[%d]", i)
+		name := strings.TrimSpace(principal.Name)
+		if name == "" {
+			return fmt.Errorf("%s.name cannot be empty", prefix)
+		}
+		if name != principal.Name {
+			return fmt.Errorf("%s.name cannot have leading or trailing whitespace", prefix)
+		}
+		if _, exists := names[name]; exists {
+			return fmt.Errorf("%s.name %q is duplicated", prefix, name)
+		}
+		names[name] = struct{}{}
+
+		uriSAN := strings.TrimSpace(principal.CertificateURISAN)
+		if uriSAN == "" {
+			return fmt.Errorf("%s.certificate_uri_san cannot be empty", prefix)
+		}
+		if uriSAN != principal.CertificateURISAN {
+			return fmt.Errorf("%s.certificate_uri_san cannot have leading or trailing whitespace", prefix)
+		}
+		parsedURI, err := url.Parse(uriSAN)
+		if err != nil || parsedURI.Scheme == "" {
+			return fmt.Errorf("%s.certificate_uri_san must be an absolute URI", prefix)
+		}
+		if _, exists := uriSANs[uriSAN]; exists {
+			return fmt.Errorf("%s.certificate_uri_san %q is duplicated", prefix, uriSAN)
+		}
+		uriSANs[uriSAN] = struct{}{}
+
+		if err := validateLocalSecretFile(prefix+".current_secret_file", principal.CurrentSecretFile, true); err != nil {
+			return err
+		}
+		if err := validateLocalSecretFile(prefix+".previous_secret_file", principal.PreviousSecretFile, false); err != nil {
+			return err
+		}
+
+		publishTargets := make(map[LocalPublishPermission]struct{}, len(principal.Permissions.Publish))
+		for j, permission := range principal.Permissions.Publish {
+			permissionPrefix := fmt.Sprintf("%s.permissions.publish[%d]", prefix, j)
+			if permission.Exchange != "" {
+				return fmt.Errorf("%s.exchange must be empty; local principals may publish only through the AMQP default exchange", permissionPrefix)
+			}
+			if permission.RoutingKey == "" {
+				return fmt.Errorf("%s.routing_key cannot be empty", permissionPrefix)
+			}
+			if containsWildcard(permission.Exchange) {
+				return fmt.Errorf("%s.exchange must be an exact value without wildcards", permissionPrefix)
+			}
+			if containsWildcard(permission.RoutingKey) {
+				return fmt.Errorf("%s.routing_key must be an exact value without wildcards", permissionPrefix)
+			}
+			if _, exists := publishTargets[permission]; exists {
+				return fmt.Errorf("%s duplicates an earlier publish permission", permissionPrefix)
+			}
+			publishTargets[permission] = struct{}{}
+		}
+
+		if len(principal.Permissions.Subscribe) != 0 {
+			return fmt.Errorf("%s.permissions.subscribe is unsupported; local principals are publish-only", prefix)
+		}
+	}
+
+	return nil
+}
+
+func validateLocalSecretFile(field, filename string, required bool) error {
+	if strings.TrimSpace(filename) == "" {
+		if required || filename != "" {
+			return fmt.Errorf("%s cannot be empty", field)
+		}
+		return nil
+	}
+
+	secret, err := readLocalSecretFile(filename)
+	if err != nil {
+		return fmt.Errorf("%s: %w", field, err)
+	}
+	defer clear(secret)
+	if len(secret) < 32 {
+		return fmt.Errorf("%s must contain at least 32 bytes", field)
+	}
+	return nil
+}
+
+func readLocalSecretFile(filename string) ([]byte, error) {
+	secret, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read secret file: %w", err)
+	}
+	if len(secret) > 0 && secret[len(secret)-1] == '\n' {
+		secret = secret[:len(secret)-1]
+		if len(secret) > 0 && secret[len(secret)-1] == '\r' {
+			secret = secret[:len(secret)-1]
+		}
+	}
+	if bytes.ContainsAny(secret, "\r\n") {
+		return nil, fmt.Errorf("secret file may contain only one terminal newline")
+	}
+	if bytes.IndexByte(secret, 0) >= 0 {
+		clear(secret)
+		return nil, fmt.Errorf("secret file must not contain NUL bytes")
+	}
+	return secret, nil
+}
+
+func containsWildcard(value string) bool {
+	return strings.ContainsAny(value, "#*+")
 }
 
 // NormalizeProtocolMode normalizes and defaults MQTT listener protocol mode.

--- a/config/config.go
+++ b/config/config.go
@@ -1294,7 +1294,7 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("auth.external.protocols: unknown protocol %q (valid: mqtt, amqp, amqp091, http, coap)", proto)
 		}
 	}
-	if err := validateLocalPrincipals(c.Auth.LocalPrincipals); err != nil {
+	if err := ValidateLocalPrincipals(c.Auth.LocalPrincipals); err != nil {
 		return err
 	}
 	if hasAddr(c.Server.AMQP091.Internal.Addr) && len(c.Auth.LocalPrincipals) == 0 {
@@ -1593,7 +1593,12 @@ func validateListenerTLS(prefix string, cfg mqtttls.Config, requireCA bool) erro
 	return nil
 }
 
-func validateLocalPrincipals(principals []LocalPrincipalConfig) error {
+// ValidateLocalPrincipals checks the declarative rules for local principals:
+// unique non-blank names and absolute URI SANs, readable high-entropy secret
+// files, and exact publish-only permissions. It is the single definition of
+// those rules, shared with the runtime store that loads the same section, so
+// startup validation and a SIGHUP reload cannot drift apart.
+func ValidateLocalPrincipals(principals []LocalPrincipalConfig) error {
 	names := make(map[string]struct{}, len(principals))
 	uriSANs := make(map[string]struct{}, len(principals))
 

--- a/config/config.go
+++ b/config/config.go
@@ -1297,8 +1297,19 @@ func (c *Config) Validate() error {
 	if err := ValidateLocalPrincipals(c.Auth.LocalPrincipals); err != nil {
 		return err
 	}
-	if hasAddr(c.Server.AMQP091.Internal.Addr) && len(c.Auth.LocalPrincipals) == 0 {
-		return fmt.Errorf("auth.local_principals must contain at least one principal when server.amqp091.internal.addr is configured")
+	if hasAddr(c.Server.AMQP091.Internal.Addr) {
+		if len(c.Auth.LocalPrincipals) == 0 {
+			return fmt.Errorf("auth.local_principals must contain at least one principal when server.amqp091.internal.addr is configured")
+		}
+		// A local publication is appended and synced on the receiving node only,
+		// and is deliberately never forwarded to other nodes: forwarding would
+		// acknowledge a publisher on a barrier no single node established. In a
+		// cluster that makes the records unreachable from consumers attached
+		// elsewhere, with nothing to signal it, so refuse the combination rather
+		// than serve a listener whose records only some readers can see.
+		if c.Cluster.Enabled {
+			return fmt.Errorf("server.amqp091.internal.addr cannot be combined with cluster.enabled: local-principal publications are durable on the receiving node only and are not forwarded to other nodes; run the internal listener on a single-node deployment")
+		}
 	}
 	for proto := range c.Hooks.Protocols {
 		if !knownAuthProtocols[proto] {

--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,14 @@ const (
 
 	writePolicyForward = "forward"
 	queueModeSync      = "sync"
+
+	authURLField               = "url"
+	authTransportField         = "transport"
+	authTimeoutField           = "timeout"
+	authProtocolsField         = "protocols"
+	authIdentityCacheSizeField = "identity_cache_size"
+	authIdentityCacheTTLField  = "identity_cache_ttl"
+	clientAuthRequire          = "require"
 )
 
 // Config holds all configuration for the MQTT broker.
@@ -132,12 +140,12 @@ func validateAuthYAML(node *yaml.Node) error {
 	return validateYAMLMapping(node, "auth", map[string]func(*yaml.Node) error{
 		"external": func(external *yaml.Node) error {
 			return validateYAMLMapping(external, "auth.external", map[string]func(*yaml.Node) error{
-				"url":                 nil,
-				"transport":           nil,
-				"timeout":             nil,
-				"protocols":           nil,
-				"identity_cache_size": nil,
-				"identity_cache_ttl":  nil,
+				authURLField:               nil,
+				authTransportField:         nil,
+				authTimeoutField:           nil,
+				authProtocolsField:         nil,
+				authIdentityCacheSizeField: nil,
+				authIdentityCacheTTLField:  nil,
 			})
 		},
 		"local_principals": func(principals *yaml.Node) error {
@@ -1018,12 +1026,12 @@ func Load(filename string) (*Config, error) {
 }
 
 var legacyAuthKeys = map[string]string{
-	"url":                 "auth.external.url",
-	"transport":           "auth.external.transport",
-	"timeout":             "auth.external.timeout",
-	"protocols":           "auth.external.protocols",
-	"identity_cache_size": "auth.external.identity_cache_size",
-	"identity_cache_ttl":  "auth.external.identity_cache_ttl",
+	authURLField:               "auth.external.url",
+	authTransportField:         "auth.external.transport",
+	authTimeoutField:           "auth.external.timeout",
+	authProtocolsField:         "auth.external.protocols",
+	authIdentityCacheSizeField: "auth.external.identity_cache_size",
+	authIdentityCacheTTLField:  "auth.external.identity_cache_ttl",
 }
 
 func rejectLegacyAuthKeys(data []byte) error {
@@ -1272,7 +1280,7 @@ func (c *Config) Validate() error {
 			if err := validateListenerTLS("server.amqp091."+slot.name, slot.cfg.TLS, slot.requireClientAuth); err != nil {
 				return err
 			}
-			if slot.requireExactClientAuth && strings.ToLower(strings.TrimSpace(slot.cfg.TLS.ClientAuth)) != "require" {
+			if slot.requireExactClientAuth && strings.ToLower(strings.TrimSpace(slot.cfg.TLS.ClientAuth)) != clientAuthRequire {
 				return fmt.Errorf("server.amqp091.%s.client_auth must be \"require\"", slot.name)
 			}
 		}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,7 +4,9 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -79,18 +81,18 @@ func TestValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "no MQTT listeners configured",
-			modify: func(c *Config) {
-				c.Server.TCP.V3.Addr = ""
-				c.Server.TCP.V5.Addr = ""
-				c.Server.TCP.TLS.Addr = ""
-				c.Server.TCP.MTLS.Addr = ""
-				c.Server.WebSocket.V3.Addr = ""
-				c.Server.WebSocket.V5.Addr = ""
-				c.Server.WebSocket.TLS.Addr = ""
-				c.Server.WebSocket.MTLS.Addr = ""
-			},
+			name:    "no messaging listeners configured",
+			modify:  disableMessagingListeners,
 			wantErr: true,
+		},
+		{
+			name: "AMQP 0.9.1-only deployment is valid",
+			modify: func(c *Config) {
+				disableMessagingListeners(c)
+				c.Server.AMQP091.Plain.Addr = ":5682"
+				c.Server.AMQP091.Plain.MaxConnections = 100
+			},
+			wantErr: false,
 		},
 		{
 			name: "TCP TLS listener without cert",
@@ -200,16 +202,16 @@ func TestValidate(t *testing.T) {
 		{
 			name: "valid auth protocols",
 			modify: func(c *Config) {
-				c.Auth.URL = testAuthURL
-				c.Auth.Protocols = map[string]bool{protocolMQTT: true, protocolAMQP091: false}
+				c.Auth.External.URL = testAuthURL
+				c.Auth.External.Protocols = map[string]bool{protocolMQTT: true, protocolAMQP091: false}
 			},
 			wantErr: false,
 		},
 		{
 			name: "unknown auth protocol",
 			modify: func(c *Config) {
-				c.Auth.URL = testAuthURL
-				c.Auth.Protocols = map[string]bool{protocolMQTT: true, "websocket": true}
+				c.Auth.External.URL = testAuthURL
+				c.Auth.External.Protocols = map[string]bool{protocolMQTT: true, "websocket": true}
 			},
 			wantErr: true,
 		},
@@ -259,6 +261,30 @@ func TestValidate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func disableMessagingListeners(c *Config) {
+	c.Server.TCP.V3.Addr = ""
+	c.Server.TCP.V5.Addr = ""
+	c.Server.TCP.TLS.Addr = ""
+	c.Server.TCP.MTLS.Addr = ""
+	c.Server.WebSocket.V3.Addr = ""
+	c.Server.WebSocket.V5.Addr = ""
+	c.Server.WebSocket.TLS.Addr = ""
+	c.Server.WebSocket.MTLS.Addr = ""
+	c.Server.HTTP.Plain.Addr = ""
+	c.Server.HTTP.TLS.Addr = ""
+	c.Server.HTTP.MTLS.Addr = ""
+	c.Server.CoAP.Plain.Addr = ""
+	c.Server.CoAP.DTLS.Addr = ""
+	c.Server.CoAP.MDTLS.Addr = ""
+	c.Server.AMQP.Plain.Addr = ""
+	c.Server.AMQP.TLS.Addr = ""
+	c.Server.AMQP.MTLS.Addr = ""
+	c.Server.AMQP091.Plain.Addr = ""
+	c.Server.AMQP091.TLS.Addr = ""
+	c.Server.AMQP091.MTLS.Addr = ""
+	c.Server.AMQP091.Internal.Addr = ""
 }
 
 func TestLoadNonExistent(t *testing.T) {
@@ -314,40 +340,40 @@ func TestSaveLoad(t *testing.T) {
 	}
 }
 
-func TestAuthEnabledFor(t *testing.T) {
+func TestExternalAuthEnabledFor(t *testing.T) {
 	tests := []struct {
 		name     string
-		cfg      AuthConfig
+		cfg      ExternalAuthConfig
 		protocol string
 		want     bool
 	}{
 		{
 			name:     "no URL disables all",
-			cfg:      AuthConfig{},
+			cfg:      ExternalAuthConfig{},
 			protocol: protocolMQTT,
 			want:     false,
 		},
 		{
 			name:     "URL set, empty protocols enables all",
-			cfg:      AuthConfig{URL: testAuthURL},
+			cfg:      ExternalAuthConfig{URL: testAuthURL},
 			protocol: protocolAMQP091,
 			want:     true,
 		},
 		{
 			name:     "protocol explicitly enabled",
-			cfg:      AuthConfig{URL: testAuthURL, Protocols: map[string]bool{protocolMQTT: true, protocolAMQP091: false}},
+			cfg:      ExternalAuthConfig{URL: testAuthURL, Protocols: map[string]bool{protocolMQTT: true, protocolAMQP091: false}},
 			protocol: protocolMQTT,
 			want:     true,
 		},
 		{
 			name:     "protocol explicitly disabled",
-			cfg:      AuthConfig{URL: testAuthURL, Protocols: map[string]bool{protocolMQTT: true, protocolAMQP091: false}},
+			cfg:      ExternalAuthConfig{URL: testAuthURL, Protocols: map[string]bool{protocolMQTT: true, protocolAMQP091: false}},
 			protocol: protocolAMQP091,
 			want:     false,
 		},
 		{
 			name:     "protocol not in map defaults to false",
-			cfg:      AuthConfig{URL: testAuthURL, Protocols: map[string]bool{protocolMQTT: true}},
+			cfg:      ExternalAuthConfig{URL: testAuthURL, Protocols: map[string]bool{protocolMQTT: true}},
 			protocol: "amqp",
 			want:     false,
 		},
@@ -355,8 +381,8 @@ func TestAuthEnabledFor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.cfg.AuthEnabledFor(tt.protocol); got != tt.want {
-				t.Fatalf("AuthEnabledFor(%q) = %v, want %v", tt.protocol, got, tt.want)
+			if got := tt.cfg.EnabledFor(tt.protocol); got != tt.want {
+				t.Fatalf("EnabledFor(%q) = %v, want %v", tt.protocol, got, tt.want)
 			}
 		})
 	}
@@ -421,7 +447,23 @@ func TestExampleConfigsValid(t *testing.T) {
 
 	for _, f := range files {
 		t.Run(filepath.Base(f), func(t *testing.T) {
-			if _, err := Load(f); err != nil {
+			loadPath := f
+			contents, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read example %s: %v", f, err)
+			}
+			if strings.Contains(string(contents), "/run/secrets/atom_audit_secret_") {
+				dir := t.TempDir()
+				current := writeSecret(t, dir, "current", strings.Repeat("a", 32))
+				previous := writeSecret(t, dir, "previous", strings.Repeat("b", 32))
+				rewritten := strings.ReplaceAll(string(contents), "/run/secrets/atom_audit_secret_current", current)
+				rewritten = strings.ReplaceAll(rewritten, "/run/secrets/atom_audit_secret_previous", previous)
+				loadPath = filepath.Join(dir, filepath.Base(f))
+				if err := os.WriteFile(loadPath, []byte(rewritten), 0o600); err != nil {
+					t.Fatalf("write rewritten example: %v", err)
+				}
+			}
+			if _, err := Load(loadPath); err != nil {
 				t.Fatalf("Load(%s): %v", f, err)
 			}
 		})

--- a/config/diff.go
+++ b/config/diff.go
@@ -99,6 +99,11 @@ var runtimeSafeFields = map[string]struct{}{
 	"Webhook.Defaults.CircuitBreaker.FailureThreshold": {},
 	"Webhook.Defaults.CircuitBreaker.ResetTimeout":     {},
 	"Webhook.Endpoints":                                {},
+
+	// Local principals and their ACL/secret-file references are swapped as one
+	// validated immutable snapshot. Listener and external-callout changes still
+	// require a restart.
+	"Auth.LocalPrincipals": {},
 }
 
 // fieldClassification maps each leaf config field path to its reload

--- a/config/diff_test.go
+++ b/config/diff_test.go
@@ -162,8 +162,8 @@ func TestDiffRestartRequiredFields(t *testing.T) {
 		},
 		{
 			name:   "auth url",
-			modify: func(cfg *Config) { cfg.Auth.URL = "http://auth:9090" },
-			path:   "Auth.URL",
+			modify: func(cfg *Config) { cfg.Auth.External.URL = "http://auth:9090" },
+			path:   "Auth.External.URL",
 		},
 		{
 			name:   "broker async fanout",

--- a/deployments/docker/README.md
+++ b/deployments/docker/README.md
@@ -49,6 +49,86 @@ FLUXMQ_API_URL=http://my-broker:8082
 FLUXMQ_NODE_URLS=http://my-broker:8082
 ```
 
+## Dedicated local-principal AMQP listener
+
+`compose.local-principal.yaml` is a production-shaped overlay for an Atom audit
+publisher. It keeps remote AMQP over TLS on port `5682`, enables an mTLS-only
+internal listener on container port `5683`, explicitly disables FluxMQ's
+otherwise-default MQTT, WebSocket, and AMQP 1.0 listeners, mounts local
+credentials as Docker secrets, and pre-provisions the `atom-audit` stream.
+
+The overlay requires Docker Compose 2.24.4 or newer because it uses
+`!override` to remove the base file's unused host port mappings.
+
+FluxMQ's native admin API is a privileged, unauthenticated control plane. This
+overlay deliberately does not publish port `8082` to the host; the inherited
+dashboard can still reach `fluxmq:8082` over the default Compose network. Keep
+that network trusted. If operators need remote admin access, place the API on
+a dedicated management network behind an authenticated mTLS reverse proxy or
+equivalent access control. Do not add a public `8082:8082` mapping.
+
+`fluxmq-auth` is a required external dependency for the remote listener. This
+example intentionally does not invent or pin an auth-service image. Before
+starting FluxMQ, provide the real service at the URL configured in
+`config-local-principal.yaml` (the default example name is
+`https://fluxmq-auth:8181`). The callout hop must use trusted HTTPS, mTLS, or a
+service mesh that supplies equivalent authenticated transport protection. The
+built-in callout client uses the container's system trust store for HTTPS and
+does not expose client-certificate fields. If mTLS is required, terminate it in
+a service-mesh sidecar and point FluxMQ at that protected loopback endpoint.
+If `fluxmq-auth` is a container, attach it to the Compose project's default
+network with the `fluxmq-auth` alias. Do not carry credentials over
+unprotected HTTP between hosts.
+
+Set each variable to an absolute host path:
+
+```bash
+export FLUXMQ_SERVER_CERT_FILE=/secure/fluxmq/server.crt
+export FLUXMQ_SERVER_KEY_FILE=/secure/fluxmq/server.key
+export ATOM_CLIENT_CA_FILE=/secure/atom/clients-ca.crt
+export ATOM_AUDIT_SECRET_CURRENT_FILE=/secure/atom/audit-secret-current
+export ATOM_AUDIT_SECRET_PREVIOUS_FILE=/secure/atom/audit-secret-previous
+
+docker compose \
+  -f deployments/docker/compose.yaml \
+  -f deployments/docker/compose.local-principal.yaml \
+  up -d
+```
+
+The previous-secret file is needed only during a rotation overlap. The Compose
+overlay declares it so the container mount is stable across rotations; use an
+unprivileged placeholder containing a different high-entropy secret when there
+is no active overlap.
+
+Secret files must contain a high-entropy printable value of at least 32
+bytes/characters. For example, encode 32 random bytes as hex or base64 rather
+than writing raw binary. Do not include embedded CR/LF or NUL characters;
+FluxMQ strips one terminal newline.
+
+Port `5683` is intentionally absent from `ports:`. The listener also binds only
+to FluxMQ's fixed `172.30.0.2` address on the private `atom-internal` network,
+so the dashboard and other containers on the default network cannot reach it.
+Attach Atom to the Compose project's `atom-internal` network and connect to
+`fluxmq:5683`; the server certificate must be valid for the name the Atom AMQP
+client verifies. Do not attach public services to that network. If the subnet
+conflicts with your environment, change the Compose subnet, FluxMQ static
+address, and `server.amqp091.internal.addr` together.
+
+The internal listener requires all three credentials:
+
+- SASL username `atom-audit-publisher`;
+- the secret from `ATOM_AUDIT_SECRET_CURRENT_FILE`;
+- a client certificate signed by `ATOM_CLIENT_CA_FILE` with URI SAN
+  `spiffe://absmach/atom/audit-publisher`.
+
+It may publish only to the default exchange with routing key `atom-audit`.
+Subscriptions and topology operations are denied. Confirmed delivery remains
+at least once: Atom must reuse a stable event ID on retries, and consumers must
+deduplicate it. See
+[the implemented design](../../docs/content/docs/deployment/internal-amqp-local-principals.md)
+for rotation, validation, rollout requirements, and the complete manual
+`rabtap` smoke procedure.
+
 ## 3-Node Cluster
 
 See `deployments/cluster/` directory for cluster configs. Both local and Docker

--- a/deployments/docker/compose.local-principal.yaml
+++ b/deployments/docker/compose.local-principal.yaml
@@ -1,0 +1,42 @@
+# Overlay for deployments/docker/compose.yaml. Port 5683 is deliberately not
+# published to the host and is bound only to FluxMQ's atom-internal interface.
+services:
+  fluxmq:
+    # Requires Docker Compose 2.24.4+ for !override. Do not retain the base
+    # file's host mappings for listeners disabled by this configuration.
+    ports: !override
+      - "5682:5682" # Remote AMQP 0.9.1 over TLS
+      - "8081:8081" # Health
+    # The unauthenticated native admin API remains available to the dashboard
+    # as fluxmq:8082 on the default container network, but is not host-published.
+    volumes:
+      - ./config-local-principal.yaml:/etc/fluxmq/config.yaml:ro
+    secrets:
+      - fluxmq_server_cert
+      - fluxmq_server_key
+      - atom_client_ca
+      - atom_audit_secret_current
+      - atom_audit_secret_previous
+    networks:
+      default: {}
+      atom-internal:
+        ipv4_address: 172.30.0.2
+
+secrets:
+  fluxmq_server_cert:
+    file: ${FLUXMQ_SERVER_CERT_FILE:?set FLUXMQ_SERVER_CERT_FILE}
+  fluxmq_server_key:
+    file: ${FLUXMQ_SERVER_KEY_FILE:?set FLUXMQ_SERVER_KEY_FILE}
+  atom_client_ca:
+    file: ${ATOM_CLIENT_CA_FILE:?set ATOM_CLIENT_CA_FILE}
+  atom_audit_secret_current:
+    file: ${ATOM_AUDIT_SECRET_CURRENT_FILE:?set ATOM_AUDIT_SECRET_CURRENT_FILE}
+  atom_audit_secret_previous:
+    file: ${ATOM_AUDIT_SECRET_PREVIOUS_FILE:?set ATOM_AUDIT_SECRET_PREVIOUS_FILE}
+
+networks:
+  atom-internal:
+    internal: true
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24

--- a/deployments/docker/config-local-principal.yaml
+++ b/deployments/docker/config-local-principal.yaml
@@ -1,0 +1,107 @@
+# Production-shaped single-node configuration for the dedicated Atom audit
+# publisher listener. Use with compose.local-principal.yaml.
+
+server:
+  # This deployment is AMQP 0.9.1-only. These explicit empty addresses
+  # override listeners that are enabled by FluxMQ defaults.
+  tcp:
+    v3:
+      addr: ""
+    v5:
+      addr: ""
+  websocket:
+    v3:
+      addr: ""
+    v5:
+      addr: ""
+  http:
+    plain:
+      addr: ""
+  coap:
+    plain:
+      addr: ""
+  amqp:
+    plain:
+      addr: ""
+
+  amqp091:
+    # Existing remote listener. All authentication and authorization uses the
+    # external callout below; it never checks local principals.
+    plain:
+      addr: ""
+    tls:
+      addr: ":5682"
+      max_connections: 10000
+      cert_file: "/run/secrets/fluxmq_server_cert"
+      key_file: "/run/secrets/fluxmq_server_key"
+      min_version: "TLS1.2"
+
+    # Bind only to FluxMQ's fixed address on the private atom-internal Docker
+    # network. Do not replace this with :5683 in a multi-network container.
+    internal:
+      addr: "172.30.0.2:5683"
+      max_connections: 32
+      cert_file: "/run/secrets/fluxmq_server_cert"
+      key_file: "/run/secrets/fluxmq_server_key"
+      ca_file: "/run/secrets/atom_client_ca"
+      client_auth: "require"
+      min_version: "TLS1.2"
+
+  health_enabled: true
+  health_addr: ":8081"
+  admin_api_addr: ":8082"
+  shutdown_timeout: "30s"
+
+broker:
+  max_message_size: 1048576
+
+storage:
+  type: "badger"
+  badger_dir: "/var/lib/fluxmq/data"
+  sync_writes: true
+
+cluster:
+  enabled: false
+
+auth:
+  external:
+    # fluxmq-auth is a required external dependency and is intentionally not
+    # defined by the Compose example. Its certificate must be trusted by the
+    # FluxMQ container. A service-mesh-protected loopback endpoint is another
+    # valid deployment choice.
+    url: "https://fluxmq-auth:8181"
+    transport: "http"
+    timeout: "2s"
+    protocols:
+      amqp091: true
+    identity_cache_size: 50000
+    identity_cache_ttl: "1h"
+
+  local_principals:
+    - name: "atom-audit-publisher"
+      certificate_uri_san: "spiffe://absmach/atom/audit-publisher"
+      current_secret_file: "/run/secrets/atom_audit_secret_current"
+      previous_secret_file: "/run/secrets/atom_audit_secret_previous"
+      permissions:
+        publish:
+          - exchange: ""
+            routing_key: "atom-audit"
+        subscribe: []
+
+queues:
+  - name: "atom-audit"
+    topics:
+      - "$queue/atom-audit/#"
+    reserved: true
+    type: "stream"
+    retention:
+      max_age: "720h"
+      max_length_bytes: 10737418240
+      max_length_messages: 0
+    limits:
+      max_message_size: 1048576
+      message_ttl: "720h"
+
+log:
+  level: "info"
+  format: "json"

--- a/docs/content/docs/configuration/hot-reload.md
+++ b/docs/content/docs/configuration/hot-reload.md
@@ -5,7 +5,7 @@ description: Change configuration at runtime without restarting the broker
 
 # Hot Reload
 
-**Last Updated:** 2026-03-18
+**Last Updated:** 2026-07-29
 
 FluxMQ supports changing a subset of configuration fields at runtime without restarting the broker. Changes are applied atomically per subsystem with automatic rollback on failure.
 
@@ -85,6 +85,17 @@ All rate limit fields are runtime-safe. Changing any rate limit field replaces t
 | ---------------- | --------------------------- |
 | `broker.max_qos` | Maximum QoS level (0, 1, 2) |
 
+### Local AMQP Principals
+
+The `auth.local_principals` snapshot and the contents of its current and
+previous secret files reload on every `SIGHUP`, even when the configured file
+paths are unchanged. The entire replacement snapshot is validated before it is
+made visible. A failed reload leaves the old snapshot active.
+
+Removing a principal, certificate URI SAN, or secret disconnects connections
+authenticated with the removed credential. ACL reductions apply to existing
+connections immediately.
+
 ## Restart-Required Fields
 
 All other fields require a full restart to take effect. These include:
@@ -94,7 +105,8 @@ All other fields require a full restart to take effect. These include:
 - **Cluster**: cluster topology and transport
 - **Session**: session defaults (affects existing connections)
 - **Webhook**: webhook worker pool configuration
-- **Auth**: authentication and authorization settings
+- **External auth**: `auth.external` callout and cache settings
+- **Local listener transport**: `server.amqp091.internal` address, limits, and TLS settings
 - **Hooks**: blocking hook callout configuration
 - **AMQP / AMQP 0.9.1**: all protocol-level settings
 

--- a/docs/content/docs/configuration/security.md
+++ b/docs/content/docs/configuration/security.md
@@ -69,6 +69,14 @@ AMQP 0.9.1 can expose a separate mTLS-only listener for tightly scoped service
 identities. This listener does not call external auth or blocking hooks and
 does not fall back to external auth for unknown identities.
 
+This is a service-to-service path for a fixed set of first-party producers
+declared in FluxMQ's own configuration — audit and event streams, internal
+telemetry, and similar broker-adjacent pipelines. Principals are static: adding
+one is a configuration and secret-provisioning change followed by `SIGHUP`,
+never a runtime registration. There is no dynamic, per-tenant, or per-user
+identity here, and each entry grants exactly one publish target. Remote
+clients, devices, and tenants authenticate through `auth.external`.
+
 ```yaml
 server:
   amqp091:
@@ -101,7 +109,15 @@ not be published to the host or Internet.
 
 Publish permissions support only the default exchange (`exchange: ""`) and an
 exact, non-empty routing key. Other exchanges and wildcard routing keys are
-rejected when the configuration is loaded.
+rejected when the configuration is loaded. At publish time the ACL is applied
+to the resolved exchange, so a client may address the default exchange as `""`
+or as `amq.default`.
+
+A publish target must be a pre-provisioned protected stream on a queue store
+that provides real crash durability; the in-memory queue store cannot back one.
+Publisher confirms are sent only after the append and its durability barrier
+complete, and are bounded by an internal timeout that NACKs rather than
+stalling the connection.
 
 Local principals are publish-only. Subscription ACLs are not implemented, so
 `permissions.subscribe` must remain `[]`; every consume or `Basic.Get`

--- a/docs/content/docs/configuration/security.md
+++ b/docs/content/docs/configuration/security.md
@@ -107,6 +107,12 @@ username, and local secret to match one configured principal. Permissions are
 exact-match allowlists. Port `5683` must remain on a private network and must
 not be published to the host or Internet.
 
+The listener is single-node only. Its publications are durable on the receiving
+node and are never forwarded to other nodes, so configuring it together with
+`cluster.enabled` is a startup error rather than a deployment whose records
+some consumers cannot reach. `cluster.enabled` defaults to true, so it must be
+set to false explicitly.
+
 Publish permissions support only the default exchange (`exchange: ""`) and an
 exact, non-empty routing key. Other exchanges and wildcard routing keys are
 rejected when the configuration is loaded. At publish time the ACL is applied

--- a/docs/content/docs/configuration/security.md
+++ b/docs/content/docs/configuration/security.md
@@ -119,7 +119,10 @@ Publisher confirms are sent only after the append and its durability barrier
 complete. The wait for that barrier is bounded: an fsync cannot be cancelled
 once started, so FluxMQ stops waiting after the internal publish timeout and
 NACKs rather than leaving the connection stalled. An abandoned append may still
-complete, so a NACK does not prove the record was not written.
+complete, so a NACK does not prove the record was not written. The number of
+abandoned appends waiting on one stream is capped; publications beyond that cap
+are refused before any storage work starts, and both outcomes close the channel
+so a stalled stream cannot accumulate retries.
 
 Local principals are publish-only. Subscription ACLs are not implemented, so
 `permissions.subscribe` must remain `[]`; every consume or `Basic.Get`

--- a/docs/content/docs/configuration/security.md
+++ b/docs/content/docs/configuration/security.md
@@ -116,8 +116,10 @@ or as `amq.default`.
 A publish target must be a pre-provisioned protected stream on a queue store
 that provides real crash durability; the in-memory queue store cannot back one.
 Publisher confirms are sent only after the append and its durability barrier
-complete, and are bounded by an internal timeout that NACKs rather than
-stalling the connection.
+complete. The wait for that barrier is bounded: an fsync cannot be cancelled
+once started, so FluxMQ stops waiting after the internal publish timeout and
+NACKs rather than leaving the connection stalled. An abandoned append may still
+complete, so a NACK does not prove the record was not written.
 
 Local principals are publish-only. Subscription ACLs are not implemented, so
 `permissions.subscribe` must remain `[]`; every consume or `Basic.Get`

--- a/docs/content/docs/configuration/security.md
+++ b/docs/content/docs/configuration/security.md
@@ -1,51 +1,121 @@
 ---
 title: Security
-description: Auth callout, TLS/mTLS listeners, inter-broker TLS, and rate limiting
+description: External auth, local principals, TLS/mTLS listeners, and rate limiting
 ---
 
 # Security Configuration
 
-**Last Updated:** 2026-03-17
+**Last Updated:** 2026-07-29
 
-## Auth Callout
+## External Auth Callout
 
 FluxMQ delegates authentication and authorization to an external service via
-gRPC or HTTP callout. When `auth.url` is set, every client connection is
+gRPC or HTTP callout. When `auth.external.url` is set, client connections on
+enabled protocols are
 verified against the external service before being accepted.
 
 ```yaml
 auth:
-  url: "auth-service:7016"
-  transport: "grpc"     # "grpc" (default) or "http"
-  timeout: 5s
+  external:
+    url: "https://auth-service.internal:7016"
+    transport: "grpc"     # "grpc" (default) or "http"
+    timeout: 5s
 ```
+
+The former flat keys such as `auth.url` are not accepted. This is an
+intentional breaking configuration change; move every external-callout field
+under `auth.external` before upgrading.
+
+Authentication requests contain client credentials. Protect the callout hop
+with server-authenticated HTTPS or a service mesh that provides mTLS. The
+built-in HTTPS client uses the host trust store and has no client-certificate
+configuration; deployments that require mTLS must terminate it in a sidecar
+or proxy. Plain HTTP is suitable only for a loopback hop already protected by
+that mesh, never for cross-host traffic.
 
 ### Per-Protocol Auth
 
-By default, all protocols require auth when `auth.url` is set. The `protocols`
-map lets you selectively enable or disable auth per protocol. This is useful
-when some listeners handle internal traffic that doesn't need external auth
-(e.g., an AMQP 0.9.1 listener used exclusively for service-to-service event
-sourcing).
+By default, all protocols require auth when `auth.external.url` is set. The
+`protocols` map lets you selectively enable or disable the external callout per
+protocol. Internal AMQP services that need local authentication use
+`server.amqp091.internal`; they do not disable authentication on a remote
+listener.
 
 ```yaml
 auth:
-  url: "auth-service:7016"
-  transport: "grpc"
-  timeout: 5s
-  protocols:
-    mqtt: true
-    http: true
-    coap: true
-    amqp: true
-    amqp091: false    # internal event store — no auth needed
+  external:
+    url: "https://auth-service.internal:7016"
+    transport: "grpc"
+    timeout: 5s
+    protocols:
+      mqtt: true
+      http: true
+      coap: true
+      amqp: true
+      amqp091: true
 ```
 
 Valid protocol keys: `mqtt`, `amqp`, `amqp091`, `http`, `coap`.
 
-When the `protocols` map is omitted or empty, all protocols require auth
-(backward compatible). When the map is present, only protocols set to `true`
-get auth; all others allow connections without authentication.
+When the `protocols` map is omitted or empty, all protocols require external
+auth. When the map is present, only protocols set to `true` get external auth;
+all others allow connections without external authentication. Do not disable
+external auth merely to carry internal traffic. Use an internal listener with
+a local principal instead.
+
+## Internal AMQP Local Principals
+
+AMQP 0.9.1 can expose a separate mTLS-only listener for tightly scoped service
+identities. This listener does not call external auth or blocking hooks and
+does not fall back to external auth for unknown identities.
+
+```yaml
+server:
+  amqp091:
+    internal:
+      addr: ":5683"
+      max_connections: 32
+      cert_file: "/run/secrets/fluxmq_server_cert"
+      key_file: "/run/secrets/fluxmq_server_key"
+      ca_file: "/run/secrets/atom_client_ca"
+      client_auth: "require"
+      min_version: "TLS1.2"
+
+auth:
+  local_principals:
+    - name: "atom-audit-publisher"
+      certificate_uri_san: "spiffe://absmach/atom/audit-publisher"
+      current_secret_file: "/run/secrets/atom_audit_secret_current"
+      previous_secret_file: "/run/secrets/atom_audit_secret_previous"
+      permissions:
+        publish:
+          - exchange: ""
+            routing_key: "atom-audit"
+        subscribe: []
+```
+
+The internal listener requires a CA-verified certificate URI SAN, SASL
+username, and local secret to match one configured principal. Permissions are
+exact-match allowlists. Port `5683` must remain on a private network and must
+not be published to the host or Internet.
+
+Publish permissions support only the default exchange (`exchange: ""`) and an
+exact, non-empty routing key. Other exchanges and wildcard routing keys are
+rejected when the configuration is loaded.
+
+Local principals are publish-only. Subscription ACLs are not implemented, so
+`permissions.subscribe` must remain `[]`; every consume or `Basic.Get`
+operation is denied.
+
+Local-principal counters are exposed under
+`by_protocol.amqp.local_principals` in `GET /api/v1/stats`. They cover active
+connections, authentication success/failure, publish and operation denials,
+reload success/failure, and forced disconnects. The counters are bounded and
+do not use principal names, certificate values, or routing keys as dimensions.
+
+See [Internal AMQP Local Principals](/deployment/internal-amqp-local-principals)
+for the complete production configuration, rotation process, tests, and
+rollout contract.
 
 ## Blocking Hooks
 

--- a/docs/content/docs/configuration/server.md
+++ b/docs/content/docs/configuration/server.md
@@ -5,7 +5,7 @@ description: Configure listeners, WebSocket path, health checks, and OpenTelemet
 
 # Server Configuration
 
-**Last Updated:** 2026-02-25
+**Last Updated:** 2026-07-29
 
 `server` controls network listeners and telemetry endpoints. Example:
 
@@ -32,6 +32,13 @@ server:
   amqp091:
     plain:
       addr: ":5682"
+    internal:
+      addr: ":5683"
+      max_connections: 32
+      cert_file: "/run/secrets/fluxmq_server_cert"
+      key_file: "/run/secrets/fluxmq_server_key"
+      ca_file: "/run/secrets/local_client_ca"
+      client_auth: "require"
 
   health_enabled: true
   health_addr: ":8081"
@@ -49,6 +56,9 @@ server:
 ## Key Fields
 
 - Listener families: `tcp`, `websocket`, `http`, `coap`, `amqp`, `amqp091`.
+- `amqp091.internal` is a private mTLS listener reserved for
+  `auth.local_principals`; it never uses external auth or blocking hooks and
+  requires a positive `max_connections` cap.
 - Listener addresses: `addr` (empty disables the specific listener).
 - MQTT parser mode per listener: TCP `v3`/`v5` listeners are protocol-pinned; WebSocket listeners can use `protocol` (`auto`, `v3`, `v5`).
 - Listener limits/timeouts: `max_connections`, `read_timeout`, `write_timeout`.

--- a/docs/content/docs/configuration/server.md
+++ b/docs/content/docs/configuration/server.md
@@ -58,7 +58,9 @@ server:
 - Listener families: `tcp`, `websocket`, `http`, `coap`, `amqp`, `amqp091`.
 - `amqp091.internal` is a private mTLS listener reserved for
   `auth.local_principals`; it never uses external auth or blocking hooks and
-  requires a positive `max_connections` cap.
+  requires a positive `max_connections` cap. It carries service-to-service
+  traffic from a fixed set of statically configured internal producers, such as
+  audit or event streams — not general client, device, or tenant connections.
 - Listener addresses: `addr` (empty disables the specific listener).
 - MQTT parser mode per listener: TCP `v3`/`v5` listeners are protocol-pinned; WebSocket listeners can use `protocol` (`auto`, `v3`, `v5`).
 - Listener limits/timeouts: `max_connections`, `read_timeout`, `write_timeout`.

--- a/docs/content/docs/deployment/internal-amqp-local-principals.md
+++ b/docs/content/docs/deployment/internal-amqp-local-principals.md
@@ -1,0 +1,439 @@
+---
+title: Internal AMQP Local Principals
+description: Implemented production design for a dedicated mTLS AMQP 0.9.1 listener
+---
+
+# Internal AMQP Local Principals
+
+**Status:** implemented
+**Last Updated:** 2026-07-29
+
+This document describes the implementation and acceptance contract for publishing
+Atom audit events to FluxMQ without sending those publications through Atom's
+own external authorization callout.
+
+## Goal
+
+Run two independent AMQP 0.9.1 authentication paths in one FluxMQ process:
+
+```text
+remote clients -> remote AMQP listener -> auth.external -> shared queues/storage
+Atom publisher -> internal AMQP :5683 -> auth.local_principals -> shared queues/storage
+```
+
+The remote listener never reads the local-principal store. The internal
+listener never calls external authentication, authorization, or blocking
+hooks. Unknown local identities fail closed; there is no fallback between the
+two paths.
+
+Both listeners share the queue manager and storage. Separate listeners isolate
+authentication latency and the trust boundary, but do not isolate CPU, memory,
+or disk capacity. Production sizing must account for the combined workload.
+
+The dedicated listener protects only AMQP ingress. FluxMQ's native admin API is
+a separate privileged control plane: it is unauthenticated and exposes queue
+operations over the same manager and storage. Keep it disabled or reachable
+only from a trusted container or management network. Any access outside that
+boundary must go through an authenticated mTLS reverse proxy or equivalent
+control. The local-principal Compose overlay leaves `fluxmq:8082` available to
+the dashboard on the default container network but does not publish port
+`8082` to the host.
+
+## Breaking configuration
+
+The old flat auth form is removed. FluxMQ does not provide a compatibility
+period or silently translate it.
+
+```yaml
+# Removed
+auth:
+  url: "https://auth.internal:9090"
+  transport: "grpc"
+```
+
+All external-callout settings move below `auth.external`. Local identities are
+declared separately in `auth.local_principals`:
+
+```yaml
+server:
+  amqp091:
+    # Existing public/remote listener. It uses auth.external and blocking hooks.
+    tls:
+      addr: ":5681"
+      max_connections: 10000
+      cert_file: "/run/secrets/fluxmq_server_cert"
+      key_file: "/run/secrets/fluxmq_server_key"
+      min_version: "TLS1.2"
+
+    # Private listener. Never expose it through a public load balancer.
+    internal:
+      addr: ":5683"
+      max_connections: 32
+      cert_file: "/run/secrets/fluxmq_server_cert"
+      key_file: "/run/secrets/fluxmq_server_key"
+      ca_file: "/run/secrets/atom_client_ca"
+      client_auth: "require"
+      min_version: "TLS1.2"
+
+auth:
+  external:
+    url: "https://auth.internal:9090"
+    transport: "grpc"
+    timeout: "2s"
+    protocols:
+      mqtt: true
+      amqp: true
+      amqp091: true
+      http: true
+      coap: true
+    identity_cache_size: 50000
+    identity_cache_ttl: "1h"
+
+  local_principals:
+    - name: "atom-audit-publisher"
+      certificate_uri_san: "spiffe://absmach/atom/audit-publisher"
+      current_secret_file: "/run/secrets/atom_audit_secret_current"
+      previous_secret_file: "/run/secrets/atom_audit_secret_previous"
+      permissions:
+        publish:
+          - exchange: ""
+            routing_key: "atom-audit"
+        subscribe: []
+```
+
+Local-principal secrets are mounted files, never inline YAML. Each file must
+contain a high-entropy printable value of at least 32 bytes/characters, for
+example 32 random bytes encoded as hex or base64. Do not use raw binary: the
+value must not contain embedded CR/LF or NUL characters. FluxMQ strips one
+terminal newline, stores only a digest in memory, and uses a constant-time
+comparison. Principal names and certificate URI SANs must be unique. Publish
+ACLs support only the default exchange (`exchange: ""`) and exact, non-empty
+routing keys; other exchanges and wildcards are invalid.
+
+The remote listener requires the separately deployed external auth service;
+FluxMQ does not bundle `fluxmq-auth`. Because authentication calls carry client
+credentials, use a trusted HTTPS endpoint or a service mesh that provides
+mTLS. The built-in HTTPS client uses the system trust store and does not expose
+client-certificate settings; terminate mTLS in a sidecar when it is required.
+An external-auth outage fails the remote path closed but does not invoke or
+interrupt the internal local-principal path.
+
+Authentication on the internal listener requires all of the following to
+match the same principal:
+
+- the SASL username;
+- the SASL secret;
+- the URI SAN in a client certificate verified by the configured CA.
+
+## Atom audit stream policy
+
+Provision the stream before starting the publisher:
+
+```yaml
+queues:
+  - name: "atom-audit"
+    topics:
+      - "$queue/atom-audit/#"
+    reserved: true
+    type: "stream"
+    retention:
+      max_age: "720h"
+      max_length_bytes: 10737418240
+      max_length_messages: 0
+    limits:
+      max_message_size: 1048576
+      message_ttl: "720h"
+```
+
+`retention.max_age` controls stream retention, while
+`limits.message_ttl` controls when each message expires. Keep the TTL at least
+as long as the intended replay window. This stream sets both to `720h` so the
+default seven-day message TTL cannot shorten the advertised 30-day replay
+availability.
+
+At startup and before activating a local-principal snapshot on `SIGHUP`,
+FluxMQ validates every local publish ACL target against both the configured and
+persisted queue definition. Startup aborts, or reload is rejected while the
+previous snapshot remains active, if a target is missing, the queue store
+lacks durable-sync support, or the persisted target is not the configured
+reserved, durable, non-replicated stream with matching retention and message
+limits. FluxMQ does not silently overwrite stale persisted queue metadata;
+stop FluxMQ, reconcile it with the YAML queue definition through a controlled
+storage migration or restore, and then restart before retrying the reload.
+
+While FluxMQ is running, the queue manager protects only the streams named by
+local-principal publish ACLs. It rejects create/update/delete operations that
+would change a protected stream's topics, type, durability, reserved flag,
+replication mode, retention window, retention byte/message limits, maximum
+message size, or message TTL. AMQP `QueueDeclare` attempts that would change
+the contract close the channel with `406 Precondition Failed`; the admin API
+returns `failed_precondition`. Other queues, including unrelated reserved
+queues, keep their existing mutation behavior.
+
+The exact durable publish path re-reads and compares the persisted contract
+immediately before every append, so out-of-band storage drift fails closed and
+cannot receive a publisher ACK. `MaxDepth` is intentionally not part of this
+contract because stream depth is not currently enforced; the effective
+retention byte/message limits are protected instead.
+
+Local durable confirms currently support single-node, non-replicated streams
+only. Enabling replication on a local publish target fails startup. Supporting
+a clustered audit stream requires a future end-to-end quorum durability
+barrier before FluxMQ can ACK the publication.
+
+The `atom-audit-publisher` may open connections and channels, enable publisher
+confirms, and publish only to the default exchange (`""`) with the exact
+routing key `atom-audit`. It cannot consume, get, declare or modify queues or
+exchanges, bind topology, purge, delete, or use transactions. A denied channel
+operation returns AMQP `403 Access Refused`.
+
+Local principals are publish-only. `permissions.subscribe` is unsupported and
+must remain empty (`[]`).
+
+FluxMQ resolves the preconfigured stream through the shared queue manager; the
+publisher never needs `QueueDeclare` permission. A publisher confirm is an ACK
+only after the exact configured stream append succeeds and that queue's
+durable storage sync completes. The append and durability barrier are one
+storage operation: segment rotation is serialized until the segment containing
+that record is synced. FluxMQ sends a NACK when the append or sync fails.
+
+Delivery is at least once. Atom may retry after a NACK or an ambiguous
+disconnect, so the same event can be appended more than once. Atom must keep a
+stable event ID across retries, and every consumer must deduplicate by that
+event ID.
+
+## Rotation and revocation
+
+Local-principal definitions and secret-file contents reload on `SIGHUP`. A
+reload validates a complete replacement snapshot before atomically activating
+it. On any read or validation error, the old snapshot remains active.
+
+Use the optional previous secret for a no-downtime rotation:
+
+1. Set the new secret as `current_secret_file` and the old one as
+   `previous_secret_file`, then send `SIGHUP`.
+2. Reconnect Atom with the new secret and verify a confirmed publication.
+3. Remove `previous_secret_file` and send `SIGHUP` again.
+4. FluxMQ disconnects sessions authenticated with the removed secret.
+
+Removing a principal or certificate URI also disconnects its sessions. ACL
+reductions apply immediately. Listener addresses and TLS settings require a
+process restart.
+
+## Implemented behavior
+
+- Bind a dedicated `server.amqp091.internal` mTLS listener on port `5683`.
+- Pass listener-scoped authentication, authorization, and hook policies into
+  AMQP connections instead of selecting them from broker-global state.
+- Keep remote AMQP on `auth.external`; do not add a local lookup to that path.
+- Add a reloadable, immutable local-principal snapshot with active-connection
+  revocation.
+- Enforce an internal-listener operation allowlist, including AMQP topology
+  methods that are outside publish/subscribe authorization today.
+- Resolve statically configured streams through the shared queue manager.
+- Enforce listener connection limits, TLS handshake timeouts, and message-size
+  limits before allocating a message body.
+- Add bounded admin statistics and structured logs for local authentication, denials,
+  reloads, and active connections. Never log secrets, hashes, or certificates.
+- Include successful internal-listener initialization and binding in
+  readiness.
+
+The bounded counters are returned by `GET /api/v1/stats` under
+`by_protocol.amqp.local_principals`; they are not per-principal metric labels.
+
+## Test and rollout contract
+
+Unit and component tests plus the real-process smoke test prove:
+
+- remote AMQP calls only `auth.external` and never checks local identities;
+- internal AMQP never calls external auth or blocking hooks, including when
+  those services are unavailable;
+- valid mTLS, URI SAN, username, and current/previous secret combinations work;
+- invalid CA, SAN, username, or secret combinations fail closed;
+- only the exact `atom-audit` publication succeeds;
+- consumption and every topology-changing operation are denied;
+- secret reload is atomic and removed credentials disconnect active sessions;
+- the stream accepts publication without a queue declaration;
+- publisher confirms ACK only after stream append and per-queue durable sync,
+  and NACK append/sync failures;
+- protected stream redeclare/update/delete attempts fail explicitly, and
+  publish-time checks reject out-of-band topic/retention/TTL/message-limit drift;
+- an audit event is replayable after a graceful FluxMQ restart.
+
+The implemented acceptance command is:
+
+```bash
+make smoke-local-auth
+```
+
+It starts a real FluxMQ process, creates test PKI, exercises both listener
+paths and negative credentials/ACLs, reloads credentials, restarts the broker,
+and verifies stream replay. This smoke test passed on 2026-07-29.
+
+### Manual rabtap deployment smoke
+
+Run this smoke after deploying the Compose overlay, and before enabling the
+Atom audit publisher. It complements `make smoke-local-auth` by proving that an
+independent AMQP 0.9.1 client can publish, receive a durable confirmation, and
+replay the event through the externally authorized listener.
+
+The examples below were verified with `rabtap` v1.44.1. Install that exact
+version when it is not already available:
+
+```bash
+go install github.com/jandelgado/rabtap@v1.44.1
+```
+
+Before running the commands, verify all of the following:
+
+- FluxMQ is built from the checkout under test and started with
+  `compose.local-principal.yaml` and `config-local-principal.yaml`.
+- The FluxMQ server certificate is valid for the hostname used in the AMQP
+  URI, normally `fluxmq` inside the Compose network.
+- The Atom client certificate is signed by `ATOM_CLIENT_CA_FILE`, has the
+  client-auth extended key usage, and contains the URI SAN
+  `spiffe://absmach/atom/audit-publisher`.
+- The local secret is printable, at least 32 characters, and URI-safe. Hex is
+  recommended. Use a short-lived smoke credential because AMQP URI credentials
+  can be visible to local process inspection and may appear in client errors.
+- A remote reader accepted by `auth.external` may subscribe to `atom-audit`.
+  The internal principal is deliberately unable to perform the replay.
+
+The CA passed to `rabtap --tls-ca-file` verifies the FluxMQ **server**
+certificate. It is the opposite trust direction from `ATOM_CLIENT_CA_FILE`,
+which FluxMQ uses to verify the Atom client certificate. They may be the same
+CA in a test deployment, but production does not require that.
+
+Port `5683` is not published to the host. Run the publish commands from Atom or
+a short-lived diagnostics container attached only to the private
+`atom-internal` network. A temporary `127.0.0.1` port mapping is acceptable for
+a developer smoke, but must never be carried into the production overlay.
+
+Export a unique event ID and read the mounted secret without its terminal
+newline:
+
+```bash
+export AUDIT_EVENT_ID="rabtap-smoke-1"
+export AUDIT_SECRET="$(tr -d '\r\n' </secure/atom/audit-secret-current)"
+export INTERNAL_AMQP_URI="amqps://atom-audit-publisher:${AUDIT_SECRET}@fluxmq:5683/"
+```
+
+Publish through the default exchange to the one permitted routing key:
+
+```bash
+printf '{"id":"%s","action":"entity.create"}\n' "${AUDIT_EVENT_ID}" |
+  rabtap pub \
+    --uri="${INTERNAL_AMQP_URI}" \
+    --exchange='' \
+    --routingkey='atom-audit' \
+    --confirms \
+    --mandatory \
+    --property='ContentType=application/json' \
+    --property='DeliveryMode=persistent' \
+    --property="MessageId=${AUDIT_EVENT_ID}" \
+    --tls-ca-file=/secure/fluxmq/server-ca.crt \
+    --tls-cert-file=/secure/atom/audit-publisher.crt \
+    --tls-key-file=/secure/atom/audit-publisher.key
+```
+
+The command must exit with status zero. `--confirms` waits for FluxMQ's broker
+ACK, which this listener sends only after the exact stream append and durable
+sync succeed. `--mandatory` also fails an unroutable publication.
+
+Prove that the local ACL remains exact and publish-only. Both commands must
+exit non-zero with AMQP `403 Access Refused`:
+
+```bash
+printf 'denied\n' |
+  rabtap pub \
+    --uri="${INTERNAL_AMQP_URI}" \
+    --exchange='' \
+    --routingkey='not-atom-audit' \
+    --confirms \
+    --tls-ca-file=/secure/fluxmq/server-ca.crt \
+    --tls-cert-file=/secure/atom/audit-publisher.crt \
+    --tls-key-file=/secure/atom/audit-publisher.key
+
+rabtap sub atom-audit \
+  --uri="${INTERNAL_AMQP_URI}" \
+  --limit=1 \
+  --idle-timeout=3s \
+  --tls-ca-file=/secure/fluxmq/server-ca.crt \
+  --tls-cert-file=/secure/atom/audit-publisher.crt \
+  --tls-key-file=/secure/atom/audit-publisher.key
+```
+
+An optional topology guard check must also fail with AMQP `403`:
+
+```bash
+rabtap queue create forbidden \
+  --uri="${INTERNAL_AMQP_URI}" \
+  --tls-ca-file=/secure/fluxmq/server-ca.crt \
+  --tls-cert-file=/secure/atom/audit-publisher.crt \
+  --tls-key-file=/secure/atom/audit-publisher.key
+```
+
+Restart FluxMQ gracefully, wait for readiness, then replay through remote AMQP
+port `5682`. Use a unique consumer group so a previous cursor cannot hide the
+test record:
+
+```bash
+docker compose \
+  -f deployments/docker/compose.yaml \
+  -f deployments/docker/compose.local-principal.yaml \
+  restart fluxmq
+
+curl --fail http://127.0.0.1:8081/health
+
+rabtap sub atom-audit \
+  --uri='amqps://remote-reader:REMOTE_SECRET@fluxmq:5682/' \
+  --offset=first \
+  --args='x-consumer-group=rabtap-smoke-unique' \
+  --limit=1 \
+  --idle-timeout=15s \
+  --format=raw \
+  --tls-ca-file=/secure/fluxmq/server-ca.crt
+```
+
+The output must contain the exact `AUDIT_EVENT_ID` published before the
+restart. The external auth service must record authentication and subscribe
+authorization for the remote reader. It must not record any request for the
+internal publication.
+
+Finally, make `auth.external` unavailable and repeat the confirmed internal
+publication. Internal port `5683` must still succeed, while remote port `5682`
+must fail closed. Restore the external service after the check. This proves
+that listener isolation is behavioral and not merely a configuration split.
+
+For a review bot or release operator, the minimum evidence to retain is:
+
+- the successful `make smoke-local-auth` output;
+- the zero exit status of the confirmed exact-target `rabtap pub`;
+- non-zero exit statuses for the wrong target, internal subscription, and
+  topology mutation;
+- the replayed event body after restart;
+- external-auth logs showing remote authentication/authorization and no
+  internal-listener callout;
+- `GET /api/v1/stats` counters showing one accepted message plus the expected
+  `publish_denied` and `operation_denied` increments.
+
+Roll out in this order:
+
+1. Deploy the breaking nested auth configuration with the internal listener
+   disabled and verify the remote path.
+2. Mount the CA, server certificate, current local secret, and pre-provision
+   `atom-audit`.
+3. Enable port `5683` only on a private network shared with Atom.
+4. Run `make smoke-local-auth` against the release source.
+5. As deployment-specific rollout gates, validate the rendered Compose or
+   orchestrator configuration, start the deployed container, and verify its
+   health/readiness and both listener paths in that environment.
+6. As a deployment-specific performance gate, load test both paths and set an
+   acceptable remote-auth latency budget for that environment. FluxMQ must not
+   add a local-principal lookup or callout to the remote path.
+7. Enable the Atom audit publisher in a separate deployment change.
+
+The feature is implemented and covered by the real-process acceptance smoke.
+A particular production deployment is ready only after its container startup,
+network-policy, certificate, external-auth transport, and performance rollout
+gates pass.

--- a/docs/content/docs/deployment/internal-amqp-local-principals.md
+++ b/docs/content/docs/deployment/internal-amqp-local-principals.md
@@ -209,6 +209,17 @@ only. Enabling replication on a local publish target fails startup. Supporting
 a clustered audit stream requires a future end-to-end quorum durability
 barrier before FluxMQ can ACK the publication.
 
+The internal listener therefore cannot run on a clustered node, and FluxMQ
+refuses that configuration at startup: `server.amqp091.internal.addr` together
+with `cluster.enabled` is a validation error. A local publication is appended
+and synced on the receiving node only and is never forwarded to other nodes,
+because forwarding would acknowledge a publisher on a barrier no single node
+established. In a cluster those records would be unreachable from consumers
+attached to any other node, with nothing to signal it, so the combination fails
+closed instead. Note that `cluster.enabled` defaults to true, so a deployment
+enabling the internal listener must set it to false explicitly, as the shipped
+`config-local-principal.yaml` does.
+
 The `atom-audit-publisher` may open connections and channels, enable publisher
 confirms, and publish only to the default exchange with the exact routing key
 `atom-audit`. It cannot consume, get, declare or modify queues or exchanges,

--- a/docs/content/docs/deployment/internal-amqp-local-principals.md
+++ b/docs/content/docs/deployment/internal-amqp-local-principals.md
@@ -232,6 +232,15 @@ when the segment is created, so the record cannot be acknowledged while its
 file is still only in the page cache. FluxMQ sends a NACK when the append or
 sync fails.
 
+Durability covers the whole queue, not only the record. A queue's log directory
+and its ancestors are synced as they are created, and queue metadata is written
+to a synced temporary file, renamed, and followed by a directory sync. Without
+that, a crash could leave an acknowledged record inside a directory or behind a
+metadata file that never reached disk. If a crash still lands between the log
+directory and its metadata, recreating the queue from the same configuration
+repairs the metadata rather than reporting the queue as already existing, so
+acknowledged records stay reachable.
+
 Only a queue store that provides a real crash-durability barrier may back a
 protected stream. FluxMQ checks this capability, not just the presence of an
 atomic append: startup aborts, and a reload is rejected, when the configured

--- a/docs/content/docs/deployment/internal-amqp-local-principals.md
+++ b/docs/content/docs/deployment/internal-amqp-local-principals.md
@@ -247,11 +247,17 @@ atomic append: startup aborts, and a reload is rejected, when the configured
 store cannot make a single append survive a machine crash. An in-memory queue
 store therefore cannot serve a local publish target.
 
-One append and its sync are bounded. If the barrier does not complete within
-the internal publish timeout, or the process is shutting down, the publication
-is NACKed instead of holding the connection open indefinitely. A NACK is not
-proof that the record was not written, so the at-least-once retry and
-deduplication rules below still apply.
+The confirm a publisher waits for is bounded, but the barrier underneath it is
+not interruptible. An fsync that has already started cannot be cancelled, so
+FluxMQ enforces the deadline by giving up on the wait: when the append and sync
+do not complete within the internal publish timeout, or the process is shutting
+down, the publication is NACKed and the connection stays responsive instead of
+a stalled disk holding an internal-listener slot open. The abandoned append can
+still complete afterwards and become visible to consumers. A NACK therefore
+never proves the record was not written, and the at-least-once retry and
+deduplication rules below apply to it. While storage is stalled, further
+publications to that stream keep timing out until the stall clears; the
+`publish_timeouts` counter reports how often this happened.
 
 Delivery is at least once. Atom may retry after a NACK or an ambiguous
 disconnect, so the same event can be appended more than once. Atom must keep a

--- a/docs/content/docs/deployment/internal-amqp-local-principals.md
+++ b/docs/content/docs/deployment/internal-amqp-local-principals.md
@@ -12,6 +12,34 @@ This document describes the implementation and acceptance contract for publishin
 Atom audit events to FluxMQ without sending those publications through Atom's
 own external authorization callout.
 
+## What this feature is for
+
+Local principals are a service-to-service ingress for a small, fixed set of
+first-party producers that are part of the deployment itself — audit and event
+streams, internal telemetry, and similar broker-adjacent pipelines. Every
+identity, its certificate URI SAN, and its exact publish target are declared in
+FluxMQ's own configuration and mounted secrets, so the set of local principals
+is known before the process starts and changes only through a deliberate
+configuration change plus `SIGHUP`.
+
+It is deliberately not a general client authentication mechanism:
+
+- there is no registration, discovery, or self-service enrollment;
+- there is no per-tenant, per-user, or dynamic identity — adding a principal is
+  a configuration and secret-provisioning change, not an API call;
+- the ACL grants exactly one `(default exchange, routing key)` pair per entry,
+  with no wildcards, patterns, or hierarchy;
+- the principal is publish-only into a pre-provisioned protected stream, so it
+  cannot consume, discover topology, or create anything;
+- it scales to a handful of principals, not to a client population. Remote
+  clients, devices, and tenants continue to authenticate through
+  `auth.external`.
+
+Use it when a service that FluxMQ's own authorization path depends on has to
+publish into FluxMQ — the case where routing that publication through the
+external callout would add remote-auth latency to every event or create a
+feedback loop. For everything else, use `auth.external`.
+
 ## Goal
 
 Run two independent AMQP 0.9.1 authentication paths in one FluxMQ process:
@@ -182,10 +210,14 @@ a clustered audit stream requires a future end-to-end quorum durability
 barrier before FluxMQ can ACK the publication.
 
 The `atom-audit-publisher` may open connections and channels, enable publisher
-confirms, and publish only to the default exchange (`""`) with the exact
-routing key `atom-audit`. It cannot consume, get, declare or modify queues or
-exchanges, bind topology, purge, delete, or use transactions. A denied channel
-operation returns AMQP `403 Access Refused`.
+confirms, and publish only to the default exchange with the exact routing key
+`atom-audit`. It cannot consume, get, declare or modify queues or exchanges,
+bind topology, purge, delete, or use transactions. A denied channel operation
+returns AMQP `403 Access Refused`.
+
+The ACL is evaluated against the exchange the router resolves, so a client may
+name the default exchange either as `""` or as its `amq.default` alias. The
+configuration itself accepts only `exchange: ""`.
 
 Local principals are publish-only. `permissions.subscribe` is unsupported and
 must remain empty (`[]`).
@@ -195,7 +227,22 @@ publisher never needs `QueueDeclare` permission. A publisher confirm is an ACK
 only after the exact configured stream append succeeds and that queue's
 durable storage sync completes. The append and durability barrier are one
 storage operation: segment rotation is serialized until the segment containing
-that record is synced. FluxMQ sends a NACK when the append or sync fails.
+that record is synced, and a newly created segment's directory entry is synced
+when the segment is created, so the record cannot be acknowledged while its
+file is still only in the page cache. FluxMQ sends a NACK when the append or
+sync fails.
+
+Only a queue store that provides a real crash-durability barrier may back a
+protected stream. FluxMQ checks this capability, not just the presence of an
+atomic append: startup aborts, and a reload is rejected, when the configured
+store cannot make a single append survive a machine crash. An in-memory queue
+store therefore cannot serve a local publish target.
+
+One append and its sync are bounded. If the barrier does not complete within
+the internal publish timeout, or the process is shutting down, the publication
+is NACKed instead of holding the connection open indefinitely. A NACK is not
+proof that the record was not written, so the at-least-once retry and
+deduplication rules below still apply.
 
 Delivery is at least once. Atom may retry after a NACK or an ambiguous
 disconnect, so the same event can be appended more than once. Atom must keep a
@@ -338,7 +385,13 @@ printf '{"id":"%s","action":"entity.create"}\n' "${AUDIT_EVENT_ID}" |
 
 The command must exit with status zero. `--confirms` waits for FluxMQ's broker
 ACK, which this listener sends only after the exact stream append and durable
-sync succeed. `--mandatory` also fails an unroutable publication.
+sync succeed.
+
+`--mandatory` is kept for parity with the remote listener but does not add a
+check here: the internal listener routes only to its protected stream, so an
+unroutable or rejected publication is reported as a NACK rather than a
+`Basic.Return`. Treat the confirm result, not a returned message, as the
+authoritative outcome.
 
 Prove that the local ACL remains exact and publish-only. Both commands must
 exit non-zero with AMQP `403 Access Refused`:

--- a/docs/content/docs/deployment/internal-amqp-local-principals.md
+++ b/docs/content/docs/deployment/internal-amqp-local-principals.md
@@ -282,6 +282,13 @@ disconnect, so the same event can be appended more than once. Atom must keep a
 stable event ID across retries, and every consumer must deduplicate by that
 event ID.
 
+Stream offsets order appends, not publications. In normal operation the two
+agree, because a publisher is answered before its next publication is
+processed. While storage is stalled they can diverge: an abandoned append that
+completes later can land after a publication that was accepted after it.
+Consumers that care about event order must use a field in the event, not the
+stream offset.
+
 ## Rotation and revocation
 
 Local-principal definitions and secret-file contents reload on `SIGHUP`. A

--- a/docs/content/docs/deployment/internal-amqp-local-principals.md
+++ b/docs/content/docs/deployment/internal-amqp-local-principals.md
@@ -255,9 +255,16 @@ down, the publication is NACKed and the connection stays responsive instead of
 a stalled disk holding an internal-listener slot open. The abandoned append can
 still complete afterwards and become visible to consumers. A NACK therefore
 never proves the record was not written, and the at-least-once retry and
-deduplication rules below apply to it. While storage is stalled, further
-publications to that stream keep timing out until the stall clears; the
-`publish_timeouts` counter reports how often this happened.
+deduplication rules below apply to it.
+
+An abandoned append keeps running and keeps its message, so FluxMQ also caps
+how many may be waiting on one stream at a time. Publications beyond that cap
+are refused before any storage work starts, which stops a publisher retrying
+against unresponsive storage from accumulating barriers and payloads. Both
+outcomes close the channel after the NACK: a publisher must reconnect rather
+than retry into a stream whose storage has not recovered. The
+`publish_timeouts` and `publish_rejections` counters report how often each
+happened; sustained growth means storage, not the publisher, is the fault.
 
 Delivery is at least once. Atom may retry after a NACK or an ambiguous
 disconnect, so the same event can be appended more than once. Atom must keep a

--- a/docs/content/docs/deployment/meta.json
+++ b/docs/content/docs/deployment/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "running-cluster",
     "running-in-production",
+    "internal-amqp-local-principals",
     "health-readiness",
     "performance-tuning"
   ]

--- a/docs/content/docs/reference/configuration-reference.md
+++ b/docs/content/docs/reference/configuration-reference.md
@@ -5,7 +5,7 @@ description: Comprehensive YAML configuration reference for server, broker, stor
 
 # Configuration Reference
 
-**Last Updated:** 2026-02-25
+**Last Updated:** 2026-07-29
 
 FluxMQ uses a single YAML configuration file. Start the broker with:
 
@@ -80,7 +80,7 @@ server:
 
   coap:
     plain:
-      addr: ":5683"
+      addr: ":5685"
     dtls: {}
     mdtls: {}
 
@@ -97,6 +97,13 @@ server:
       max_connections: 10000
     tls: {}
     mtls: {}
+    internal:
+      addr: ":5683"
+      max_connections: 32
+      cert_file: "/run/secrets/fluxmq_server_cert"
+      key_file: "/run/secrets/fluxmq_server_key"
+      ca_file: "/run/secrets/local_client_ca"
+      client_auth: "require"
 
   health_enabled: true
   health_addr: ":8081"
@@ -117,12 +124,12 @@ server:
 
 ### Listener Fields
 
-These apply to listener blocks (for example `server.tcp.v3`, `server.websocket.v3`, `server.amqp091.tls`, and so on).
+These apply to listener blocks (for example `server.tcp.v3`, `server.websocket.v3`, `server.amqp091.tls`, and so on). `server.amqp091.internal` is reserved for `auth.local_principals`, requires mTLS, and never uses external auth or blocking hooks.
 
 | Field             | Description                                                                                                                                    |
 | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `addr`            | Listener bind address (`"<host>:<port>"` or `":<port>"`). Empty string disables that listener.                                                 |
-| `max_connections` | Connection cap for that listener (`>= 0`). `0` means no explicit cap. Applies to TCP/AMQP/AMQP091 listeners.                                   |
+| `max_connections` | Connection cap for that listener (`>= 0`). `0` means no explicit cap except on `server.amqp091.internal`, where a positive cap is required. Applies to TCP/AMQP/AMQP091 listeners. |
 | `read_timeout`    | Read timeout for TCP listeners (`time.Duration`).                                                                                              |
 | `write_timeout`   | Write timeout for TCP listeners (`time.Duration`).                                                                                             |
 | `protocol`        | MQTT parser mode. For TCP, use `v3` on `server.tcp.v3` and `v5` on `server.tcp.v5`; for WebSocket listeners you can use `auto`, `v3`, or `v5`. |
@@ -681,25 +688,49 @@ ratelimit:
 
 ```yaml
 auth:
-  url: "auth-service:7016"
-  transport: "grpc"
-  timeout: 5s
-  protocols:
-    mqtt: true
-    http: true
-    coap: true
-    amqp: true
-    amqp091: false
+  external:
+    url: "https://auth-service.internal:7016"
+    transport: "grpc"
+    timeout: 5s
+    protocols:
+      mqtt: true
+      http: true
+      coap: true
+      amqp: true
+      amqp091: true
+    identity_cache_size: 50000
+    identity_cache_ttl: "1h"
+
+  local_principals:
+    - name: "atom-audit-publisher"
+      certificate_uri_san: "spiffe://absmach/atom/audit-publisher"
+      current_secret_file: "/run/secrets/atom_audit_secret_current"
+      previous_secret_file: "/run/secrets/atom_audit_secret_previous"
+      permissions:
+        publish:
+          - exchange: ""
+            routing_key: "atom-audit"
+        subscribe: []
 ```
 
-| Field       | Default | Description                                                                                               |
-| ----------- | ------- | --------------------------------------------------------------------------------------------------------- |
-| `url`       | `""`    | Auth service address. Empty disables auth callout entirely.                                               |
-| `transport` | `grpc`  | Wire format for callout: `grpc` or `http`.                                                                |
-| `timeout`   | `0`     | Per-call timeout (e.g. `5s`). Zero uses the transport default.                                            |
-| `protocols` | `{}`    | Per-protocol auth toggle. Empty map = all protocols require auth. When set, only `true` entries get auth. |
+| Field                                           | Default | Description |
+| ----------------------------------------------- | ------- | ----------- |
+| `external.url`                                  | `""`    | External auth service address. Empty disables the callout. |
+| `external.transport`                            | `grpc`  | Callout transport: `grpc` or `http`. |
+| `external.timeout`                              | `0`     | Per-call timeout. Zero uses the transport default. |
+| `external.protocols`                            | `{}`    | External-auth protocol toggle. Empty means every protocol. |
+| `external.identity_cache_size`                  | `0`     | Maximum cached external identities; zero selects the broker default (`10000`), while a negative value disables size eviction. |
+| `external.identity_cache_ttl`                   | `0`     | External identity cache TTL; zero selects the broker default (`24h`), while a negative value disables TTL eviction. |
+| `local_principals[].name`                       | —       | Unique SASL username for the local principal. |
+| `local_principals[].certificate_uri_san`        | —       | Exact URI SAN required on a CA-verified client certificate. |
+| `local_principals[].current_secret_file`        | —       | File containing an active high-entropy printable value of at least 32 characters, without embedded CR/LF or NUL. One terminal newline is stripped. |
+| `local_principals[].previous_secret_file`       | `""`    | Optional old secret with the same printable-value requirements, accepted during rotation overlap. |
+| `local_principals[].permissions.publish`        | `[]`    | Exact AMQP publish targets. `exchange` must be `""` (the default exchange); `routing_key` must be exact and non-empty. |
+| `local_principals[].permissions.subscribe`      | `[]`    | Unsupported for local principals; it must remain empty. Local principals are publish-only. |
 
-Valid `protocols` keys: `mqtt`, `amqp`, `amqp091`, `http`, `coap`.
+Valid `external.protocols` keys: `mqtt`, `amqp`, `amqp091`, `http`, `coap`.
+The old flat `auth.url`, `auth.transport`, `auth.timeout`, `auth.protocols`, and
+cache fields are invalid.
 
 See [Security configuration](/configuration/security) for detailed examples.
 

--- a/examples/production.yaml
+++ b/examples/production.yaml
@@ -7,6 +7,8 @@
 # Required out-of-band setup:
 #   - TLS certificate + key, plus CA bundle for client mTLS
 #   - External auth callout reachable on auth.internal:9090 (or disable)
+#   - Atom client CA + 32-byte local-principal secret files when enabling
+#     the internal AMQP audit listener
 #   - OTLP-compatible collector reachable on otel.internal:4317
 #   - Persistent volume mounted at /var/lib/fluxmq
 #
@@ -78,8 +80,19 @@ server:
   amqp091:
     tls:
       addr: ":5681"
+      max_connections: 10000
       cert_file: "/etc/fluxmq/certs/server.crt"
       key_file: "/etc/fluxmq/certs/server.key"
+    # Private, mTLS-only listener for local service principals. Never expose
+    # this port through a public load balancer.
+    internal:
+      addr: ":5683"
+      max_connections: 32
+      cert_file: "/run/secrets/fluxmq_internal_server_cert"
+      key_file: "/run/secrets/fluxmq_internal_server_key"
+      ca_file: "/run/secrets/atom_client_ca"
+      client_auth: "require"
+      min_version: "TLS1.2"
 
   coap:
     mdtls:
@@ -134,17 +147,31 @@ storage:
 # IdentityCacheSize bounds memory; IdentityCacheTTL forces re-auth on a
 # schedule so revoked tokens are eventually rejected.
 auth:
-  url: "https://auth.internal:9090"
-  transport: "grpc"
-  timeout: "2s"
-  protocols:
-    mqtt: true
-    amqp: true
-    amqp091: true
-    http: true
-    coap: true
-  identity_cache_size: 50000
-  identity_cache_ttl: "1h"
+  external:
+    url: "https://auth.internal:9090"
+    transport: "grpc"
+    timeout: "2s"
+    protocols:
+      mqtt: true
+      amqp: true
+      amqp091: true
+      http: true
+      coap: true
+    identity_cache_size: 50000
+    identity_cache_ttl: "1h"
+
+  # Local principals are valid only on server.amqp091.internal. Unknown
+  # principals fail closed and never fall back to auth.external.
+  local_principals:
+    - name: "atom-audit-publisher"
+      certificate_uri_san: "spiffe://absmach/atom/audit-publisher"
+      current_secret_file: "/run/secrets/atom_audit_secret_current"
+      previous_secret_file: "/run/secrets/atom_audit_secret_previous"
+      permissions:
+        publish:
+          - exchange: ""
+            routing_key: "atom-audit"
+        subscribe: []
 
 # Optional blocking hooks. Enable only when an external policy/normalization
 # service must decide before FluxMQ continues the operation.
@@ -212,6 +239,23 @@ cluster:
 log:
   level: "info"
   format: "json"
+
+# Pre-provisioned stream used by the restricted Atom publisher. The publisher
+# is not permitted to declare or mutate broker topology.
+queues:
+  - name: "atom-audit"
+    topics:
+      - "$queue/atom-audit/#"
+    reserved: true
+    type: "stream"
+    retention:
+      max_age: "720h"
+      max_length_bytes: 10737418240
+      max_length_messages: 0
+    limits:
+      max_message_size: 1048576
+      # Keep per-message expiry aligned with the 30-day retention window.
+      message_ttl: "720h"
 
 # Notes for operators:
 #   1. Run the broker container with read_only rootfs, cap_drop ALL, and

--- a/logstorage/adapter.go
+++ b/logstorage/adapter.go
@@ -220,7 +220,13 @@ func (a *Adapter) Append(ctx context.Context, queueName string, msg *types.Messa
 
 // AppendAndSync appends a message and syncs the exact segment containing it as
 // one operation. It is the durability primitive used before publisher ACKs.
+// A cancelled context aborts before the append, so the caller can NACK without
+// the record ever reaching the log; the append and its fsync are not
+// interruptible once started.
 func (a *Adapter) AppendAndSync(ctx context.Context, queueName string, msg *types.Message) (uint64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
 	if err := a.queueConfigExists(queueName); err != nil {
 		return 0, err
 	}
@@ -228,6 +234,11 @@ func (a *Adapter) AppendAndSync(ctx context.Context, queueName string, msg *type
 	value, key, headers := encodeMessage(msg)
 	return a.store.AppendAndSync(queueName, value, key, headers)
 }
+
+// SupportsDurableSync reports that AppendAndSync establishes a real crash
+// durability barrier: the segment file and its directory entry are fsynced
+// before it returns.
+func (a *Adapter) SupportsDurableSync() bool { return true }
 
 // SyncQueue flushes the queue's current active segment. AppendAndSync must be
 // used when the caller needs a barrier tied to one particular append.

--- a/logstorage/adapter.go
+++ b/logstorage/adapter.go
@@ -17,6 +17,7 @@ const headerTopic = "_topic"
 
 var (
 	_ storage.QueueStore         = (*Adapter)(nil)
+	_ storage.DurableQueueStore  = (*Adapter)(nil)
 	_ storage.ConsumerGroupStore = (*Adapter)(nil)
 )
 
@@ -186,12 +187,7 @@ func (a *Adapter) queueConfigExists(queueName string) error {
 	return nil
 }
 
-// Append adds a message to the end of a queue's log.
-func (a *Adapter) Append(ctx context.Context, queueName string, msg *types.Message) (uint64, error) {
-	if err := a.queueConfigExists(queueName); err != nil {
-		return 0, err
-	}
-
+func encodeMessage(msg *types.Message) ([]byte, []byte, map[string][]byte) {
 	value := msg.GetPayload()
 	key := []byte{}
 
@@ -209,7 +205,34 @@ func (a *Adapter) Append(ctx context.Context, queueName string, msg *types.Messa
 		headers["_expires_at"] = []byte(strconv.FormatInt(msg.ExpiresAt.UnixMilli(), 10))
 	}
 
+	return value, key, headers
+}
+
+// Append adds a message to the end of a queue's log.
+func (a *Adapter) Append(ctx context.Context, queueName string, msg *types.Message) (uint64, error) {
+	if err := a.queueConfigExists(queueName); err != nil {
+		return 0, err
+	}
+
+	value, key, headers := encodeMessage(msg)
 	return a.store.Append(queueName, value, key, headers)
+}
+
+// AppendAndSync appends a message and syncs the exact segment containing it as
+// one operation. It is the durability primitive used before publisher ACKs.
+func (a *Adapter) AppendAndSync(ctx context.Context, queueName string, msg *types.Message) (uint64, error) {
+	if err := a.queueConfigExists(queueName); err != nil {
+		return 0, err
+	}
+
+	value, key, headers := encodeMessage(msg)
+	return a.store.AppendAndSync(queueName, value, key, headers)
+}
+
+// SyncQueue flushes the queue's current active segment. AppendAndSync must be
+// used when the caller needs a barrier tied to one particular append.
+func (a *Adapter) SyncQueue(_ context.Context, queueName string) error {
+	return a.store.SyncQueue(queueName)
 }
 
 // AppendBatch adds multiple messages to a queue's log.

--- a/logstorage/adapter.go
+++ b/logstorage/adapter.go
@@ -5,6 +5,7 @@ package logstorage
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"time"
 
@@ -117,12 +118,20 @@ func (a *Adapter) OffsetBySize(ctx context.Context, queueName string, retentionB
 // QueueStore interface implementation
 
 // CreateQueue creates a new queue with the given configuration.
+//
+// A queue is two pieces of state: its log directory and its metadata. A crash
+// between the two leaves a log with no metadata, which every other API reads as
+// a queue that does not exist. Treat that case as a repair and write the
+// missing metadata rather than reporting the queue as already created, so a
+// torn creation cannot strand records that were acknowledged as durable.
 func (a *Adapter) CreateQueue(ctx context.Context, config types.QueueConfig) error {
 	if err := a.store.CreateQueue(config.Name); err != nil {
-		if err == ErrAlreadyExists {
+		if !errors.Is(err, ErrAlreadyExists) {
+			return err
+		}
+		if _, getErr := a.queueStore.Get(config.Name); getErr == nil {
 			return storage.ErrQueueAlreadyExists
 		}
-		return err
 	}
 
 	if err := a.queueStore.Save(config); err != nil {

--- a/logstorage/adapter_test.go
+++ b/logstorage/adapter_test.go
@@ -5,6 +5,7 @@ package logstorage
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -234,4 +235,59 @@ func TestAdapter_AppendAndSyncHonorsContextAndReportsDurability(t *testing.T) {
 func TestSyncDirRejectsMissingDirectory(t *testing.T) {
 	require.NoError(t, SyncDir(t.TempDir()))
 	require.Error(t, SyncDir(filepath.Join(t.TempDir(), "absent")))
+}
+
+func TestAdapter_CreateQueueRestoresMetadataLostAfterCrash(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	cfg := types.DefaultQueueConfig("audit", "$queue/audit/#")
+	cfg.Type = types.QueueTypeStream
+	cfg.Reserved = true
+
+	adapter, err := NewAdapter(dir, DefaultAdapterConfig())
+	require.NoError(t, err)
+	require.NoError(t, adapter.CreateQueue(ctx, cfg))
+	_, err = adapter.AppendAndSync(ctx, "audit", &types.Message{ID: "1", Topic: "t", Payload: []byte("a")})
+	require.NoError(t, err)
+	require.NoError(t, adapter.Close())
+
+	// A crash between the log directory reaching disk and its metadata doing so
+	// leaves the acknowledged record present but the queue invisible.
+	require.NoError(t, os.Remove(filepath.Join(dir, "config", "queues.json")))
+
+	reopened, err := NewAdapter(dir, DefaultAdapterConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { reopened.Close() })
+
+	_, err = reopened.GetQueue(ctx, "audit")
+	require.ErrorIs(t, err, storage.ErrQueueNotFound, "precondition: metadata is gone")
+
+	require.NoError(t, reopened.CreateQueue(ctx, cfg), "recreating the queue must repair the lost metadata")
+
+	restored, err := reopened.GetQueue(ctx, "audit")
+	require.NoError(t, err)
+	assert.Equal(t, cfg.Name, restored.Name)
+
+	msg, err := reopened.Read(ctx, "audit", 0)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("a"), msg.Payload)
+
+	// A queue whose metadata is intact is still reported as already existing.
+	assert.ErrorIs(t, reopened.CreateQueue(ctx, cfg), storage.ErrQueueAlreadyExists)
+}
+
+func TestMkdirAllSyncedCreatesNestedDirectories(t *testing.T) {
+	root := t.TempDir()
+	nested := filepath.Join(root, "queues", "audit", "segments")
+	require.NoError(t, MkdirAllSynced(nested, 0o755))
+
+	info, err := os.Stat(nested)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	require.NoError(t, MkdirAllSynced(nested, 0o755), "existing directories are accepted")
+
+	file := filepath.Join(root, "file")
+	require.NoError(t, os.WriteFile(file, []byte("x"), 0o600))
+	require.Error(t, MkdirAllSynced(file, 0o755), "a file in the path must not be reported as a directory")
 }

--- a/logstorage/adapter_test.go
+++ b/logstorage/adapter_test.go
@@ -5,6 +5,7 @@ package logstorage
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -200,4 +201,37 @@ func TestAdapter_ExpiresAtBatchRoundtrip(t *testing.T) {
 	got1, err := adapter.Read(ctx, "q1", 1)
 	require.NoError(t, err)
 	assert.True(t, got1.ExpiresAt.IsZero())
+}
+
+func TestAdapter_AppendAndSyncHonorsContextAndReportsDurability(t *testing.T) {
+	dir := t.TempDir()
+	adapter, err := NewAdapter(dir, DefaultAdapterConfig())
+	require.NoError(t, err)
+	defer adapter.Close()
+
+	assert.True(t, adapter.SupportsDurableSync())
+
+	ctx := context.Background()
+	cfg := types.DefaultQueueConfig("audit", "$queue/audit/#")
+	require.NoError(t, adapter.CreateQueue(ctx, cfg))
+
+	cancelled, cancel := context.WithCancel(ctx)
+	cancel()
+	_, err = adapter.AppendAndSync(cancelled, "audit", &types.Message{ID: "1", Topic: "t", Payload: []byte("a")})
+	require.ErrorIs(t, err, context.Canceled)
+
+	count, err := adapter.Count(ctx, "audit")
+	require.NoError(t, err)
+	assert.Zero(t, count, "cancelled publish must not reach the log")
+
+	_, err = adapter.AppendAndSync(ctx, "audit", &types.Message{ID: "2", Topic: "t", Payload: []byte("b")})
+	require.NoError(t, err)
+	count, err = adapter.Count(ctx, "audit")
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), count)
+}
+
+func TestSyncDirRejectsMissingDirectory(t *testing.T) {
+	require.NoError(t, SyncDir(t.TempDir()))
+	require.Error(t, SyncDir(filepath.Join(t.TempDir(), "absent")))
 }

--- a/logstorage/manager.go
+++ b/logstorage/manager.go
@@ -5,7 +5,6 @@ package logstorage
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 	"sync"
@@ -57,8 +56,9 @@ func DefaultManagerConfig() ManagerConfig {
 
 // NewSegmentManager creates a new segment manager for the given directory.
 func NewSegmentManager(dir string, config ManagerConfig) (*SegmentManager, error) {
-	// Ensure directory exists
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	// Ensure the directory and every missing parent are durable before any
+	// segment inside them can be synced on a publisher's behalf.
+	if err := MkdirAllSynced(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create segment directory: %w", err)
 	}
 

--- a/logstorage/manager.go
+++ b/logstorage/manager.go
@@ -190,8 +190,12 @@ func (m *SegmentManager) createSegment(baseOffset uint64) error {
 	return nil
 }
 
-// Append appends a batch to the log and returns the base offset.
-func (m *SegmentManager) Append(batch *Batch) (uint64, error) {
+// appendWithBarrier appends a batch and, when barrier is non-nil, runs the
+// barrier against the exact segment that accepted the batch before releasing
+// the manager lock. Keeping the lock across both operations prevents another
+// append from rotating the active segment between the write and its durability
+// barrier.
+func (m *SegmentManager) appendWithBarrier(batch *Batch, barrier func(*Segment) error) (uint64, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -210,15 +214,35 @@ func (m *SegmentManager) Append(batch *Batch) (uint64, error) {
 	batch.BaseOffset = m.tailOffset
 	batch.Compression = m.config.Compression
 
-	// Append to active segment
-	offset, err := m.activeSegment.Append(batch)
+	// Capture the target so a durability barrier always applies to the segment
+	// containing this batch, even if rotation behavior changes in the future.
+	target := m.activeSegment
+	offset, err := target.Append(batch)
 	if err != nil {
 		return 0, err
 	}
 
 	m.tailOffset = batch.NextOffset()
+	if barrier != nil {
+		if err := barrier(target); err != nil {
+			return offset, fmt.Errorf("durability barrier for offset %d: %w", offset, err)
+		}
+	}
 
 	return offset, nil
+}
+
+// Append appends a batch to the log and returns the base offset.
+func (m *SegmentManager) Append(batch *Batch) (uint64, error) {
+	return m.appendWithBarrier(batch, nil)
+}
+
+// AppendAndSync appends a batch and syncs the exact segment containing it
+// before returning. Segment rotation is serialized with the entire operation.
+func (m *SegmentManager) AppendAndSync(batch *Batch) (uint64, error) {
+	return m.appendWithBarrier(batch, func(segment *Segment) error {
+		return segment.Sync()
+	})
 }
 
 // AppendMessage appends a single message and returns its offset.
@@ -226,6 +250,14 @@ func (m *SegmentManager) AppendMessage(value []byte, key []byte, headers map[str
 	batch := NewBatch(0)
 	batch.Append(value, key, headers)
 	return m.Append(batch)
+}
+
+// AppendMessageAndSync appends one message and syncs the exact segment
+// containing it before returning.
+func (m *SegmentManager) AppendMessageAndSync(value []byte, key []byte, headers map[string][]byte) (uint64, error) {
+	batch := NewBatch(0)
+	batch.Append(value, key, headers)
+	return m.AppendAndSync(batch)
 }
 
 // shouldRotate checks if the active segment should be rotated.

--- a/logstorage/manager_test.go
+++ b/logstorage/manager_test.go
@@ -72,6 +72,59 @@ func TestSegmentManager_RotateAndRead(t *testing.T) {
 	assert.Equal(t, []byte("b"), rangeMsgs[1].Value)
 }
 
+func TestSegmentManager_DurableAppendSerializesConcurrentRotation(t *testing.T) {
+	cfg := DefaultManagerConfig()
+	cfg.MaxSegmentSize = 1
+	cfg.MaxSegmentAge = 0
+	cfg.SyncInterval = 0
+	cfg.Compression = CompressionNone
+
+	mgr := newTestManager(t, cfg)
+	defer mgr.Close()
+
+	batch := NewBatch(0)
+	batch.Append([]byte("durable"), nil, nil)
+
+	rotationAttempted := make(chan struct{})
+	rotationResult := make(chan error, 1)
+	var syncedSegment *Segment
+	offset, err := mgr.appendWithBarrier(batch, func(target *Segment) error {
+		syncedSegment = target
+
+		// The old two-call Append/SyncQueue path released this lock here,
+		// allowing the concurrent append to rotate target to readonly before
+		// Sync selected the active segment. The atomic path must retain it.
+		if mgr.mu.TryLock() {
+			mgr.mu.Unlock()
+			t.Fatal("segment manager lock was released before durability barrier")
+		}
+		if mgr.activeSegment != target {
+			t.Fatal("active segment changed before durability barrier")
+		}
+
+		rotationBatch := NewBatch(0)
+		rotationBatch.Append([]byte("rotate"), nil, nil)
+		go func() {
+			close(rotationAttempted)
+			_, appendErr := mgr.Append(rotationBatch)
+			rotationResult <- appendErr
+		}()
+		<-rotationAttempted
+		return target.Sync()
+	})
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0), offset)
+	require.NoError(t, <-rotationResult)
+
+	require.NotNil(t, syncedSegment)
+	assert.Equal(t, uint64(0), syncedSegment.BaseOffset())
+	segments := mgr.Segments()
+	require.Len(t, segments, 2)
+	assert.Equal(t, uint64(0), segments[0].BaseOffset)
+	assert.Equal(t, uint64(1), segments[1].BaseOffset)
+	assert.Equal(t, uint64(2), mgr.Tail())
+}
+
 func TestSegmentManager_Truncate(t *testing.T) {
 	cfg := DefaultManagerConfig()
 	cfg.MaxSegmentSize = 1

--- a/logstorage/queue_config.go
+++ b/logstorage/queue_config.go
@@ -37,7 +37,7 @@ const (
 // NewQueueConfigStore creates or opens a queue config store.
 func NewQueueConfigStore(baseDir string) (*QueueConfigStore, error) {
 	dir := filepath.Join(baseDir, "config")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := MkdirAllSynced(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create config directory: %w", err)
 	}
 
@@ -159,14 +159,22 @@ func (s *QueueConfigStore) saveUnlocked() error {
 		return fmt.Errorf("failed to marshal queue config state: %w", err)
 	}
 
+	// Queue metadata must reach disk before the queue it describes can be used
+	// to acknowledge a publisher: an atomic rename makes the replacement
+	// all-or-nothing, but not durable. Sync the replacement, then the directory
+	// that now names it.
 	tempPath := s.configPath() + TempExtension
-	if err := os.WriteFile(tempPath, data, 0o644); err != nil {
+	if err := WriteFileSynced(tempPath, data, 0o644); err != nil {
 		return fmt.Errorf("failed to write queue config file: %w", err)
 	}
 
 	if err := os.Rename(tempPath, s.configPath()); err != nil {
 		os.Remove(tempPath)
 		return fmt.Errorf("failed to rename queue config file: %w", err)
+	}
+
+	if err := SyncDir(s.dir); err != nil {
+		return fmt.Errorf("failed to sync queue config directory: %w", err)
 	}
 
 	s.dirty = false

--- a/logstorage/segment.go
+++ b/logstorage/segment.go
@@ -197,6 +197,57 @@ func SyncDir(dir string) error {
 	return nil
 }
 
+// MkdirAllSynced creates a directory and every missing parent, syncing each
+// parent as its child appears in it. os.MkdirAll leaves those new entries in
+// the page cache, so a crash can lose a whole queue directory even though the
+// segment inside it was synced.
+func MkdirAllSynced(path string, perm os.FileMode) error {
+	info, err := os.Stat(path)
+	if err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("%s exists and is not a directory", path)
+		}
+		return nil
+	}
+	if !os.IsNotExist(err) {
+		return err
+	}
+
+	parent := filepath.Dir(path)
+	if parent != path {
+		if err := MkdirAllSynced(parent, perm); err != nil {
+			return err
+		}
+	}
+
+	if err := os.Mkdir(path, perm); err != nil {
+		if os.IsExist(err) {
+			return nil
+		}
+		return err
+	}
+	return SyncDir(parent)
+}
+
+// WriteFileSynced writes a file and flushes its contents before returning. It
+// is the durable half of a write-then-rename replacement; the caller must still
+// sync the containing directory after the rename.
+func WriteFileSynced(path string, data []byte, perm os.FileMode) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		file.Close()
+		return err
+	}
+	return file.Close()
+}
+
 // scan reads through the segment to build batch positions and determine state.
 func (s *Segment) scan() error {
 	s.batchPositions = make([]batchPosition, 0, 64)

--- a/logstorage/segment.go
+++ b/logstorage/segment.go
@@ -163,7 +163,38 @@ func CreateSegment(dir string, baseOffset uint64, config SegmentConfig) (*Segmen
 		return nil, fmt.Errorf("failed to create time index: %w", err)
 	}
 
+	// Make the new directory entries durable. Syncing a file only flushes its
+	// contents; without this, a crash can lose the whole segment even after a
+	// caller observed a successful Sync, which would break the durability
+	// barrier AppendAndSync promises.
+	if err := SyncDir(dir); err != nil {
+		file.Close()
+		seg.index.Close()
+		seg.timeIndex.Close()
+		os.Remove(path)
+		os.Remove(indexPath)
+		os.Remove(timeIndexPath)
+		return nil, fmt.Errorf("failed to sync segment directory: %w", err)
+	}
+
 	return seg, nil
+}
+
+// SyncDir flushes a directory entry so files created inside it survive a crash.
+// Directory fsync is a no-op on filesystems that do not need it, and returns
+// ErrInvalid on platforms that do not allow opening a directory for sync; both
+// are reported as success because there is nothing further the caller can do.
+func SyncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	defer d.Close()
+
+	if err := d.Sync(); err != nil && !errors.Is(err, os.ErrInvalid) && !errors.Is(err, errors.ErrUnsupported) {
+		return err
+	}
+	return nil
 }
 
 // scan reads through the segment to build batch positions and determine state.

--- a/logstorage/store.go
+++ b/logstorage/store.go
@@ -49,7 +49,7 @@ func DefaultStoreConfig() StoreConfig {
 
 // NewStore creates a new AOL store.
 func NewStore(baseDir string, config StoreConfig) (*Store, error) {
-	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+	if err := MkdirAllSynced(baseDir, 0o755); err != nil {
 		return nil, fmt.Errorf("failed to create store directory: %w", err)
 	}
 

--- a/logstorage/store.go
+++ b/logstorage/store.go
@@ -253,6 +253,18 @@ func (s *Store) Append(queueName string, value []byte, key []byte, headers map[s
 	return manager.AppendMessage(value, key, headers)
 }
 
+// AppendAndSync appends a message and establishes its durability barrier as one
+// queue operation. The queue's segment manager prevents rotation until the
+// segment containing the appended message has been synced.
+func (s *Store) AppendAndSync(queueName string, value []byte, key []byte, headers map[string][]byte) (uint64, error) {
+	manager, err := s.getOrCreateQueue(queueName)
+	if err != nil {
+		return 0, err
+	}
+
+	return manager.AppendMessageAndSync(value, key, headers)
+}
+
 // AppendBatch appends a batch of messages to a queue.
 func (s *Store) AppendBatch(queueName string, batch *Batch) (uint64, error) {
 	manager, err := s.getOrCreateQueue(queueName)
@@ -809,6 +821,17 @@ func (s *Store) Sync() error {
 	}
 
 	return nil
+}
+
+// SyncQueue flushes the current active segment for one queue. Callers that need
+// a durability guarantee for a specific append must use AppendAndSync so a
+// concurrent segment rotation cannot move the active-segment pointer first.
+func (s *Store) SyncQueue(queueName string) error {
+	manager, err := s.getQueue(queueName)
+	if err != nil {
+		return err
+	}
+	return manager.Sync()
 }
 
 // Compact compacts all consumer state.

--- a/queue/manager.go
+++ b/queue/manager.go
@@ -515,8 +515,8 @@ func buildProtectedQueueContracts(contracts []types.QueueConfig) (map[string]typ
 
 func (m *Manager) validateProtectedQueueContractsLocked(ctx context.Context, contracts map[string]types.QueueConfig) error {
 	if len(contracts) > 0 {
-		if _, ok := m.queueStore.(storage.DurableQueueStore); !ok {
-			return fmt.Errorf("%w: protected queues require durable sync support with atomic append", ErrDurableSyncUnsupported)
+		if _, err := m.durableQueueStore(); err != nil {
+			return err
 		}
 	}
 
@@ -539,6 +539,31 @@ func (m *Manager) validateProtectedQueueContractsLocked(ctx context.Context, con
 		}
 	}
 	return nil
+}
+
+// protectedQueueContract copies one registered contract out of the registry so
+// callers can do storage work without holding protectedQueuesMu.
+func (m *Manager) protectedQueueContract(queueName string) (types.QueueConfig, bool) {
+	m.protectedQueuesMu.RLock()
+	defer m.protectedQueuesMu.RUnlock()
+
+	contract, protected := m.protectedQueueContracts[queueName]
+	if !protected {
+		return types.QueueConfig{}, false
+	}
+	return cloneQueueConfig(contract), true
+}
+
+// durableQueueStore returns the queue store only when it can actually make a
+// single append durable. A store that implements DurableQueueStore without real
+// crash durability must not back a protected queue, because publishers are
+// acknowledged on the strength of that barrier.
+func (m *Manager) durableQueueStore() (storage.DurableQueueStore, error) {
+	durableStore, ok := m.queueStore.(storage.DurableQueueStore)
+	if !ok || !durableStore.SupportsDurableSync() {
+		return nil, fmt.Errorf("%w: protected queues require durable sync support with atomic append", ErrDurableSyncUnsupported)
+	}
+	return durableStore, nil
 }
 
 func (m *Manager) validateProtectedQueueMutationLocked(config types.QueueConfig) error {
@@ -861,10 +886,13 @@ func (m *Manager) Publish(ctx context.Context, publish types.PublishRequest) err
 // per-queue durability barrier before returning success. The target must be a
 // reserved, durable, non-replicated stream. This method never performs topic
 // fanout and never auto-creates a queue.
+//
+// The contract snapshot is copied out of the registry before any storage work
+// starts. Holding protectedQueuesMu across the append would let one fsync block
+// every contract reload, and a reload waiting for the write lock would in turn
+// stall every subsequent publish.
 func (m *Manager) PublishToDurableStream(ctx context.Context, queueName string, publish types.PublishRequest) error {
-	m.protectedQueuesMu.RLock()
-	defer m.protectedQueuesMu.RUnlock()
-	expected, protected := m.protectedQueueContracts[queueName]
+	expected, protected := m.protectedQueueContract(queueName)
 	if !protected {
 		return fmt.Errorf("%w: %s", ErrQueueNotProtected, queueName)
 	}
@@ -892,9 +920,9 @@ func (m *Manager) PublishToDurableStream(ctx context.Context, queueName string, 
 	if queueConfig.Replication.Enabled {
 		return fmt.Errorf("%w: %s", ErrDurableReplicatedStreamUnsupported, queueName)
 	}
-	durableStore, ok := m.queueStore.(storage.DurableQueueStore)
-	if !ok {
-		return fmt.Errorf("%w: %s", ErrDurableSyncUnsupported, queueName)
+	durableStore, err := m.durableQueueStore()
+	if err != nil {
+		return fmt.Errorf("%w: %s", err, queueName)
 	}
 	if queueConfig.MaxMessageSize <= 0 || int64(len(publish.Payload)) > queueConfig.MaxMessageSize {
 		return fmt.Errorf(

--- a/queue/manager.go
+++ b/queue/manager.go
@@ -5,8 +5,11 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -20,6 +23,36 @@ import (
 	"github.com/absmach/fluxmq/queue/types"
 	brokerstorage "github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/topics"
+)
+
+var (
+	// ErrQueueNotStream is returned when an exact stream publish targets a
+	// queue that exists but is not configured as a stream.
+	ErrQueueNotStream = errors.New("queue is not a stream")
+	// ErrQueueNotDurable is returned when an exact durable publish targets an
+	// ephemeral queue.
+	ErrQueueNotDurable = errors.New("queue is not durable")
+	// ErrQueueNotReserved is returned when an exact internal publish targets a
+	// queue that is no longer protected as a statically reserved queue.
+	ErrQueueNotReserved = errors.New("queue is not reserved")
+	// ErrQueueMessageTooLarge is returned before append when an exact stream
+	// publish exceeds the target queue's configured maximum message size.
+	ErrQueueMessageTooLarge = errors.New("message exceeds queue maximum size")
+	// ErrQueueNotProtected is returned when the exact durable stream publish
+	// path is used for a queue without a registered immutable contract.
+	ErrQueueNotProtected = errors.New("queue has no protected contract")
+	// ErrProtectedQueueMutation is returned when a create, update, or delete
+	// would violate a registered queue contract.
+	ErrProtectedQueueMutation = errors.New("protected queue mutation rejected")
+	// ErrProtectedQueueContractDrift is returned when a protected queue's
+	// persisted configuration no longer matches its registered contract.
+	ErrProtectedQueueContractDrift = errors.New("protected queue contract drift")
+	// ErrDurableSyncUnsupported is returned before append when the configured
+	// queue store cannot establish a per-queue durability barrier.
+	ErrDurableSyncUnsupported = errors.New("queue store does not support durable sync")
+	// ErrDurableReplicatedStreamUnsupported prevents a false durability ACK in
+	// clustered mode until the same barrier is carried through leader forwarding.
+	ErrDurableReplicatedStreamUnsupported = errors.New("durable exact stream publish does not support replication")
 )
 
 type queueCluster interface {
@@ -46,6 +79,13 @@ type Manager struct {
 	config           Config
 	writePolicy      WritePolicy
 	distributionMode DistributionMode
+
+	// protectedQueueContracts contains only queues that back exact internal
+	// publishers. Its lock spans both contract checks and queue mutations so a
+	// runtime contract replacement cannot race an administrative mutation.
+	protectedQueuesMu       sync.RWMutex
+	protectedQueueContracts map[string]types.QueueConfig
+	protectedQueueConfigErr error
 
 	// Raft replication coordinator (queue -> raft group routing).
 	raftCoordinator queueRaftCoordinator
@@ -108,6 +148,11 @@ type Config struct {
 
 	// Queue configurations from main config
 	QueueConfigs []types.QueueConfig
+
+	// ProtectedQueueContracts are immutable runtime contracts for queues used
+	// by exact internal publishers. Only explicitly listed queues are protected;
+	// Reserved alone does not make a queue immutable.
+	ProtectedQueueContracts []types.QueueConfig
 
 	// OnConsumerRemoved is called when stale consumers are removed during
 	// heartbeat cleanup. The callback receives the queue name, group ID,
@@ -185,6 +230,7 @@ func NewManager(queueStore storage.QueueStore, groupStore storage.ConsumerGroupS
 	}
 
 	distMode := normalizeDistributionMode(config.DistributionMode)
+	protectedQueueContracts, protectedQueueConfigErr := buildProtectedQueueContracts(config.ProtectedQueueContracts)
 
 	var remote RemoteRouter
 	if cl != nil {
@@ -213,16 +259,18 @@ func NewManager(queueStore storage.QueueStore, groupStore storage.ConsumerGroupS
 		consumerManager: consumerMgr,
 		deliveryTarget:  dt,
 
-		logger:           logger,
-		config:           config,
-		writePolicy:      normalizeWritePolicy(config.WritePolicy),
-		distributionMode: distMode,
-		cluster:          cl,
-		localNodeID:      localNodeID,
-		subscriptions:    make(map[string]map[string]*subscriptionRef),
-		stopCh:           make(chan struct{}),
-		delivery:         engine,
-		metrics:          metrics,
+		logger:                  logger,
+		config:                  config,
+		writePolicy:             normalizeWritePolicy(config.WritePolicy),
+		distributionMode:        distMode,
+		protectedQueueContracts: protectedQueueContracts,
+		protectedQueueConfigErr: protectedQueueConfigErr,
+		cluster:                 cl,
+		localNodeID:             localNodeID,
+		subscriptions:           make(map[string]map[string]*subscriptionRef),
+		stopCh:                  make(chan struct{}),
+		delivery:                engine,
+		metrics:                 metrics,
 	}
 
 	return mgr
@@ -242,6 +290,9 @@ func (m *Manager) Start(ctx context.Context) error {
 	// Ensure reserved queues exist
 	if err := m.ensureReservedQueues(ctx); err != nil {
 		return fmt.Errorf("failed to create reserved queues: %w", err)
+	}
+	if err := m.ValidateProtectedQueueContracts(ctx); err != nil {
+		return fmt.Errorf("invalid protected queue contract: %w", err)
 	}
 
 	// Cleanup ephemeral queues that expired while broker was down
@@ -374,6 +425,200 @@ func (m *Manager) QueueStore() storage.QueueStore {
 	return m.queueStore
 }
 
+// ProtectedQueueContracts returns a snapshot of the currently registered
+// immutable queue contracts.
+func (m *Manager) ProtectedQueueContracts() []types.QueueConfig {
+	m.protectedQueuesMu.RLock()
+	defer m.protectedQueuesMu.RUnlock()
+
+	contracts := make([]types.QueueConfig, 0, len(m.protectedQueueContracts))
+	for _, contract := range m.protectedQueueContracts {
+		contracts = append(contracts, cloneQueueConfig(contract))
+	}
+	return contracts
+}
+
+// ReplaceProtectedQueueContracts validates and atomically replaces the
+// immutable queue-contract registry. Queue mutations and exact publishes are
+// blocked for the duration, so no operation can enter between persisted-state
+// validation and the registry swap.
+func (m *Manager) ReplaceProtectedQueueContracts(ctx context.Context, contracts []types.QueueConfig) error {
+	next, err := buildProtectedQueueContracts(contracts)
+	if err != nil {
+		return err
+	}
+
+	m.protectedQueuesMu.Lock()
+	defer m.protectedQueuesMu.Unlock()
+	if err := m.validateProtectedQueueContractsLocked(ctx, next); err != nil {
+		return err
+	}
+	m.protectedQueueContracts = next
+	m.protectedQueueConfigErr = nil
+	return nil
+}
+
+// NarrowProtectedQueueContracts replaces the registry with an exact subset of
+// the already-installed contracts without reading queue storage. It is used to
+// remove stale contracts after another subsystem has atomically committed its
+// new authorization snapshot; unlike ReplaceProtectedQueueContracts, this
+// finalization step cannot fail because of storage I/O.
+func (m *Manager) NarrowProtectedQueueContracts(contracts []types.QueueConfig) error {
+	next, err := buildProtectedQueueContracts(contracts)
+	if err != nil {
+		return err
+	}
+
+	m.protectedQueuesMu.Lock()
+	defer m.protectedQueuesMu.Unlock()
+	for name, contract := range next {
+		installed, ok := m.protectedQueueContracts[name]
+		if !ok {
+			return fmt.Errorf("protected queue contract %q is not installed", name)
+		}
+		if err := protectedQueueContractMismatch(installed, contract); err != nil {
+			return fmt.Errorf("protected queue contract %q differs from installed contract: %w", name, err)
+		}
+	}
+	m.protectedQueueContracts = next
+	m.protectedQueueConfigErr = nil
+	return nil
+}
+
+// ValidateProtectedQueueContracts verifies every registered contract against
+// the persisted queue configuration.
+func (m *Manager) ValidateProtectedQueueContracts(ctx context.Context) error {
+	m.protectedQueuesMu.RLock()
+	defer m.protectedQueuesMu.RUnlock()
+	if m.protectedQueueConfigErr != nil {
+		return m.protectedQueueConfigErr
+	}
+	return m.validateProtectedQueueContractsLocked(ctx, m.protectedQueueContracts)
+}
+
+func buildProtectedQueueContracts(contracts []types.QueueConfig) (map[string]types.QueueConfig, error) {
+	protected := make(map[string]types.QueueConfig, len(contracts))
+	for _, contract := range contracts {
+		if contract.Name == "" {
+			return nil, fmt.Errorf("protected queue contract name cannot be empty")
+		}
+		if _, exists := protected[contract.Name]; exists {
+			return nil, fmt.Errorf("protected queue contract %q is duplicated", contract.Name)
+		}
+		if err := protectedQueueContractMismatch(contract, contract); err != nil {
+			return nil, fmt.Errorf("invalid protected queue contract %q: %w", contract.Name, err)
+		}
+		protected[contract.Name] = cloneQueueConfig(contract)
+	}
+	return protected, nil
+}
+
+func (m *Manager) validateProtectedQueueContractsLocked(ctx context.Context, contracts map[string]types.QueueConfig) error {
+	if len(contracts) > 0 {
+		if _, ok := m.queueStore.(storage.DurableQueueStore); !ok {
+			return fmt.Errorf("%w: protected queues require durable sync support with atomic append", ErrDurableSyncUnsupported)
+		}
+	}
+
+	names := make([]string, 0, len(contracts))
+	for name := range contracts {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		persisted, err := m.queueStore.GetQueue(ctx, name)
+		if err != nil {
+			return fmt.Errorf("%w: load queue %q: %v", ErrProtectedQueueContractDrift, name, err)
+		}
+		if persisted == nil {
+			return fmt.Errorf("%w: load queue %q: %v", ErrProtectedQueueContractDrift, name, storage.ErrQueueNotFound)
+		}
+		if err := protectedQueueContractMismatch(contracts[name], *persisted); err != nil {
+			return fmt.Errorf("%w: %v", ErrProtectedQueueContractDrift, err)
+		}
+	}
+	return nil
+}
+
+func (m *Manager) validateProtectedQueueMutationLocked(config types.QueueConfig) error {
+	expected, protected := m.protectedQueueContracts[config.Name]
+	if !protected {
+		return nil
+	}
+	if err := protectedQueueContractMismatch(expected, config); err != nil {
+		return fmt.Errorf("%w: %v", ErrProtectedQueueMutation, err)
+	}
+	return nil
+}
+
+// ValidateProtectedQueueContract compares the persisted fields that define an
+// exact internal publisher's safety and replay guarantees. MaxDepth is
+// deliberately excluded because stream depth is not currently enforced.
+func ValidateProtectedQueueContract(expected, persisted types.QueueConfig) error {
+	if err := protectedQueueContractMismatch(expected, persisted); err != nil {
+		return fmt.Errorf("%w: %v", ErrProtectedQueueContractDrift, err)
+	}
+	return nil
+}
+
+func protectedQueueContractMismatch(expected, persisted types.QueueConfig) error {
+	target := expected.Name
+	switch {
+	case expected.Type != types.QueueTypeStream:
+		return fmt.Errorf("protected queue %q must be configured as a stream, got %q", target, expected.Type)
+	case !expected.Durable:
+		return fmt.Errorf("protected queue %q must be configured as durable", target)
+	case !expected.Reserved:
+		return fmt.Errorf("protected queue %q must be configured as reserved", target)
+	case expected.Replication.Enabled:
+		return fmt.Errorf("protected queue %q must not configure replication", target)
+	case expected.MaxMessageSize <= 0:
+		return fmt.Errorf("protected queue %q must configure a positive limits.max_message_size", target)
+	case persisted.Name != expected.Name:
+		return protectedQueueFieldMismatch(target, "name", persisted.Name, expected.Name)
+	case !slices.Equal(persisted.Topics, expected.Topics):
+		return protectedQueueFieldMismatch(target, "topics", persisted.Topics, expected.Topics)
+	case persisted.Type != types.QueueTypeStream:
+		return fmt.Errorf("protected queue %q must be a stream, got %q", target, persisted.Type)
+	case !persisted.Durable:
+		return fmt.Errorf("protected queue %q must be durable", target)
+	case !persisted.Reserved:
+		return fmt.Errorf("protected queue %q must be reserved", target)
+	case persisted.Replication.Enabled:
+		return fmt.Errorf("protected queue %q must not enable replication", target)
+	case persisted.Type != expected.Type:
+		return protectedQueueFieldMismatch(target, "type", persisted.Type, expected.Type)
+	case persisted.Durable != expected.Durable:
+		return protectedQueueFieldMismatch(target, "durable", persisted.Durable, expected.Durable)
+	case persisted.Reserved != expected.Reserved:
+		return protectedQueueFieldMismatch(target, "reserved", persisted.Reserved, expected.Reserved)
+	case persisted.Replication.Enabled != expected.Replication.Enabled:
+		return protectedQueueFieldMismatch(target, "replication.enabled", persisted.Replication.Enabled, expected.Replication.Enabled)
+	case persisted.Retention.RetentionTime != expected.Retention.RetentionTime:
+		return protectedQueueFieldMismatch(target, "retention.max_age", persisted.Retention.RetentionTime, expected.Retention.RetentionTime)
+	case persisted.Retention.RetentionBytes != expected.Retention.RetentionBytes:
+		return protectedQueueFieldMismatch(target, "retention.max_length_bytes", persisted.Retention.RetentionBytes, expected.Retention.RetentionBytes)
+	case persisted.Retention.RetentionMessages != expected.Retention.RetentionMessages:
+		return protectedQueueFieldMismatch(target, "retention.max_length_messages", persisted.Retention.RetentionMessages, expected.Retention.RetentionMessages)
+	case persisted.MaxMessageSize != expected.MaxMessageSize:
+		return protectedQueueFieldMismatch(target, "limits.max_message_size", persisted.MaxMessageSize, expected.MaxMessageSize)
+	case persisted.MessageTTL != expected.MessageTTL:
+		return protectedQueueFieldMismatch(target, "limits.message_ttl", persisted.MessageTTL, expected.MessageTTL)
+	default:
+		return nil
+	}
+}
+
+func protectedQueueFieldMismatch(target, field string, got, want any) error {
+	return fmt.Errorf("protected queue %q field %s is %v, want %v", target, field, got, want)
+}
+
+func cloneQueueConfig(config types.QueueConfig) types.QueueConfig {
+	config.Topics = append([]string(nil), config.Topics...)
+	return config
+}
+
 // GroupStore returns the consumer group store used by the manager.
 func (m *Manager) GroupStore() storage.ConsumerGroupStore {
 	return m.groupStore
@@ -383,6 +628,12 @@ func (m *Manager) GroupStore() storage.ConsumerGroupStore {
 
 // CreateQueue creates a new queue.
 func (m *Manager) CreateQueue(ctx context.Context, config types.QueueConfig) error {
+	m.protectedQueuesMu.RLock()
+	defer m.protectedQueuesMu.RUnlock()
+	if err := m.validateProtectedQueueMutationLocked(config); err != nil {
+		return err
+	}
+
 	if config.Replication.Enabled && m.raftCoordinator != nil && m.raftCoordinator.IsEnabled() {
 		if err := m.raftCoordinator.EnsureQueue(ctx, config); err != nil {
 			return err
@@ -415,6 +666,12 @@ func (m *Manager) CreateQueue(ctx context.Context, config types.QueueConfig) err
 
 // UpdateQueue updates an existing queue.
 func (m *Manager) UpdateQueue(ctx context.Context, config types.QueueConfig) error {
+	m.protectedQueuesMu.RLock()
+	defer m.protectedQueuesMu.RUnlock()
+	if err := m.validateProtectedQueueMutationLocked(config); err != nil {
+		return err
+	}
+
 	current, err := m.queueStore.GetQueue(ctx, config.Name)
 	if err != nil {
 		return err
@@ -476,6 +733,12 @@ func (m *Manager) GetOrCreateQueue(ctx context.Context, queueName string, topics
 
 // DeleteQueue deletes a queue.
 func (m *Manager) DeleteQueue(ctx context.Context, queueName string) error {
+	m.protectedQueuesMu.RLock()
+	defer m.protectedQueuesMu.RUnlock()
+	if _, protected := m.protectedQueueContracts[queueName]; protected {
+		return fmt.Errorf("%w: queue %q cannot be deleted", ErrProtectedQueueMutation, queueName)
+	}
+
 	queueCfg, err := m.queueStore.GetQueue(ctx, queueName)
 	if err != nil {
 		return err
@@ -594,6 +857,64 @@ func (m *Manager) Publish(ctx context.Context, publish types.PublishRequest) err
 	return nil
 }
 
+// PublishToDurableStream appends to exactly queueName and establishes a
+// per-queue durability barrier before returning success. The target must be a
+// reserved, durable, non-replicated stream. This method never performs topic
+// fanout and never auto-creates a queue.
+func (m *Manager) PublishToDurableStream(ctx context.Context, queueName string, publish types.PublishRequest) error {
+	m.protectedQueuesMu.RLock()
+	defer m.protectedQueuesMu.RUnlock()
+	expected, protected := m.protectedQueueContracts[queueName]
+	if !protected {
+		return fmt.Errorf("%w: %s", ErrQueueNotProtected, queueName)
+	}
+
+	publish = normalizePublishRequest(publish)
+	queueConfig, err := m.queueStore.GetQueue(ctx, queueName)
+	if err != nil {
+		return fmt.Errorf("get exact stream %q: %w", queueName, err)
+	}
+	if queueConfig == nil {
+		return fmt.Errorf("get exact stream %q: %w", queueName, storage.ErrQueueNotFound)
+	}
+	if err := protectedQueueContractMismatch(expected, *queueConfig); err != nil {
+		return fmt.Errorf("%w: %v", ErrProtectedQueueContractDrift, err)
+	}
+	if !queueConfig.Reserved {
+		return fmt.Errorf("%w: %s", ErrQueueNotReserved, queueName)
+	}
+	if queueConfig.Type != types.QueueTypeStream {
+		return fmt.Errorf("%w: %s", ErrQueueNotStream, queueName)
+	}
+	if !queueConfig.Durable {
+		return fmt.Errorf("%w: %s", ErrQueueNotDurable, queueName)
+	}
+	if queueConfig.Replication.Enabled {
+		return fmt.Errorf("%w: %s", ErrDurableReplicatedStreamUnsupported, queueName)
+	}
+	durableStore, ok := m.queueStore.(storage.DurableQueueStore)
+	if !ok {
+		return fmt.Errorf("%w: %s", ErrDurableSyncUnsupported, queueName)
+	}
+	if queueConfig.MaxMessageSize <= 0 || int64(len(publish.Payload)) > queueConfig.MaxMessageSize {
+		return fmt.Errorf(
+			"%w: queue %s accepts at most %d bytes, got %d",
+			ErrQueueMessageTooLarge,
+			queueName,
+			queueConfig.MaxMessageSize,
+			len(publish.Payload),
+		)
+	}
+
+	msg := newQueuedMessage(publish, queueConfig)
+	offset, err := durableStore.AppendAndSync(ctx, queueName, msg)
+	if err := m.completeAppend(queueName, publish.Topic, offset, err); err != nil {
+		return err
+	}
+	m.delivery.Schedule(queueName)
+	return nil
+}
+
 // HandleQueuePublish implements cluster.QueueHandler.HandleQueuePublish.
 func (m *Manager) HandleQueuePublish(ctx context.Context, publish types.PublishRequest, mode types.PublishMode) error {
 	publish = normalizePublishRequest(publish)
@@ -685,65 +1006,77 @@ func (m *Manager) resolvePublishTargets(ctx context.Context, publish types.Publi
 }
 
 func (m *Manager) publishLocalToTargets(ctx context.Context, publish types.PublishRequest, targets []queuePublishTarget) error {
-	cleanProps := cloneWithoutForwardingMeta(publish.Properties)
-
+	errs := make([]error, 0)
 	for _, target := range targets {
-		queueName := target.name
-		queueConfig := target.config
-		if queueConfig == nil {
+		if err := m.appendLocalTarget(ctx, publish, target); err != nil {
+			errs = append(errs, err)
 			continue
 		}
-
-		// Create message for this queue
-		now := time.Now()
-		msg := &types.Message{
-			ID:         generateMessageID(),
-			Payload:    publish.Payload,
-			Topic:      publish.Topic,
-			Properties: cleanProps,
-			State:      types.StateQueued,
-			CreatedAt:  now,
-		}
-		if queueConfig.MessageTTL > 0 {
-			msg.ExpiresAt = now.Add(queueConfig.MessageTTL)
-		}
-
-		var (
-			offset uint64
-			err    error
-		)
-
-		replicated := queueConfig.Replication.Enabled
-		if replicated && m.raftCoordinator != nil && m.raftCoordinator.IsEnabled() {
-			syncMode := queueConfig.Replication.Mode != types.ReplicationAsync
-			offset, err = m.raftCoordinator.ApplyAppendWithOptions(ctx, queueName, msg, raft.ApplyOptions{
-				SyncMode:   &syncMode,
-				AckTimeout: queueConfig.Replication.AckTimeout,
-			})
-		} else {
-			if replicated && (m.raftCoordinator == nil || !m.raftCoordinator.IsEnabled()) {
-				m.logger.Warn("queue replication enabled but raft manager unavailable; appending locally",
-					slog.String("queue", queueName))
-			}
-			offset, err = m.queueStore.Append(ctx, queueName, msg)
-		}
-
-		if err != nil {
-			m.logger.Warn("failed to append to queue",
-				slog.String("queue", queueName),
-				slog.String("topic", publish.Topic),
-				slog.String("error", err.Error()))
-			continue
-		}
-
-		m.logger.Debug("message published",
-			slog.String("queue", queueName),
-			slog.String("topic", publish.Topic),
-			slog.Uint64("offset", offset))
-
-		m.delivery.Schedule(queueName)
+		m.delivery.Schedule(target.name)
 	}
 
+	return errors.Join(errs...)
+}
+
+func (m *Manager) appendLocalTarget(ctx context.Context, publish types.PublishRequest, target queuePublishTarget) error {
+	queueName := target.name
+	queueConfig := target.config
+	if queueConfig == nil {
+		return fmt.Errorf("append to queue %q: missing queue configuration", queueName)
+	}
+
+	msg := newQueuedMessage(publish, queueConfig)
+
+	var (
+		offset uint64
+		err    error
+	)
+	replicated := queueConfig.Replication.Enabled
+	if replicated && m.raftCoordinator != nil && m.raftCoordinator.IsEnabled() {
+		syncMode := queueConfig.Replication.Mode != types.ReplicationAsync
+		offset, err = m.raftCoordinator.ApplyAppendWithOptions(ctx, queueName, msg, raft.ApplyOptions{
+			SyncMode:   &syncMode,
+			AckTimeout: queueConfig.Replication.AckTimeout,
+		})
+	} else {
+		if replicated && (m.raftCoordinator == nil || !m.raftCoordinator.IsEnabled()) {
+			m.logger.Warn("queue replication enabled but raft manager unavailable; appending locally",
+				slog.String("queue", queueName))
+		}
+		offset, err = m.queueStore.Append(ctx, queueName, msg)
+	}
+	return m.completeAppend(queueName, publish.Topic, offset, err)
+}
+
+func newQueuedMessage(publish types.PublishRequest, queueConfig *types.QueueConfig) *types.Message {
+	now := time.Now()
+	msg := &types.Message{
+		ID:         generateMessageID(),
+		Payload:    publish.Payload,
+		Topic:      publish.Topic,
+		Properties: cloneWithoutForwardingMeta(publish.Properties),
+		State:      types.StateQueued,
+		CreatedAt:  now,
+	}
+	if queueConfig.MessageTTL > 0 {
+		msg.ExpiresAt = now.Add(queueConfig.MessageTTL)
+	}
+	return msg
+}
+
+func (m *Manager) completeAppend(queueName, topic string, offset uint64, err error) error {
+	if err != nil {
+		m.logger.Warn("failed to append to queue",
+			slog.String("queue", queueName),
+			slog.String("topic", topic),
+			slog.String("error", err.Error()))
+		return fmt.Errorf("append to queue %q: %w", queueName, err)
+	}
+
+	m.logger.Debug("message published",
+		slog.String("queue", queueName),
+		slog.String("topic", topic),
+		slog.Uint64("offset", offset))
 	return nil
 }
 

--- a/queue/manager_test.go
+++ b/queue/manager_test.go
@@ -15,6 +15,7 @@ import (
 
 	corebroker "github.com/absmach/fluxmq/broker"
 	"github.com/absmach/fluxmq/cluster"
+	"github.com/absmach/fluxmq/logstorage"
 	core "github.com/absmach/fluxmq/mqtt"
 	clusterv1 "github.com/absmach/fluxmq/pkg/proto/cluster/v1"
 	"github.com/absmach/fluxmq/queue/consumer"
@@ -110,6 +111,10 @@ func (s *recordingDurableQueueStore) AppendAndSync(ctx context.Context, queueNam
 	s.mu.Unlock()
 	return offset, err
 }
+
+// SupportsDurableSync reports true so the manager treats this test double as a
+// crash-durable store; the wrapped in-memory store never is.
+func (s *recordingDurableQueueStore) SupportsDurableSync() bool { return true }
 
 func (s *recordingDurableQueueStore) Operations() []string {
 	s.mu.Lock()
@@ -492,6 +497,108 @@ func TestPublishToDurableStreamRejectsMissingAndClassicQueue(t *testing.T) {
 	})
 }
 
+// volatileDurableQueueStore implements the durable-append method without real
+// crash durability, the shape an in-memory store has.
+type volatileDurableQueueStore struct {
+	storage.QueueStore
+	appendAndSyncCalls int
+}
+
+func (s *volatileDurableQueueStore) AppendAndSync(ctx context.Context, queueName string, msg *types.Message) (uint64, error) {
+	s.appendAndSyncCalls++
+	return s.QueueStore.Append(ctx, queueName, msg)
+}
+
+func (s *volatileDurableQueueStore) SupportsDurableSync() bool { return false }
+
+func TestProtectedQueuesRejectStoreWithoutRealDurableSync(t *testing.T) {
+	ctx := context.Background()
+	expected := protectedAuditQueueConfig()
+	store := &volatileDurableQueueStore{QueueStore: memlog.New()}
+	if err := store.CreateQueue(ctx, expected); err != nil {
+		t.Fatalf("create protected queue: %v", err)
+	}
+	manager := NewManager(store, newMockGroupStore(), nil, managerConfigWithProtectedQueue(expected), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+
+	err := manager.PublishToDurableStream(ctx, testAuditQueueName, types.PublishRequest{
+		Topic:   testAuditQueueTopic,
+		Payload: []byte("{}"),
+	})
+	if !errors.Is(err, ErrDurableSyncUnsupported) {
+		t.Fatalf("error = %v, want ErrDurableSyncUnsupported", err)
+	}
+	if store.appendAndSyncCalls != 0 {
+		t.Fatalf("appendAndSync calls = %d, want 0; a publisher must never be acknowledged on a volatile store", store.appendAndSyncCalls)
+	}
+	if err := manager.ValidateProtectedQueueContracts(ctx); !errors.Is(err, ErrDurableSyncUnsupported) {
+		t.Fatalf("ValidateProtectedQueueContracts() error = %v, want ErrDurableSyncUnsupported", err)
+	}
+}
+
+// blockingDurableQueueStore holds AppendAndSync open until the test releases
+// it, standing in for a slow fsync.
+type blockingDurableQueueStore struct {
+	storage.QueueStore
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *blockingDurableQueueStore) AppendAndSync(ctx context.Context, queueName string, msg *types.Message) (uint64, error) {
+	close(s.started)
+	<-s.release
+	return s.QueueStore.Append(ctx, queueName, msg)
+}
+
+func (s *blockingDurableQueueStore) SupportsDurableSync() bool { return true }
+
+func TestPublishToDurableStreamDoesNotBlockContractReload(t *testing.T) {
+	ctx := context.Background()
+	expected := protectedAuditQueueConfig()
+	store := &blockingDurableQueueStore{
+		QueueStore: memlog.New(),
+		started:    make(chan struct{}),
+		release:    make(chan struct{}),
+	}
+	if err := store.CreateQueue(ctx, expected); err != nil {
+		t.Fatalf("create protected queue: %v", err)
+	}
+	manager := NewManager(store, newMockGroupStore(), nil, managerConfigWithProtectedQueue(expected), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+
+	publishErr := make(chan error, 1)
+	go func() {
+		publishErr <- manager.PublishToDurableStream(ctx, testAuditQueueName, types.PublishRequest{
+			Topic:   testAuditQueueTopic,
+			Payload: []byte("{}"),
+		})
+	}()
+
+	select {
+	case <-store.started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the durable append to start")
+	}
+
+	reloaded := make(chan error, 1)
+	go func() {
+		reloaded <- manager.ReplaceProtectedQueueContracts(ctx, []types.QueueConfig{expected})
+	}()
+
+	select {
+	case err := <-reloaded:
+		if err != nil {
+			t.Fatalf("ReplaceProtectedQueueContracts() error = %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		close(store.release)
+		t.Fatal("contract reload blocked behind an in-flight durable append")
+	}
+
+	close(store.release)
+	if err := <-publishErr; err != nil {
+		t.Fatalf("PublishToDurableStream() error = %v", err)
+	}
+}
+
 func TestPublishToDurableStreamRejectsUnsafeConfigurationBeforeAppend(t *testing.T) {
 	ctx := context.Background()
 
@@ -774,6 +881,58 @@ func TestPublishToDurableStreamTargetsOneQueueAndSyncsBeforeSuccess(t *testing.T
 	overlapTail, err := base.Tail(ctx, "overlap")
 	if err != nil || overlapTail != 0 {
 		t.Fatalf("overlap tail = %d, error = %v, want 0", overlapTail, err)
+	}
+}
+
+// TestPublishToDurableStreamAcknowledgesOnlyPersistedRecords is the
+// end-to-end form of the ACK contract: when the publish call returns success,
+// the record must be recoverable from storage alone, with none of the
+// publishing process's in-memory state. It uses the real file-backed store
+// rather than a double, because the point under test is what reached disk.
+func TestPublishToDurableStreamAcknowledgesOnlyPersistedRecords(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	queueConfig := protectedAuditQueueConfig()
+
+	store, err := logstorage.NewAdapter(dir, logstorage.DefaultAdapterConfig())
+	if err != nil {
+		t.Fatalf("open queue store: %v", err)
+	}
+	manager := NewManager(store, newMockGroupStore(), nil, managerConfigWithProtectedQueue(queueConfig), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	if err := manager.CreateQueue(ctx, queueConfig); err != nil {
+		t.Fatalf("create protected stream: %v", err)
+	}
+
+	payload := []byte(`{"id":"durability-1"}`)
+	if err := manager.PublishToDurableStream(ctx, testAuditQueueName, types.PublishRequest{
+		Topic:   testAuditQueueTopic,
+		Payload: payload,
+	}); err != nil {
+		t.Fatalf("PublishToDurableStream() error = %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close queue store: %v", err)
+	}
+
+	reopened, err := logstorage.NewAdapter(dir, logstorage.DefaultAdapterConfig())
+	if err != nil {
+		t.Fatalf("reopen queue store: %v", err)
+	}
+	t.Cleanup(func() { reopened.Close() })
+
+	count, err := reopened.Count(ctx, testAuditQueueName)
+	if err != nil {
+		t.Fatalf("Count() error = %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("persisted records = %d, want 1", count)
+	}
+	msg, err := reopened.Read(ctx, testAuditQueueName, 0)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if string(msg.Payload) != string(payload) {
+		t.Fatalf("persisted payload = %q, want %q", msg.Payload, payload)
 	}
 }
 

--- a/queue/manager_test.go
+++ b/queue/manager_test.go
@@ -30,7 +30,12 @@ var (
 	errTestSync   = errors.New("sync failed")
 )
 
-const node1 = "node-1"
+const (
+	node1                = "node-1"
+	testAuditQueueName   = "atom-audit"
+	testAuditQueueTopic  = "$queue/atom-audit"
+	testAuditQueueFilter = "$queue/atom-audit/#"
+)
 
 type targetCheckingDeliverer struct {
 	targets map[string]bool
@@ -121,7 +126,7 @@ func (d *targetCheckingDeliverer) HasDeliveryTarget(clientID string) bool {
 }
 
 func protectedAuditQueueConfig() types.QueueConfig {
-	config := types.DefaultQueueConfig("atom-audit", "$queue/atom-audit/#")
+	config := types.DefaultQueueConfig(testAuditQueueName, testAuditQueueFilter)
 	config.Type = types.QueueTypeStream
 	config.Reserved = true
 	config.Retention.RetentionTime = 30 * 24 * time.Hour
@@ -455,8 +460,8 @@ func TestPublishToDurableStreamRejectsMissingAndClassicQueue(t *testing.T) {
 
 	t.Run("missing", func(t *testing.T) {
 		manager, store := newManager()
-		err := manager.PublishToDurableStream(ctx, "atom-audit", types.PublishRequest{
-			Topic:   "$queue/atom-audit",
+		err := manager.PublishToDurableStream(ctx, testAuditQueueName, types.PublishRequest{
+			Topic:   testAuditQueueTopic,
 			Payload: []byte("{}"),
 		})
 		if !errors.Is(err, storage.ErrQueueNotFound) {
@@ -469,13 +474,13 @@ func TestPublishToDurableStreamRejectsMissingAndClassicQueue(t *testing.T) {
 
 	t.Run("classic", func(t *testing.T) {
 		manager, store := newManager()
-		queueConfig := types.DefaultQueueConfig("atom-audit", "$queue/atom-audit/#")
+		queueConfig := types.DefaultQueueConfig(testAuditQueueName, testAuditQueueFilter)
 		queueConfig.Reserved = true
 		if err := store.QueueStore.CreateQueue(ctx, queueConfig); err != nil {
 			t.Fatalf("create classic queue: %v", err)
 		}
-		err := manager.PublishToDurableStream(ctx, "atom-audit", types.PublishRequest{
-			Topic:   "$queue/atom-audit",
+		err := manager.PublishToDurableStream(ctx, testAuditQueueName, types.PublishRequest{
+			Topic:   testAuditQueueTopic,
 			Payload: []byte("{}"),
 		})
 		if !errors.Is(err, ErrProtectedQueueContractDrift) {
@@ -554,8 +559,8 @@ func TestPublishToDurableStreamRejectsUnsafeConfigurationBeforeAppend(t *testing
 			}
 			manager := NewManager(managerStore, newMockGroupStore(), nil, managerConfigWithProtectedQueue(expected), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
 
-			err := manager.PublishToDurableStream(ctx, "atom-audit", types.PublishRequest{
-				Topic:   "$queue/atom-audit",
+			err := manager.PublishToDurableStream(ctx, testAuditQueueName, types.PublishRequest{
+				Topic:   testAuditQueueTopic,
 				Payload: []byte("{}"),
 			})
 			if !errors.Is(err, tc.wantErr) {
@@ -564,7 +569,7 @@ func TestPublishToDurableStreamRejectsUnsafeConfigurationBeforeAppend(t *testing
 			if operations := store.Operations(); len(operations) != 0 {
 				t.Fatalf("operations = %v, want none", operations)
 			}
-			tail, tailErr := base.Tail(ctx, "atom-audit")
+			tail, tailErr := base.Tail(ctx, testAuditQueueName)
 			if tailErr != nil || tail != 0 {
 				t.Fatalf("tail = %d, error = %v, want empty queue", tail, tailErr)
 			}
@@ -753,8 +758,8 @@ func TestPublishToDurableStreamTargetsOneQueueAndSyncsBeforeSuccess(t *testing.T
 		}
 	}
 
-	if err := manager.PublishToDurableStream(ctx, "atom-audit", types.PublishRequest{
-		Topic:   "$queue/atom-audit",
+	if err := manager.PublishToDurableStream(ctx, testAuditQueueName, types.PublishRequest{
+		Topic:   testAuditQueueTopic,
 		Payload: []byte("audit-event"),
 	}); err != nil {
 		t.Fatalf("durable stream publish: %v", err)
@@ -762,7 +767,7 @@ func TestPublishToDurableStreamTargetsOneQueueAndSyncsBeforeSuccess(t *testing.T
 	if operations := store.Operations(); fmt.Sprint(operations) != "[append:atom-audit sync:atom-audit]" {
 		t.Fatalf("operations = %v, want append then sync for atom-audit", operations)
 	}
-	auditTail, err := base.Tail(ctx, "atom-audit")
+	auditTail, err := base.Tail(ctx, testAuditQueueName)
 	if err != nil || auditTail != 1 {
 		t.Fatalf("atom-audit tail = %d, error = %v, want 1", auditTail, err)
 	}
@@ -794,8 +799,8 @@ func TestPublishToDurableStreamPropagatesAppendAndSyncFailures(t *testing.T) {
 				t.Fatalf("create stream: %v", err)
 			}
 
-			err := manager.PublishToDurableStream(ctx, "atom-audit", types.PublishRequest{
-				Topic:   "$queue/atom-audit",
+			err := manager.PublishToDurableStream(ctx, testAuditQueueName, types.PublishRequest{
+				Topic:   testAuditQueueTopic,
 				Payload: []byte("{}"),
 			})
 			if !errors.Is(err, tc.wantErr) {

--- a/queue/manager_test.go
+++ b/queue/manager_test.go
@@ -5,6 +5,7 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -24,10 +25,91 @@ import (
 	brokerstorage "github.com/absmach/fluxmq/storage"
 )
 
+var (
+	errTestAppend = errors.New("append failed")
+	errTestSync   = errors.New("sync failed")
+)
+
 const node1 = "node-1"
 
 type targetCheckingDeliverer struct {
 	targets map[string]bool
+}
+
+type recordingDurableQueueStore struct {
+	storage.QueueStore
+	mu         sync.Mutex
+	appendErr  error
+	syncErr    error
+	operations []string
+}
+
+// queueStoreWithoutDurableSync deliberately narrows the wrapped store to the
+// QueueStore contract so its atomic durable-append method is not exposed to the
+// manager.
+type queueStoreWithoutDurableSync struct {
+	storage.QueueStore
+}
+
+type getErrorQueueStore struct {
+	storage.QueueStore
+	getErr error
+}
+
+func (s *getErrorQueueStore) GetQueue(ctx context.Context, queueName string) (*types.QueueConfig, error) {
+	if s.getErr != nil {
+		return nil, s.getErr
+	}
+	return s.QueueStore.GetQueue(ctx, queueName)
+}
+
+func (s *recordingDurableQueueStore) Append(ctx context.Context, queueName string, msg *types.Message) (uint64, error) {
+	s.mu.Lock()
+	s.operations = append(s.operations, "append:"+queueName)
+	err := s.appendErr
+	s.mu.Unlock()
+	if err != nil {
+		return 0, err
+	}
+	return s.QueueStore.Append(ctx, queueName, msg)
+}
+
+func (s *recordingDurableQueueStore) AppendAndSync(ctx context.Context, queueName string, msg *types.Message) (uint64, error) {
+	s.mu.Lock()
+	s.operations = append(s.operations, "append:"+queueName)
+	appendErr := s.appendErr
+	syncErr := s.syncErr
+	s.mu.Unlock()
+	if appendErr != nil {
+		return 0, appendErr
+	}
+
+	if syncErr != nil {
+		offset, err := s.QueueStore.Append(ctx, queueName, msg)
+		if err != nil {
+			return offset, err
+		}
+		s.mu.Lock()
+		s.operations = append(s.operations, "sync:"+queueName)
+		s.mu.Unlock()
+		return offset, syncErr
+	}
+
+	durableStore, ok := s.QueueStore.(storage.DurableQueueStore)
+	if !ok {
+		return 0, ErrDurableSyncUnsupported
+	}
+	offset, err := durableStore.AppendAndSync(ctx, queueName, msg)
+	s.mu.Lock()
+	s.operations = append(s.operations, "sync:"+queueName)
+	s.mu.Unlock()
+	return offset, err
+}
+
+func (s *recordingDurableQueueStore) Operations() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.operations...)
 }
 
 func (d *targetCheckingDeliverer) Deliver(context.Context, string, *brokerstorage.Message) error {
@@ -36,6 +118,22 @@ func (d *targetCheckingDeliverer) Deliver(context.Context, string, *brokerstorag
 
 func (d *targetCheckingDeliverer) HasDeliveryTarget(clientID string) bool {
 	return d.targets[clientID]
+}
+
+func protectedAuditQueueConfig() types.QueueConfig {
+	config := types.DefaultQueueConfig("atom-audit", "$queue/atom-audit/#")
+	config.Type = types.QueueTypeStream
+	config.Reserved = true
+	config.Retention.RetentionTime = 30 * 24 * time.Hour
+	config.Retention.RetentionBytes = 10 * 1024 * 1024 * 1024
+	config.MessageTTL = 30 * 24 * time.Hour
+	return config
+}
+
+func managerConfigWithProtectedQueue(contract types.QueueConfig) Config {
+	config := DefaultConfig()
+	config.ProtectedQueueContracts = []types.QueueConfig{contract}
+	return config
 }
 
 // mockGroupStore implements storage.ConsumerGroupStore for testing.
@@ -344,6 +442,385 @@ func TestWildcardQueueSubscription(t *testing.T) {
 			t.Logf("Group state: %s cursor=%v", g.ID, g.Cursor)
 		}
 		t.Fatal("Timeout waiting for message delivery")
+	}
+}
+
+func TestPublishToDurableStreamRejectsMissingAndClassicQueue(t *testing.T) {
+	ctx := context.Background()
+	expected := protectedAuditQueueConfig()
+	newManager := func() (*Manager, *recordingDurableQueueStore) {
+		store := &recordingDurableQueueStore{QueueStore: memlog.New()}
+		return NewManager(store, newMockGroupStore(), nil, managerConfigWithProtectedQueue(expected), slog.New(slog.NewTextHandler(io.Discard, nil)), nil), store
+	}
+
+	t.Run("missing", func(t *testing.T) {
+		manager, store := newManager()
+		err := manager.PublishToDurableStream(ctx, "atom-audit", types.PublishRequest{
+			Topic:   "$queue/atom-audit",
+			Payload: []byte("{}"),
+		})
+		if !errors.Is(err, storage.ErrQueueNotFound) {
+			t.Fatalf("error = %v, want queue not found", err)
+		}
+		if operations := store.Operations(); len(operations) != 0 {
+			t.Fatalf("operations = %v, want none", operations)
+		}
+	})
+
+	t.Run("classic", func(t *testing.T) {
+		manager, store := newManager()
+		queueConfig := types.DefaultQueueConfig("atom-audit", "$queue/atom-audit/#")
+		queueConfig.Reserved = true
+		if err := store.QueueStore.CreateQueue(ctx, queueConfig); err != nil {
+			t.Fatalf("create classic queue: %v", err)
+		}
+		err := manager.PublishToDurableStream(ctx, "atom-audit", types.PublishRequest{
+			Topic:   "$queue/atom-audit",
+			Payload: []byte("{}"),
+		})
+		if !errors.Is(err, ErrProtectedQueueContractDrift) {
+			t.Fatalf("error = %v, want ErrProtectedQueueContractDrift", err)
+		}
+		if operations := store.Operations(); len(operations) != 0 {
+			t.Fatalf("operations = %v, want none", operations)
+		}
+	})
+}
+
+func TestPublishToDurableStreamRejectsUnsafeConfigurationBeforeAppend(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		configure     func(expected, persisted *types.QueueConfig)
+		withoutSyncer bool
+		wantErr       error
+	}{
+		{
+			name: "non-reserved stream",
+			configure: func(_, persisted *types.QueueConfig) {
+				persisted.Reserved = false
+			},
+			wantErr: ErrProtectedQueueContractDrift,
+		},
+		{
+			name: "non-durable stream",
+			configure: func(_, persisted *types.QueueConfig) {
+				persisted.Durable = false
+			},
+			wantErr: ErrProtectedQueueContractDrift,
+		},
+		{
+			name: "replicated stream",
+			configure: func(_, persisted *types.QueueConfig) {
+				persisted.Replication.Enabled = true
+			},
+			wantErr: ErrProtectedQueueContractDrift,
+		},
+		{
+			name: "message exceeds queue maximum",
+			configure: func(expected, persisted *types.QueueConfig) {
+				expected.MaxMessageSize = 1
+				persisted.MaxMessageSize = 1
+			},
+			wantErr: ErrQueueMessageTooLarge,
+		},
+		{
+			name:          "store without durable sync",
+			withoutSyncer: true,
+			wantErr:       ErrDurableSyncUnsupported,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			base := memlog.New()
+			expected := protectedAuditQueueConfig()
+			persisted := expected
+			if tc.configure != nil {
+				tc.configure(&expected, &persisted)
+			}
+			if err := base.CreateQueue(ctx, expected); err != nil {
+				t.Fatalf("create stream: %v", err)
+			}
+			if err := base.UpdateQueue(ctx, persisted); err != nil {
+				t.Fatalf("inject stored queue configuration: %v", err)
+			}
+
+			store := &recordingDurableQueueStore{QueueStore: base}
+			var managerStore storage.QueueStore = store
+			if tc.withoutSyncer {
+				managerStore = &queueStoreWithoutDurableSync{QueueStore: base}
+			}
+			manager := NewManager(managerStore, newMockGroupStore(), nil, managerConfigWithProtectedQueue(expected), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+
+			err := manager.PublishToDurableStream(ctx, "atom-audit", types.PublishRequest{
+				Topic:   "$queue/atom-audit",
+				Payload: []byte("{}"),
+			})
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tc.wantErr)
+			}
+			if operations := store.Operations(); len(operations) != 0 {
+				t.Fatalf("operations = %v, want none", operations)
+			}
+			tail, tailErr := base.Tail(ctx, "atom-audit")
+			if tailErr != nil || tail != 0 {
+				t.Fatalf("tail = %d, error = %v, want empty queue", tail, tailErr)
+			}
+		})
+	}
+}
+
+func TestProtectedQueueRejectsContractMutationsAndDelete(t *testing.T) {
+	ctx := context.Background()
+	expected := protectedAuditQueueConfig()
+	tests := []struct {
+		name   string
+		mutate func(*types.QueueConfig)
+	}{
+		{name: "topics", mutate: func(config *types.QueueConfig) { config.Topics = []string{"#"} }},
+		{name: "type", mutate: func(config *types.QueueConfig) { config.Type = types.QueueTypeClassic }},
+		{name: "durable", mutate: func(config *types.QueueConfig) { config.Durable = false }},
+		{name: "reserved", mutate: func(config *types.QueueConfig) { config.Reserved = false }},
+		{name: "replication", mutate: func(config *types.QueueConfig) { config.Replication.Enabled = true }},
+		{name: "retention age", mutate: func(config *types.QueueConfig) { config.Retention.RetentionTime-- }},
+		{name: "retention bytes", mutate: func(config *types.QueueConfig) { config.Retention.RetentionBytes-- }},
+		{name: "retention messages", mutate: func(config *types.QueueConfig) { config.Retention.RetentionMessages++ }},
+		{name: "maximum message size", mutate: func(config *types.QueueConfig) { config.MaxMessageSize-- }},
+		{name: "message TTL", mutate: func(config *types.QueueConfig) { config.MessageTTL-- }},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store := memlog.New()
+			manager := NewManager(store, newMockGroupStore(), nil, managerConfigWithProtectedQueue(expected), nil, nil)
+			if err := manager.CreateQueue(ctx, expected); err != nil {
+				t.Fatalf("create protected queue: %v", err)
+			}
+			updated := expected
+			tc.mutate(&updated)
+			if err := manager.UpdateQueue(ctx, updated); !errors.Is(err, ErrProtectedQueueMutation) {
+				t.Fatalf("UpdateQueue() error = %v, want ErrProtectedQueueMutation", err)
+			}
+			persisted, err := store.GetQueue(ctx, expected.Name)
+			if err != nil {
+				t.Fatalf("GetQueue() error = %v", err)
+			}
+			if err := ValidateProtectedQueueContract(expected, *persisted); err != nil {
+				t.Fatalf("rejected update changed persisted contract: %v", err)
+			}
+		})
+	}
+
+	t.Run("delete", func(t *testing.T) {
+		store := memlog.New()
+		manager := NewManager(store, newMockGroupStore(), nil, managerConfigWithProtectedQueue(expected), nil, nil)
+		if err := manager.CreateQueue(ctx, expected); err != nil {
+			t.Fatalf("create protected queue: %v", err)
+		}
+		if err := manager.DeleteQueue(ctx, expected.Name); !errors.Is(err, ErrProtectedQueueMutation) {
+			t.Fatalf("DeleteQueue() error = %v, want ErrProtectedQueueMutation", err)
+		}
+		if _, err := store.GetQueue(ctx, expected.Name); err != nil {
+			t.Fatalf("protected queue was deleted: %v", err)
+		}
+	})
+
+	t.Run("MaxDepth is not protected", func(t *testing.T) {
+		store := memlog.New()
+		manager := NewManager(store, newMockGroupStore(), nil, managerConfigWithProtectedQueue(expected), nil, nil)
+		if err := manager.CreateQueue(ctx, expected); err != nil {
+			t.Fatalf("create protected queue: %v", err)
+		}
+		updated := expected
+		updated.MaxDepth++
+		if err := manager.UpdateQueue(ctx, updated); err != nil {
+			t.Fatalf("MaxDepth-only update rejected: %v", err)
+		}
+	})
+
+	t.Run("other reserved queue remains mutable", func(t *testing.T) {
+		store := memlog.New()
+		manager := NewManager(store, newMockGroupStore(), nil, managerConfigWithProtectedQueue(expected), nil, nil)
+		other := types.DefaultQueueConfig("other-reserved", "other/#")
+		other.Reserved = true
+		if err := manager.CreateQueue(ctx, other); err != nil {
+			t.Fatalf("create other reserved queue: %v", err)
+		}
+		other.MessageTTL++
+		other.Reserved = false
+		if err := manager.UpdateQueue(ctx, other); err != nil {
+			t.Fatalf("update other reserved queue: %v", err)
+		}
+		if err := manager.DeleteQueue(ctx, other.Name); err != nil {
+			t.Fatalf("delete other reserved queue: %v", err)
+		}
+	})
+}
+
+func TestNarrowProtectedQueueContractsDoesNotReadStorage(t *testing.T) {
+	ctx := context.Background()
+	base := memlog.New()
+	audit := protectedAuditQueueConfig()
+	security := protectedAuditQueueConfig()
+	security.Name = "atom-security"
+	security.Topics = []string{"$queue/atom-security/#"}
+	for _, contract := range []types.QueueConfig{audit, security} {
+		if err := base.CreateQueue(ctx, contract); err != nil {
+			t.Fatalf("create queue %q: %v", contract.Name, err)
+		}
+	}
+	store := &getErrorQueueStore{QueueStore: base}
+	config := DefaultConfig()
+	config.ProtectedQueueContracts = []types.QueueConfig{audit, security}
+	manager := NewManager(store, newMockGroupStore(), nil, config, nil, nil)
+
+	store.getErr = errors.New("queue store unavailable")
+	if err := manager.NarrowProtectedQueueContracts([]types.QueueConfig{security}); err != nil {
+		t.Fatalf("NarrowProtectedQueueContracts() performed storage I/O: %v", err)
+	}
+	contracts := manager.ProtectedQueueContracts()
+	if len(contracts) != 1 || contracts[0].Name != security.Name {
+		t.Fatalf("protected contracts = %+v, want only %q", contracts, security.Name)
+	}
+}
+
+func TestPublishToDurableStreamRejectsPersistedContractDrift(t *testing.T) {
+	ctx := context.Background()
+	expected := protectedAuditQueueConfig()
+	tests := []struct {
+		name   string
+		mutate func(*types.QueueConfig)
+	}{
+		{name: "topics", mutate: func(config *types.QueueConfig) { config.Topics = []string{"#"} }},
+		{name: "retention age", mutate: func(config *types.QueueConfig) { config.Retention.RetentionTime-- }},
+		{name: "retention bytes", mutate: func(config *types.QueueConfig) { config.Retention.RetentionBytes-- }},
+		{name: "retention messages", mutate: func(config *types.QueueConfig) { config.Retention.RetentionMessages++ }},
+		{name: "maximum message size", mutate: func(config *types.QueueConfig) { config.MaxMessageSize++ }},
+		{name: "message TTL", mutate: func(config *types.QueueConfig) { config.MessageTTL-- }},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			base := memlog.New()
+			if err := base.CreateQueue(ctx, expected); err != nil {
+				t.Fatalf("create queue: %v", err)
+			}
+			drifted := expected
+			tc.mutate(&drifted)
+			if err := base.UpdateQueue(ctx, drifted); err != nil {
+				t.Fatalf("inject persisted drift: %v", err)
+			}
+			store := &recordingDurableQueueStore{QueueStore: base}
+			manager := NewManager(store, newMockGroupStore(), nil, managerConfigWithProtectedQueue(expected), nil, nil)
+			err := manager.PublishToDurableStream(ctx, expected.Name, types.PublishRequest{Payload: []byte("{}")})
+			if !errors.Is(err, ErrProtectedQueueContractDrift) {
+				t.Fatalf("PublishToDurableStream() error = %v, want ErrProtectedQueueContractDrift", err)
+			}
+			if operations := store.Operations(); len(operations) != 0 {
+				t.Fatalf("operations = %v, want no append", operations)
+			}
+		})
+	}
+
+	t.Run("MaxDepth drift is ignored", func(t *testing.T) {
+		base := memlog.New()
+		drifted := expected
+		drifted.MaxDepth++
+		if err := base.CreateQueue(ctx, drifted); err != nil {
+			t.Fatalf("create queue: %v", err)
+		}
+		store := &recordingDurableQueueStore{QueueStore: base}
+		manager := NewManager(store, newMockGroupStore(), nil, managerConfigWithProtectedQueue(expected), nil, nil)
+		if err := manager.PublishToDurableStream(ctx, expected.Name, types.PublishRequest{Payload: []byte("{}")}); err != nil {
+			t.Fatalf("PublishToDurableStream() rejected MaxDepth drift: %v", err)
+		}
+	})
+}
+
+func TestPublishToDurableStreamTargetsOneQueueAndSyncsBeforeSuccess(t *testing.T) {
+	ctx := context.Background()
+	base := memlog.New()
+	store := &recordingDurableQueueStore{QueueStore: base}
+	audit := protectedAuditQueueConfig()
+	manager := NewManager(store, newMockGroupStore(), nil, managerConfigWithProtectedQueue(audit), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	overlap := types.DefaultQueueConfig("overlap", "$queue/#")
+	overlap.Type = types.QueueTypeStream
+	for _, queueConfig := range []types.QueueConfig{audit, overlap} {
+		if err := manager.CreateQueue(ctx, queueConfig); err != nil {
+			t.Fatalf("create queue %q: %v", queueConfig.Name, err)
+		}
+	}
+
+	if err := manager.PublishToDurableStream(ctx, "atom-audit", types.PublishRequest{
+		Topic:   "$queue/atom-audit",
+		Payload: []byte("audit-event"),
+	}); err != nil {
+		t.Fatalf("durable stream publish: %v", err)
+	}
+	if operations := store.Operations(); fmt.Sprint(operations) != "[append:atom-audit sync:atom-audit]" {
+		t.Fatalf("operations = %v, want append then sync for atom-audit", operations)
+	}
+	auditTail, err := base.Tail(ctx, "atom-audit")
+	if err != nil || auditTail != 1 {
+		t.Fatalf("atom-audit tail = %d, error = %v, want 1", auditTail, err)
+	}
+	overlapTail, err := base.Tail(ctx, "overlap")
+	if err != nil || overlapTail != 0 {
+		t.Fatalf("overlap tail = %d, error = %v, want 0", overlapTail, err)
+	}
+}
+
+func TestPublishToDurableStreamPropagatesAppendAndSyncFailures(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name           string
+		appendErr      error
+		syncErr        error
+		wantErr        error
+		wantOperations string
+	}{
+		{name: "append", appendErr: errTestAppend, wantErr: errTestAppend, wantOperations: "[append:atom-audit]"},
+		{name: "sync", syncErr: errTestSync, wantErr: errTestSync, wantOperations: "[append:atom-audit sync:atom-audit]"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			base := memlog.New()
+			store := &recordingDurableQueueStore{QueueStore: base, appendErr: tc.appendErr, syncErr: tc.syncErr}
+			queueConfig := protectedAuditQueueConfig()
+			manager := NewManager(store, newMockGroupStore(), nil, managerConfigWithProtectedQueue(queueConfig), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+			if err := manager.CreateQueue(ctx, queueConfig); err != nil {
+				t.Fatalf("create stream: %v", err)
+			}
+
+			err := manager.PublishToDurableStream(ctx, "atom-audit", types.PublishRequest{
+				Topic:   "$queue/atom-audit",
+				Payload: []byte("{}"),
+			})
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("error = %v, want %v", err, tc.wantErr)
+			}
+			if operations := fmt.Sprint(store.Operations()); operations != tc.wantOperations {
+				t.Fatalf("operations = %s, want %s", operations, tc.wantOperations)
+			}
+		})
+	}
+}
+
+func TestPublishPropagatesQueueAppendFailure(t *testing.T) {
+	ctx := context.Background()
+	base := memlog.New()
+	store := &recordingDurableQueueStore{QueueStore: base, appendErr: errTestAppend}
+	manager := NewManager(store, newMockGroupStore(), nil, DefaultConfig(), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	queueConfig := types.DefaultQueueConfig("events", "events/#")
+	if err := manager.CreateQueue(ctx, queueConfig); err != nil {
+		t.Fatalf("create queue: %v", err)
+	}
+
+	err := manager.Publish(ctx, types.PublishRequest{Topic: "events/created", Payload: []byte("event")})
+	if !errors.Is(err, errTestAppend) {
+		t.Fatalf("error = %v, want append failure", err)
 	}
 }
 

--- a/queue/storage/log.go
+++ b/queue/storage/log.go
@@ -70,6 +70,14 @@ type QueueStore interface {
 	Count(ctx context.Context, queueName string) (uint64, error)
 }
 
+// DurableQueueStore atomically appends and establishes a durability barrier for
+// the exact record written to a single queue. Implementations must serialize
+// segment rotation with the entire operation; Append followed by a separate
+// active-segment sync does not satisfy this contract.
+type DurableQueueStore interface {
+	AppendAndSync(ctx context.Context, queueName string, msg *types.Message) (uint64, error)
+}
+
 // ConsumerGroupStore manages cursor-based consumer groups with PEL tracking.
 type ConsumerGroupStore interface {
 	// CreateConsumerGroup creates a new consumer group for a queue.

--- a/queue/storage/log.go
+++ b/queue/storage/log.go
@@ -76,6 +76,13 @@ type QueueStore interface {
 // active-segment sync does not satisfy this contract.
 type DurableQueueStore interface {
 	AppendAndSync(ctx context.Context, queueName string, msg *types.Message) (uint64, error)
+
+	// SupportsDurableSync reports whether AppendAndSync survives process and
+	// machine crashes. Implementing the interface is not sufficient evidence:
+	// a volatile store can order an append without making it durable, so
+	// callers that acknowledge writes on behalf of a publisher must consult
+	// this method before promising durability.
+	SupportsDurableSync() bool
 }
 
 // ConsumerGroupStore manages cursor-based consumer groups with PEL tracking.

--- a/queue/storage/memory/log/store.go
+++ b/queue/storage/memory/log/store.go
@@ -194,12 +194,16 @@ func (s *Store) Append(ctx context.Context, queueName string, msg *types.Message
 	return offset, nil
 }
 
-// AppendAndSync is the in-memory implementation of an atomic durable append.
-// Append already serializes the write under the queue lock; there is no
-// separate filesystem durability barrier in this store.
+// AppendAndSync serializes the write under the queue lock, matching the
+// ordering half of the durable-append contract. Nothing in this store survives
+// process exit, so SupportsDurableSync reports false and callers must not
+// acknowledge writes as durable on top of it.
 func (s *Store) AppendAndSync(ctx context.Context, queueName string, msg *types.Message) (uint64, error) {
 	return s.Append(ctx, queueName, msg)
 }
+
+// SupportsDurableSync reports false: this store is in-memory only.
+func (s *Store) SupportsDurableSync() bool { return false }
 
 // AppendBatch adds multiple messages to a queue's log.
 func (s *Store) AppendBatch(ctx context.Context, queueName string, msgs []*types.Message) (uint64, error) {

--- a/queue/storage/memory/log/store.go
+++ b/queue/storage/memory/log/store.go
@@ -15,6 +15,8 @@ import (
 	"github.com/absmach/fluxmq/queue/types"
 )
 
+var _ storage.DurableQueueStore = (*Store)(nil)
+
 // Store implements queueStore and ConsumerGroupStore using in-memory data structures.
 type Store struct {
 	logs       sync.Map // map[string]*Log
@@ -190,6 +192,13 @@ func (s *Store) Append(ctx context.Context, queueName string, msg *types.Message
 	sl.messages = append(sl.messages, stabilizeForStore(msg))
 
 	return offset, nil
+}
+
+// AppendAndSync is the in-memory implementation of an atomic durable append.
+// Append already serializes the write under the queue lock; there is no
+// separate filesystem durability barrier in this store.
+func (s *Store) AppendAndSync(ctx context.Context, queueName string, msg *types.Message) (uint64, error) {
+	return s.Append(ctx, queueName, msg)
 }
 
 // AppendBatch adds multiple messages to a queue's log.

--- a/reload/manager.go
+++ b/reload/manager.go
@@ -44,6 +44,16 @@ type WebhookTuner interface {
 	Reconfigure(cfg config.WebhookConfig) error
 }
 
+// LocalPrincipalsReloadFunc validates and atomically swaps the complete local
+// principal snapshot. changed reports whether secret material or effective
+// principal policy changed, including changes to mounted files whose paths are
+// unchanged in YAML.
+type LocalPrincipalsReloadFunc func(principals []config.LocalPrincipalConfig) (changed bool, err error)
+
+// LocalPrincipalsReloadFailureFunc observes a configuration-load failure while
+// local principals are active. The current immutable snapshot remains active.
+type LocalPrincipalsReloadFailureFunc func(err error)
+
 // ErrShuttingDown indicates reload was rejected because shutdown has started.
 var ErrShuttingDown = errors.New("server is shutting down")
 
@@ -66,11 +76,13 @@ type Manager struct {
 	shuttingDown atomic.Bool
 
 	// Subsystem references for direct calls (decision #1 from eng review).
-	rateLimiter  *ratelimit.AtomicManager
-	broker       BrokerTuner
-	sessionTuner SessionTuner
-	webhookTuner WebhookTuner
-	logSetup     func(cfg config.LogConfig)
+	rateLimiter           *ratelimit.AtomicManager
+	broker                BrokerTuner
+	sessionTuner          SessionTuner
+	webhookTuner          WebhookTuner
+	localPrincipalsReload LocalPrincipalsReloadFunc
+	localPrincipalsFailed LocalPrincipalsReloadFailureFunc
+	logSetup              func(cfg config.LogConfig)
 }
 
 // Option configures the Manager.
@@ -94,6 +106,17 @@ func WithSessionTuner(t SessionTuner) Option {
 // WithWebhookTuner sets the webhook tuner for reload updates.
 func WithWebhookTuner(t WebhookTuner) Option {
 	return func(m *Manager) { m.webhookTuner = t }
+}
+
+// WithLocalPrincipalsReload sets the atomic local-principal reload callback.
+func WithLocalPrincipalsReload(fn LocalPrincipalsReloadFunc) Option {
+	return func(m *Manager) { m.localPrincipalsReload = fn }
+}
+
+// WithLocalPrincipalsReloadFailure sets the observer for load failures that
+// prevent an active local-principal configuration from reaching its callback.
+func WithLocalPrincipalsReloadFailure(fn LocalPrincipalsReloadFailureFunc) Option {
+	return func(m *Manager) { m.localPrincipalsFailed = fn }
 }
 
 // WithLogSetup sets the function called to reconfigure logging.
@@ -149,10 +172,24 @@ func (m *Manager) Reload(ctx context.Context) (*ReloadResult, error) {
 
 	newCfg, err := config.Load(m.configFile)
 	if err != nil {
+		if m.localPrincipalsFailed != nil && len(m.current.Auth.LocalPrincipals) > 0 {
+			m.localPrincipalsFailed(err)
+		}
 		return nil, fmt.Errorf("reload failed: %w", err)
 	}
 
 	diff := config.Diff(m.current, newCfg)
+	if m.localPrincipalsReload != nil && !hasFieldChange(diff.RuntimeSafe, "Auth.LocalPrincipals") {
+		// Secret files can change without their configured paths changing. Probe
+		// the immutable local-principal snapshot on every reload and retain this
+		// synthetic change only when the callback reports an effective change.
+		diff.RuntimeSafe = append(diff.RuntimeSafe, config.FieldChange{
+			Path:     "Auth.LocalPrincipals",
+			OldValue: m.current.Auth.LocalPrincipals,
+			NewValue: newCfg.Auth.LocalPrincipals,
+			Class:    config.RuntimeSafe,
+		})
+	}
 	if !diff.HasChanges() {
 		result.Duration = time.Since(start)
 		slog.Info("config reload: no changes detected", "version", m.version)
@@ -183,6 +220,11 @@ func (m *Manager) Reload(ctx context.Context) (*ReloadResult, error) {
 		m.current = updated
 		m.version++
 	}
+	if len(result.Applied) == 0 && len(result.RestartRequired) == 0 {
+		result.Duration = time.Since(start)
+		slog.Info("config reload: no changes detected", "version", m.version)
+		return result, nil
+	}
 	result.Version = m.version
 	result.Duration = time.Since(start)
 
@@ -210,7 +252,7 @@ func (m *Manager) applyRuntimeChanges(_ context.Context, old, new *config.Config
 	}
 
 	// Partition changes by subsystem.
-	var logChanges, rateLimitChanges, brokerChanges, sessionChanges, webhookChanges []config.FieldChange
+	var logChanges, rateLimitChanges, brokerChanges, sessionChanges, webhookChanges, localPrincipalChanges []config.FieldChange
 	for _, c := range changes {
 		switch {
 		case isLogField(c.Path):
@@ -223,6 +265,8 @@ func (m *Manager) applyRuntimeChanges(_ context.Context, old, new *config.Config
 			sessionChanges = append(sessionChanges, c)
 		case isWebhookField(c.Path):
 			webhookChanges = append(webhookChanges, c)
+		case c.Path == "Auth.LocalPrincipals":
+			localPrincipalChanges = append(localPrincipalChanges, c)
 		}
 	}
 
@@ -283,7 +327,39 @@ func (m *Manager) applyRuntimeChanges(_ context.Context, old, new *config.Config
 		}
 	}
 
+	if len(localPrincipalChanges) > 0 {
+		if m.localPrincipalsReload == nil {
+			errs = append(errs, "Auth.LocalPrincipals: local-principal reload is not configured")
+			for i := len(rollbacks) - 1; i >= 0; i-- {
+				rollbacks[i]()
+			}
+			return nil, errs
+		}
+
+		changed, err := m.localPrincipalsReload(new.Auth.LocalPrincipals)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("Auth.LocalPrincipals: %v", err))
+			for i := len(rollbacks) - 1; i >= 0; i-- {
+				rollbacks[i]()
+			}
+			return nil, errs
+		}
+		configChanged := !reflect.DeepEqual(localPrincipalChanges[0].OldValue, localPrincipalChanges[0].NewValue)
+		if changed || configChanged {
+			applied = append(applied, localPrincipalChanges...)
+		}
+	}
+
 	return applied, errs
+}
+
+func hasFieldChange(changes []config.FieldChange, path string) bool {
+	for _, change := range changes {
+		if change.Path == path {
+			return true
+		}
+	}
+	return false
 }
 
 func configToRatelimit(cfg config.RateLimitConfig) ratelimit.Config {
@@ -347,10 +423,9 @@ func isSessionField(path string) bool   { return len(path) > 8 && path[:8] == "S
 func isWebhookField(path string) bool   { return len(path) > 8 && path[:8] == "Webhook." }
 
 // applyFieldChanges returns a new Config with only the given field changes
-// applied on top of base. The shallow copy is safe because all current
-// runtime-safe fields (log, ratelimit, broker tuning) are value types.
-// If a slice/map-typed field is ever promoted to runtime-safe, this must
-// be updated to deep-copy the relevant section.
+// applied on top of base. Scalar runtime fields are replaced by value and
+// Auth.LocalPrincipals is replaced as one immutable slice; runtime code never
+// mutates the stored configuration slice.
 func applyFieldChanges(base *config.Config, changes []config.FieldChange) (*config.Config, error) {
 	updated := *base
 

--- a/reload/manager.go
+++ b/reload/manager.go
@@ -24,6 +24,8 @@ const (
 	logLevelDebug = "debug"
 	logLevelWarn  = "warn"
 	logFormatJSON = "json"
+
+	localPrincipalsPath = "Auth.LocalPrincipals"
 )
 
 // BrokerTuner applies broker-level config changes atomically.
@@ -179,12 +181,12 @@ func (m *Manager) Reload(ctx context.Context) (*ReloadResult, error) {
 	}
 
 	diff := config.Diff(m.current, newCfg)
-	if m.localPrincipalsReload != nil && !hasFieldChange(diff.RuntimeSafe, "Auth.LocalPrincipals") {
+	if m.localPrincipalsReload != nil && !hasFieldChange(diff.RuntimeSafe, localPrincipalsPath) {
 		// Secret files can change without their configured paths changing. Probe
 		// the immutable local-principal snapshot on every reload and retain this
 		// synthetic change only when the callback reports an effective change.
 		diff.RuntimeSafe = append(diff.RuntimeSafe, config.FieldChange{
-			Path:     "Auth.LocalPrincipals",
+			Path:     localPrincipalsPath,
 			OldValue: m.current.Auth.LocalPrincipals,
 			NewValue: newCfg.Auth.LocalPrincipals,
 			Class:    config.RuntimeSafe,
@@ -265,7 +267,7 @@ func (m *Manager) applyRuntimeChanges(_ context.Context, old, new *config.Config
 			sessionChanges = append(sessionChanges, c)
 		case isWebhookField(c.Path):
 			webhookChanges = append(webhookChanges, c)
-		case c.Path == "Auth.LocalPrincipals":
+		case c.Path == localPrincipalsPath:
 			localPrincipalChanges = append(localPrincipalChanges, c)
 		}
 	}

--- a/reload/manager.go
+++ b/reload/manager.go
@@ -201,7 +201,7 @@ func (m *Manager) Reload(ctx context.Context) (*ReloadResult, error) {
 	result.RestartRequired = diff.RestartRequired
 
 	if len(diff.RuntimeSafe) > 0 {
-		applied, errs := m.applyRuntimeChanges(ctx, m.current, newCfg, diff.RuntimeSafe)
+		applied, _, errs := m.applyRuntimeChanges(ctx, m.current, newCfg, diff.RuntimeSafe)
 		result.Applied = applied
 		if len(errs) > 0 {
 			result.Errors = errs
@@ -234,9 +234,11 @@ func (m *Manager) Reload(ctx context.Context) (*ReloadResult, error) {
 	return result, nil
 }
 
-func (m *Manager) applyRuntimeChanges(_ context.Context, old, new *config.Config, changes []config.FieldChange) (applied []config.FieldChange, errs []string) {
-	var rollbacks []func()
-
+// applyRuntimeChanges applies every runtime-safe change, rolling back the
+// subsystems it already applied if a later one fails. On success it returns the
+// undo functions in application order, so a caller that extends the sequence
+// can still unwind it; the reload path itself has nothing left to unwind.
+func (m *Manager) applyRuntimeChanges(_ context.Context, old, new *config.Config, changes []config.FieldChange) (applied []config.FieldChange, rollbacks []func(), errs []string) {
 	// applySubsystem applies one subsystem-level change. On failure, rolls back
 	// all previously applied subsystems and returns false.
 	applySubsystem := func(subsystemChanges []config.FieldChange, applyFn func() error, rollbackFn func()) bool {
@@ -279,7 +281,7 @@ func (m *Manager) applyRuntimeChanges(_ context.Context, old, new *config.Config
 		}, func() {
 			m.logSetup(old.Log)
 		}) {
-			return applied, errs
+			return applied, nil, errs
 		}
 	}
 
@@ -292,7 +294,7 @@ func (m *Manager) applyRuntimeChanges(_ context.Context, old, new *config.Config
 			oldManager := ratelimit.NewManager(configToRatelimit(old.RateLimit))
 			m.rateLimiter.Swap(oldManager)
 		}) {
-			return applied, errs
+			return applied, nil, errs
 		}
 	}
 
@@ -304,7 +306,7 @@ func (m *Manager) applyRuntimeChanges(_ context.Context, old, new *config.Config
 		}, func() {
 			m.broker.SetMaxQoS(oldQoS)
 		}) {
-			return applied, errs
+			return applied, nil, errs
 		}
 	}
 
@@ -315,7 +317,7 @@ func (m *Manager) applyRuntimeChanges(_ context.Context, old, new *config.Config
 		}, func() {
 			m.sessionTuner.SetSessionConfig(old.Session)
 		}) {
-			return applied, errs
+			return applied, nil, errs
 		}
 	}
 
@@ -325,7 +327,7 @@ func (m *Manager) applyRuntimeChanges(_ context.Context, old, new *config.Config
 		}, func() {
 			_ = m.webhookTuner.Reconfigure(old.Webhook)
 		}) {
-			return applied, errs
+			return applied, nil, errs
 		}
 	}
 
@@ -335,7 +337,7 @@ func (m *Manager) applyRuntimeChanges(_ context.Context, old, new *config.Config
 			for i := len(rollbacks) - 1; i >= 0; i-- {
 				rollbacks[i]()
 			}
-			return nil, errs
+			return nil, nil, errs
 		}
 
 		changed, err := m.localPrincipalsReload(new.Auth.LocalPrincipals)
@@ -344,15 +346,25 @@ func (m *Manager) applyRuntimeChanges(_ context.Context, old, new *config.Config
 			for i := len(rollbacks) - 1; i >= 0; i-- {
 				rollbacks[i]()
 			}
-			return nil, errs
+			return nil, nil, errs
 		}
+		// Register the undo even though nothing runs after this block today.
+		// Without it, a subsystem added later would roll back everything except
+		// the credential swap, leaving the process authenticating against
+		// principals the rest of the configuration no longer describes.
+		rollbacks = append(rollbacks, func() {
+			if _, restoreErr := m.localPrincipalsReload(old.Auth.LocalPrincipals); restoreErr != nil {
+				slog.Error("config reload: failed to restore local principals during rollback",
+					"error", restoreErr)
+			}
+		})
 		configChanged := !reflect.DeepEqual(localPrincipalChanges[0].OldValue, localPrincipalChanges[0].NewValue)
 		if changed || configChanged {
 			applied = append(applied, localPrincipalChanges...)
 		}
 	}
 
-	return applied, errs
+	return applied, rollbacks, errs
 }
 
 func hasFieldChange(changes []config.FieldChange, path string) bool {

--- a/reload/manager_test.go
+++ b/reload/manager_test.go
@@ -146,6 +146,80 @@ func TestReloadLocalPrincipalSecretContent(t *testing.T) {
 	}
 }
 
+// TestReloadLocalPrincipalsRegisterRollback pins the ordering contract of
+// applyRuntimeChanges: a subsystem that fails after the credential swap must
+// see that swap undone. Nothing runs after local principals today, so the test
+// drives applyRuntimeChanges directly with a failing subsystem appended.
+func TestReloadLocalPrincipalsRegisterRollback(t *testing.T) {
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "local-secret")
+	const (
+		initialSecret = "0123456789abcdef0123456789abcdef"
+		nextSecret    = "abcdef0123456789abcdef0123456789"
+	)
+	if err := os.WriteFile(secretPath, []byte(initialSecret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	path := writeConfig(t, dir, fmt.Sprintf(`auth:
+  local_principals:
+    - name: atom-audit-publisher
+      certificate_uri_san: spiffe://absmach/atom/audit-publisher
+      current_secret_file: %q
+      permissions:
+        publish:
+          - exchange: ""
+            routing_key: atom-audit
+        subscribe: []
+`, secretPath))
+	initial, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := localauth.New(initial.Auth.LocalPrincipals)
+	if err != nil {
+		t.Fatal(err)
+	}
+	m := New(path, initial, WithLocalPrincipalsReload(store.Reload))
+
+	if err := os.WriteFile(secretPath, []byte(nextSecret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	applied, rollbacks, errs := m.applyRuntimeChanges(context.Background(), initial, updated, []config.FieldChange{{
+		Path:     localPrincipalsPath,
+		OldValue: initial.Auth.LocalPrincipals,
+		NewValue: updated.Auth.LocalPrincipals,
+		Class:    config.RuntimeSafe,
+	}})
+	if len(errs) != 0 || len(applied) == 0 {
+		t.Fatalf("applyRuntimeChanges() applied=%v errs=%v, want the swap to succeed", applied, errs)
+	}
+	if _, ok := store.Authenticate("atom-audit-publisher", nextSecret, "spiffe://absmach/atom/audit-publisher"); !ok {
+		t.Fatal("reloaded credential was not activated")
+	}
+
+	// Restore the file so the registered rollback has something to load, then
+	// run it the way a later failing subsystem would.
+	if err := os.WriteFile(secretPath, []byte(initialSecret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if len(rollbacks) != 1 {
+		t.Fatalf("registered rollbacks = %d, want 1; a later subsystem could not undo the credential swap", len(rollbacks))
+	}
+	rollbacks[0]()
+
+	if _, ok := store.Authenticate("atom-audit-publisher", initialSecret, "spiffe://absmach/atom/audit-publisher"); !ok {
+		t.Fatal("rollback did not restore the previous local-principal snapshot")
+	}
+	if _, ok := store.Authenticate("atom-audit-publisher", nextSecret, "spiffe://absmach/atom/audit-publisher"); ok {
+		t.Fatal("rollback left the rolled-back credential active")
+	}
+}
+
 func (r *ReloadResult) HasChanges() bool {
 	return len(r.Applied) > 0 || len(r.RestartRequired) > 0
 }

--- a/reload/manager_test.go
+++ b/reload/manager_test.go
@@ -116,7 +116,7 @@ func TestReloadLocalPrincipalSecretContent(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(result.Applied) != 1 || result.Applied[0].Path != "Auth.LocalPrincipals" {
+	if len(result.Applied) != 1 || result.Applied[0].Path != localPrincipalsPath {
 		t.Fatalf("unexpected applied changes: %+v", result.Applied)
 	}
 	if m.Version() != 2 || store.Generation() != 2 {

--- a/reload/manager_test.go
+++ b/reload/manager_test.go
@@ -6,12 +6,14 @@ package reload
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
 
+	"github.com/absmach/fluxmq/broker/localauth"
 	"github.com/absmach/fluxmq/config"
 	"github.com/absmach/fluxmq/ratelimit"
 )
@@ -55,6 +57,92 @@ func TestReloadNoChanges(t *testing.T) {
 	}
 	if m.Version() != 1 {
 		t.Errorf("version should remain 1, got %d", m.Version())
+	}
+}
+
+func TestReloadLocalPrincipalSecretContent(t *testing.T) {
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "local-secret")
+	const (
+		initialSecret = "0123456789abcdef0123456789abcdef"
+		nextSecret    = "abcdef0123456789abcdef0123456789"
+	)
+	if err := os.WriteFile(secretPath, []byte(initialSecret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	path := writeConfig(t, dir, fmt.Sprintf(`auth:
+  local_principals:
+    - name: atom-audit-publisher
+      certificate_uri_san: spiffe://absmach/atom/audit-publisher
+      current_secret_file: %q
+      permissions:
+        publish:
+          - exchange: ""
+            routing_key: atom-audit
+        subscribe: []
+`, secretPath))
+	initial, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store, err := localauth.New(initial.Auth.LocalPrincipals)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var reloadFailures atomic.Int64
+	m := New(path, initial,
+		WithLocalPrincipalsReload(store.Reload),
+		WithLocalPrincipalsReloadFailure(func(error) { reloadFailures.Add(1) }),
+	)
+
+	noChange, err := m.Reload(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(noChange.Applied) != 0 || m.Version() != 1 || store.Generation() != 1 {
+		t.Fatalf("no-op reload changed state: result=%+v version=%d generation=%d", noChange, m.Version(), store.Generation())
+	}
+
+	oldAuthentication, ok := store.Authenticate("atom-audit-publisher", initialSecret, "spiffe://absmach/atom/audit-publisher")
+	if !ok {
+		t.Fatal("initial local authentication failed")
+	}
+	if err := os.WriteFile(secretPath, []byte(nextSecret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := m.Reload(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Applied) != 1 || result.Applied[0].Path != "Auth.LocalPrincipals" {
+		t.Fatalf("unexpected applied changes: %+v", result.Applied)
+	}
+	if m.Version() != 2 || store.Generation() != 2 {
+		t.Fatalf("secret reload did not advance state: version=%d generation=%d", m.Version(), store.Generation())
+	}
+	if store.IsActive(oldAuthentication) {
+		t.Fatal("retired local credential remains active")
+	}
+	if _, ok := store.Authenticate("atom-audit-publisher", nextSecret, "spiffe://absmach/atom/audit-publisher"); !ok {
+		t.Fatal("reloaded local credential was rejected")
+	}
+
+	if err := os.WriteFile(secretPath, []byte("too-short"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := m.Reload(context.Background()); err == nil {
+		t.Fatal("invalid local secret reload succeeded")
+	}
+	if reloadFailures.Load() != 1 {
+		t.Fatalf("local reload failure notifications = %d, want 1", reloadFailures.Load())
+	}
+	if m.Version() != 2 || store.Generation() != 2 {
+		t.Fatalf("failed reload changed state: version=%d generation=%d", m.Version(), store.Generation())
+	}
+	if _, ok := store.Authenticate("atom-audit-publisher", nextSecret, "spiffe://absmach/atom/audit-publisher"); !ok {
+		t.Fatal("failed reload replaced the last valid local-principal snapshot")
 	}
 }
 

--- a/server/amqp/server.go
+++ b/server/amqp/server.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/absmach/fluxmq/amqp/broker"
@@ -17,25 +19,68 @@ import (
 
 // Config represents the configuration for the AMQP 0.9.1 server.
 type Config struct {
-	Address         string
-	TLSConfig       *tls.Config
-	ShutdownTimeout time.Duration
-	MaxConnections  int
-	Logger          *slog.Logger
+	Address   string
+	TLSConfig *tls.Config
+	// HandshakeTimeout bounds the complete transport and AMQP handshake through
+	// Connection.Open. A successful AMQP handshake clears the deadline.
+	HandshakeTimeout time.Duration
+	// TLSHandshakeTimeout is retained for source compatibility and is used when
+	// HandshakeTimeout is unset.
+	TLSHandshakeTimeout time.Duration
+	ShutdownTimeout     time.Duration
+	MaxConnections      int
+	ConnectionPolicy    *broker.ConnectionPolicy
+	Logger              *slog.Logger
 }
 
 // Server is an AMQP 0.9.1 server.
 type Server struct {
-	cfg    Config
-	broker *broker.Broker
+	cfg       Config
+	broker    *broker.Broker
+	mu        sync.RWMutex
+	listener  net.Listener
+	connSem   chan struct{}
+	ready     chan struct{}
+	readyOnce sync.Once
 }
 
 // New creates a new AMQP 0.9.1 server.
 func New(cfg Config, b *broker.Broker) *Server {
-	return &Server{
-		cfg:    cfg,
-		broker: b,
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
 	}
+	if cfg.HandshakeTimeout <= 0 {
+		cfg.HandshakeTimeout = cfg.TLSHandshakeTimeout
+	}
+	if cfg.HandshakeTimeout <= 0 {
+		cfg.HandshakeTimeout = 10 * time.Second
+	}
+	var connSem chan struct{}
+	if cfg.MaxConnections > 0 {
+		connSem = make(chan struct{}, cfg.MaxConnections)
+	}
+	return &Server{
+		cfg:     cfg,
+		broker:  b,
+		connSem: connSem,
+		ready:   make(chan struct{}),
+	}
+}
+
+// Ready is closed after the listener has bound successfully. It can be used by
+// process readiness wiring to ensure every configured listener is accepting.
+func (s *Server) Ready() <-chan struct{} {
+	return s.ready
+}
+
+// Addr returns the bound listener address, or nil before Listen has bound.
+func (s *Server) Addr() net.Addr {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.listener == nil {
+		return nil
+	}
+	return s.listener.Addr()
 }
 
 // Listen starts the AMQP 0.9.1 server.
@@ -43,13 +88,17 @@ func (s *Server) Listen(ctx context.Context) error {
 	var lc net.ListenConfig
 	ln, err := lc.Listen(ctx, "tcp", s.cfg.Address)
 	if err != nil {
-		return err
+		return fmt.Errorf("listen on %s: %w", s.cfg.Address, err)
 	}
 	defer ln.Close()
 
 	if s.cfg.TLSConfig != nil {
 		ln = tls.NewListener(ln, s.cfg.TLSConfig)
 	}
+	s.mu.Lock()
+	s.listener = ln
+	s.mu.Unlock()
+	s.readyOnce.Do(func() { close(s.ready) })
 
 	s.cfg.Logger.Info("AMQP 0.9.1 server listening", "address", s.cfg.Address)
 
@@ -68,11 +117,54 @@ func (s *Server) Listen(ctx context.Context) error {
 			s.cfg.Logger.Error("Failed to accept new connection", "error", err)
 			continue
 		}
+		if !s.tryAcquireConnectionSlot(ctx, conn) {
+			continue
+		}
 		go s.handleConnection(ctx, conn)
 	}
 }
 
+func (s *Server) tryAcquireConnectionSlot(ctx context.Context, conn net.Conn) bool {
+	if s.connSem == nil {
+		return true
+	}
+	select {
+	case s.connSem <- struct{}{}:
+		return true
+	case <-ctx.Done():
+		_ = conn.Close()
+		return false
+	default:
+		s.cfg.Logger.Warn("AMQP 0.9.1 connection limit reached", "remote", conn.RemoteAddr().String())
+		_ = conn.Close()
+		return false
+	}
+}
+
+func (s *Server) releaseConnectionSlot() {
+	if s.connSem != nil {
+		<-s.connSem
+	}
+}
+
 func (s *Server) handleConnection(ctx context.Context, conn net.Conn) {
+	defer s.releaseConnectionSlot()
+	defer conn.Close()
 	defer connguard.Recover(s.cfg.Logger, "amqp091", conn.RemoteAddr().String())
+	deadline := time.Now().Add(s.cfg.HandshakeTimeout)
+	if err := conn.SetDeadline(deadline); err != nil {
+		s.cfg.Logger.Warn("AMQP 0.9.1 handshake deadline failed", "remote", conn.RemoteAddr().String(), "error", err)
+		return
+	}
+	if tlsConn, ok := conn.(*tls.Conn); ok {
+		if err := tlsConn.HandshakeContext(ctx); err != nil {
+			s.cfg.Logger.Warn("AMQP 0.9.1 TLS handshake failed", "remote", conn.RemoteAddr().String(), "error", err)
+			return
+		}
+	}
+	if s.cfg.ConnectionPolicy != nil {
+		s.broker.HandleConnectionWithPolicy(ctx, conn, s.cfg.ConnectionPolicy)
+		return
+	}
 	s.broker.HandleConnection(ctx, conn)
 }

--- a/server/amqp/server_test.go
+++ b/server/amqp/server_test.go
@@ -1,0 +1,426 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package amqp
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"log/slog"
+	"math/big"
+	"net"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	amqpbroker "github.com/absmach/fluxmq/amqp/broker"
+	"github.com/absmach/fluxmq/amqp/codec"
+)
+
+const testLocalCertificateURI = "spiffe://absmach/atom/audit-publisher"
+
+type reloadRaceLocalPolicy struct {
+	authenticated chan struct{}
+	retired       atomic.Bool
+}
+
+func (p *reloadRaceLocalPolicy) AuthenticateLocal(_ context.Context, _, _, _ string, _ amqpbroker.VerifiedPeerIdentity) (string, string, string, bool, error) {
+	close(p.authenticated)
+	return "atom-audit-publisher", "old-credential-fingerprint", testLocalCertificateURI, true, nil
+}
+
+func (p *reloadRaceLocalPolicy) CanPublishLocal(amqpbroker.LocalSessionIdentity, string, string) bool {
+	return !p.retired.Load()
+}
+
+func (p *reloadRaceLocalPolicy) IsSessionActive(amqpbroker.LocalSessionIdentity) bool {
+	return !p.retired.Load()
+}
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestServerSignalsReadyAfterBinding(t *testing.T) {
+	b := amqpbroker.New(nil, testLogger())
+	s := New(Config{Address: "127.0.0.1:0", Logger: testLogger()}, b)
+	if s.Addr() != nil {
+		t.Fatal("address must be nil before binding")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- s.Listen(ctx) }()
+
+	select {
+	case <-s.Ready():
+	case <-time.After(time.Second):
+		t.Fatal("server did not become ready")
+	}
+	if s.Addr() == nil {
+		t.Fatal("expected bound listener address")
+	}
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Listen returned error: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("server did not stop after cancellation")
+	}
+}
+
+func TestServerEnforcesConnectionLimit(t *testing.T) {
+	s := New(Config{MaxConnections: 1, Logger: testLogger()}, amqpbroker.New(nil, testLogger()))
+	firstClient, firstServer := net.Pipe()
+	defer firstClient.Close()
+	defer firstServer.Close()
+	if !s.tryAcquireConnectionSlot(context.Background(), firstServer) {
+		t.Fatal("first connection should acquire slot")
+	}
+
+	secondClient, secondServer := net.Pipe()
+	defer secondClient.Close()
+	if s.tryAcquireConnectionSlot(context.Background(), secondServer) {
+		t.Fatal("second connection should be rejected")
+	}
+	if _, err := secondClient.Write([]byte("closed")); err == nil {
+		t.Fatal("rejected connection should be closed")
+	}
+	s.releaseConnectionSlot()
+}
+
+func TestServerBoundsTLSHandshake(t *testing.T) {
+	handshakeTimeout := 20 * time.Millisecond
+	s := New(Config{
+		TLSHandshakeTimeout: handshakeTimeout,
+		Logger:              testLogger(),
+	}, amqpbroker.New(nil, testLogger()))
+	client, rawServer := net.Pipe()
+	defer client.Close()
+	tlsServer := tls.Server(rawServer, &tls.Config{MinVersion: tls.VersionTLS12})
+
+	done := make(chan struct{})
+	started := time.Now()
+	go func() {
+		s.handleConnection(context.Background(), tlsServer)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		if elapsed := time.Since(started); elapsed < handshakeTimeout {
+			t.Fatalf("TLS handshake returned before configured deadline: %v", elapsed)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("TLS handshake was not bounded")
+	}
+}
+
+func TestServerBoundsAMQPHandshakeAfterTLS(t *testing.T) {
+	handshakeTimeout := 100 * time.Millisecond
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	s := New(Config{
+		HandshakeTimeout: handshakeTimeout,
+		Logger:           logger,
+	}, amqpbroker.New(nil, logger))
+	clientTransport, serverTransport := net.Pipe()
+	defer clientTransport.Close()
+	tlsServer := tls.Server(serverTransport, &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		MaxVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{testTLSCertificate(t)},
+	})
+	tlsClient := tls.Client(clientTransport, &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		MaxVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: true, //nolint:gosec // self-signed certificate in a loopback unit test
+	})
+
+	serverTLSReady := make(chan error, 1)
+	go func() {
+		serverTLSReady <- tlsServer.Handshake()
+	}()
+	if err := tlsClient.Handshake(); err != nil {
+		t.Fatalf("complete TLS handshake: %v", err)
+	}
+	if err := <-serverTLSReady; err != nil {
+		t.Fatalf("complete server TLS handshake: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		s.handleConnection(context.Background(), tlsServer)
+		close(done)
+	}()
+	go func() {
+		_, _ = io.Copy(io.Discard, tlsClient)
+	}()
+
+	// Stall before sending the AMQP protocol header. The TLS handshake succeeded,
+	// so only a deadline retained through the AMQP handshake can release the slot.
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatalf("post-TLS AMQP handshake was not bounded; logs:\n%s", logs.String())
+	}
+}
+
+func TestRetiredLocalCredentialDuringHandshakeReleasesConnectionSlot(t *testing.T) {
+	serverTLS, clientTLS := testMutualTLSConfigs(t)
+	logger := testLogger()
+	b := amqpbroker.New(nil, logger)
+	localPolicy := &reloadRaceLocalPolicy{authenticated: make(chan struct{})}
+	s := New(Config{
+		HandshakeTimeout: 2 * time.Second,
+		MaxConnections:   1,
+		ConnectionPolicy: amqpbroker.NewLocalPublishOnlyConnectionPolicy(
+			localPolicy,
+			localPolicy,
+			localPolicy,
+			0,
+		),
+		Logger: logger,
+	}, b)
+
+	clientTransport, serverTransport := net.Pipe()
+	tlsServer := tls.Server(serverTransport, serverTLS)
+	tlsClient := tls.Client(clientTransport, clientTLS)
+	defer tlsClient.Close()
+	if !s.tryAcquireConnectionSlot(context.Background(), tlsServer) {
+		t.Fatal("stale connection did not acquire the only listener slot")
+	}
+	done := make(chan struct{})
+	go func() {
+		s.handleConnection(context.Background(), tlsServer)
+		close(done)
+	}()
+
+	if err := tlsClient.Handshake(); err != nil {
+		t.Fatalf("TLS handshake: %v", err)
+	}
+	if err := tlsClient.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+		t.Fatalf("set client deadline: %v", err)
+	}
+	if _, err := tlsClient.Write([]byte{'A', 'M', 'Q', 'P', 0, 0, 9, 1}); err != nil {
+		t.Fatalf("write AMQP protocol header: %v", err)
+	}
+	readAMQPMethod[*codec.ConnectionStart](t, tlsClient)
+	writeAMQPMethod(t, tlsClient, &codec.ConnectionStartOk{
+		Mechanism: "PLAIN",
+		Response:  "\x00atom-audit-publisher\x00old-secret",
+		Locale:    "en_US",
+	})
+
+	select {
+	case <-localPolicy.authenticated:
+	case <-time.After(time.Second):
+		t.Fatal("local authentication did not complete")
+	}
+	localPolicy.retired.Store(true)
+	if disconnected := b.DisconnectInvalidLocalSessions(localPolicy.IsSessionActive); disconnected != 0 {
+		t.Fatalf("pre-registration reload scan disconnected %d sessions, want 0", disconnected)
+	}
+
+	tune := readAMQPMethod[*codec.ConnectionTune](t, tlsClient)
+	writeAMQPMethod(t, tlsClient, &codec.ConnectionTuneOk{
+		ChannelMax: tune.ChannelMax,
+		FrameMax:   tune.FrameMax,
+		Heartbeat:  tune.Heartbeat,
+	})
+	writeAMQPMethod(t, tlsClient, &codec.ConnectionOpen{VirtualHost: "/"})
+	readAMQPMethod[*codec.ConnectionOpenOk](t, tlsClient)
+	closeMethod := readAMQPMethod[*codec.ConnectionClose](t, tlsClient)
+	if closeMethod.ReplyCode != codec.AccessRefused {
+		t.Fatalf("connection close code = %d, want %d", closeMethod.ReplyCode, codec.AccessRefused)
+	}
+	// The server has already sent the protocol error. Close the raw peer so the
+	// TLS close-notify path cannot keep the connection slot during test cleanup.
+	_ = clientTransport.Close()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("retired local connection did not terminate")
+	}
+	if ids := b.ConnectionIDs(); len(ids) != 0 {
+		t.Fatalf("retired local connection remained registered: %v", ids)
+	}
+	if current := b.GetStats().GetCurrentConnections(); current != 0 {
+		t.Fatalf("active connection stats = %d, want 0", current)
+	}
+	if local := b.GetStats().GetLocalConnections(); local != 0 {
+		t.Fatalf("active local connection stats = %d, want 0", local)
+	}
+
+	nextClient, nextServer := net.Pipe()
+	defer nextClient.Close()
+	defer nextServer.Close()
+	if !s.tryAcquireConnectionSlot(context.Background(), nextServer) {
+		t.Fatal("retired local connection continued occupying the only listener slot")
+	}
+	s.releaseConnectionSlot()
+}
+
+func writeAMQPMethod(t *testing.T, conn net.Conn, method interface{ Write(io.Writer) error }) {
+	t.Helper()
+	var payload bytes.Buffer
+	if err := method.Write(&payload); err != nil {
+		t.Fatalf("encode AMQP method: %v", err)
+	}
+	if err := (&codec.Frame{Type: codec.FrameMethod, Channel: 0, Payload: payload.Bytes()}).WriteFrame(conn); err != nil {
+		t.Fatalf("write AMQP method: %v", err)
+	}
+}
+
+func readAMQPMethod[T any](t *testing.T, conn net.Conn) T {
+	t.Helper()
+	var zero T
+	frame, err := codec.ReadFrame(conn)
+	if err != nil {
+		t.Fatalf("read AMQP frame: %v", err)
+		return zero
+	}
+	decoded, err := frame.Decode()
+	if err != nil {
+		t.Fatalf("decode AMQP method: %v", err)
+		return zero
+	}
+	method, ok := decoded.(T)
+	if !ok {
+		t.Fatalf("AMQP method = %T, want %T", decoded, zero)
+		return zero
+	}
+	return method
+}
+
+func testMutualTLSConfigs(t *testing.T) (*tls.Config, *tls.Config) {
+	t.Helper()
+	now := time.Now()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "FluxMQ test CA"},
+		NotBefore:             now.Add(-time.Minute),
+		NotAfter:              now.Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create CA certificate: %v", err)
+	}
+	caCertificate, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("parse CA certificate: %v", err)
+	}
+
+	serverCertificate := issueTestCertificate(t, caCertificate, caKey, &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		DNSNames:     []string{"localhost"},
+		NotBefore:    now.Add(-time.Minute),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	certificateURI, err := url.Parse(testLocalCertificateURI)
+	if err != nil {
+		t.Fatalf("parse client certificate URI: %v", err)
+	}
+	clientCertificate := issueTestCertificate(t, caCertificate, caKey, &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject:      pkix.Name{CommonName: "atom-audit-publisher"},
+		URIs:         []*url.URL{certificateURI},
+		NotBefore:    now.Add(-time.Minute),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+
+	caPool := x509.NewCertPool()
+	caPool.AddCert(caCertificate)
+	return &tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			Certificates: []tls.Certificate{serverCertificate},
+			ClientAuth:   tls.RequireAndVerifyClientCert,
+			ClientCAs:    caPool,
+		}, &tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			ServerName:   "localhost",
+			RootCAs:      caPool,
+			Certificates: []tls.Certificate{clientCertificate},
+		}
+}
+
+func issueTestCertificate(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, template *x509.Certificate) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate certificate key: %v", err)
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, ca, &key.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal certificate key: %v", err)
+	}
+	certificate, err := tls.X509KeyPair(
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}),
+	)
+	if err != nil {
+		t.Fatalf("parse certificate key pair: %v", err)
+	}
+	return certificate
+}
+
+func testTLSCertificate(t *testing.T) tls.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate test TLS key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create test TLS certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal test TLS key: %v", err)
+	}
+	certificate, err := tls.X509KeyPair(
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}),
+	)
+	if err != nil {
+		t.Fatalf("load test TLS key pair: %v", err)
+	}
+	return certificate
+}

--- a/server/amqp/server_test.go
+++ b/server/amqp/server_test.go
@@ -26,16 +26,19 @@ import (
 	"github.com/absmach/fluxmq/amqp/codec"
 )
 
-const testLocalCertificateURI = "spiffe://absmach/atom/audit-publisher"
+const (
+	testLocalCertificateURI = "spiffe://absmach/atom/audit-publisher"
+	testServerName          = "localhost"
+)
 
 type reloadRaceLocalPolicy struct {
 	authenticated chan struct{}
 	retired       atomic.Bool
 }
 
-func (p *reloadRaceLocalPolicy) AuthenticateLocal(_ context.Context, _, _, _ string, _ amqpbroker.VerifiedPeerIdentity) (string, string, string, bool, error) {
+func (p *reloadRaceLocalPolicy) AuthenticateLocal(_ context.Context, _, _, _ string, _ amqpbroker.VerifiedPeerIdentity) (string, string, string, string, bool, error) {
 	close(p.authenticated)
-	return "atom-audit-publisher", "old-credential-fingerprint", testLocalCertificateURI, true, nil
+	return "atom-audit-publisher", "old-credential-fingerprint", "old-permissions-fingerprint", testLocalCertificateURI, true, nil
 }
 
 func (p *reloadRaceLocalPolicy) CanPublishLocal(amqpbroker.LocalSessionIdentity, string, string) bool {
@@ -332,8 +335,8 @@ func testMutualTLSConfigs(t *testing.T) (*tls.Config, *tls.Config) {
 
 	serverCertificate := issueTestCertificate(t, caCertificate, caKey, &x509.Certificate{
 		SerialNumber: big.NewInt(2),
-		Subject:      pkix.Name{CommonName: "localhost"},
-		DNSNames:     []string{"localhost"},
+		Subject:      pkix.Name{CommonName: testServerName},
+		DNSNames:     []string{testServerName},
 		NotBefore:    now.Add(-time.Minute),
 		NotAfter:     now.Add(time.Hour),
 		KeyUsage:     x509.KeyUsageDigitalSignature,
@@ -362,7 +365,7 @@ func testMutualTLSConfigs(t *testing.T) (*tls.Config, *tls.Config) {
 			ClientCAs:    caPool,
 		}, &tls.Config{
 			MinVersion:   tls.VersionTLS12,
-			ServerName:   "localhost",
+			ServerName:   testServerName,
 			RootCAs:      caPool,
 			Certificates: []tls.Certificate{clientCertificate},
 		}
@@ -400,12 +403,12 @@ func testTLSCertificate(t *testing.T) tls.Certificate {
 	}
 	template := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: "localhost"},
+		Subject:      pkix.Name{CommonName: testServerName},
 		NotBefore:    time.Now().Add(-time.Minute),
 		NotAfter:     time.Now().Add(time.Hour),
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		DNSNames:     []string{"localhost"},
+		DNSNames:     []string{testServerName},
 	}
 	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
 	if err != nil {

--- a/server/api/stats.go
+++ b/server/api/stats.go
@@ -68,6 +68,7 @@ type amqpStats struct {
 // certificate, URI, routing-key, or tenant values become metric dimensions.
 type amqpLocalPrincipalStats struct {
 	ActiveConnections uint64                       `json:"active_connections"`
+	PublishTimeouts   uint64                       `json:"publish_timeouts"`
 	Authentication    amqpLocalAuthenticationStats `json:"authentication"`
 	Authorization     amqpLocalAuthorizationStats  `json:"authorization"`
 	Reloads           amqpLocalReloadStats         `json:"reloads"`
@@ -188,6 +189,7 @@ func (s *Server) buildStatsResponse() statsResponse {
 			Errors:      errorStats{Protocol: ast.GetProtocolErrors()},
 			LocalPrincipals: amqpLocalPrincipalStats{
 				ActiveConnections: ast.GetLocalConnections(),
+				PublishTimeouts:   ast.GetLocalPublishTimeouts(),
 				Authentication: amqpLocalAuthenticationStats{
 					Success: ast.GetLocalAuthSuccess(),
 					Failure: ast.GetLocalAuthFailures(),

--- a/server/api/stats.go
+++ b/server/api/stats.go
@@ -69,6 +69,7 @@ type amqpStats struct {
 type amqpLocalPrincipalStats struct {
 	ActiveConnections uint64                       `json:"active_connections"`
 	PublishTimeouts   uint64                       `json:"publish_timeouts"`
+	PublishRejections uint64                       `json:"publish_rejections"`
 	Authentication    amqpLocalAuthenticationStats `json:"authentication"`
 	Authorization     amqpLocalAuthorizationStats  `json:"authorization"`
 	Reloads           amqpLocalReloadStats         `json:"reloads"`
@@ -190,6 +191,7 @@ func (s *Server) buildStatsResponse() statsResponse {
 			LocalPrincipals: amqpLocalPrincipalStats{
 				ActiveConnections: ast.GetLocalConnections(),
 				PublishTimeouts:   ast.GetLocalPublishTimeouts(),
+				PublishRejections: ast.GetLocalPublishRejections(),
 				Authentication: amqpLocalAuthenticationStats{
 					Success: ast.GetLocalAuthSuccess(),
 					Failure: ast.GetLocalAuthFailures(),

--- a/server/api/stats.go
+++ b/server/api/stats.go
@@ -55,12 +55,38 @@ type mqttErrorStats struct {
 
 // amqpStats holds AMQP 0.9.1-specific counters.
 type amqpStats struct {
-	Connections connectionStats `json:"connections"`
-	Messages    messageStats    `json:"messages"`
-	Bytes       byteStats       `json:"bytes"`
-	Channels    uint64          `json:"channels"`
-	Consumers   uint64          `json:"consumers"`
-	Errors      errorStats      `json:"errors"`
+	Connections     connectionStats         `json:"connections"`
+	Messages        messageStats            `json:"messages"`
+	Bytes           byteStats               `json:"bytes"`
+	Channels        uint64                  `json:"channels"`
+	Consumers       uint64                  `json:"consumers"`
+	Errors          errorStats              `json:"errors"`
+	LocalPrincipals amqpLocalPrincipalStats `json:"local_principals"`
+}
+
+// amqpLocalPrincipalStats uses a fixed set of counters. No principal,
+// certificate, URI, routing-key, or tenant values become metric dimensions.
+type amqpLocalPrincipalStats struct {
+	ActiveConnections uint64                       `json:"active_connections"`
+	Authentication    amqpLocalAuthenticationStats `json:"authentication"`
+	Authorization     amqpLocalAuthorizationStats  `json:"authorization"`
+	Reloads           amqpLocalReloadStats         `json:"reloads"`
+}
+
+type amqpLocalAuthenticationStats struct {
+	Success uint64 `json:"success"`
+	Failure uint64 `json:"failure"`
+}
+
+type amqpLocalAuthorizationStats struct {
+	PublishDenied   uint64 `json:"publish_denied"`
+	OperationDenied uint64 `json:"operation_denied"`
+}
+
+type amqpLocalReloadStats struct {
+	Success           uint64 `json:"success"`
+	Failure           uint64 `json:"failure"`
+	ForcedDisconnects uint64 `json:"forced_disconnects"`
 }
 
 type byProtocolStats struct {
@@ -160,6 +186,22 @@ func (s *Server) buildStatsResponse() statsResponse {
 			Channels:    ast.GetCurrentChannels(),
 			Consumers:   ast.GetConsumers(),
 			Errors:      errorStats{Protocol: ast.GetProtocolErrors()},
+			LocalPrincipals: amqpLocalPrincipalStats{
+				ActiveConnections: ast.GetLocalConnections(),
+				Authentication: amqpLocalAuthenticationStats{
+					Success: ast.GetLocalAuthSuccess(),
+					Failure: ast.GetLocalAuthFailures(),
+				},
+				Authorization: amqpLocalAuthorizationStats{
+					PublishDenied:   ast.GetLocalPublishDenials(),
+					OperationDenied: ast.GetLocalOperationDenials(),
+				},
+				Reloads: amqpLocalReloadStats{
+					Success:           ast.GetLocalReloadSuccess(),
+					Failure:           ast.GetLocalReloadFailures(),
+					ForcedDisconnects: ast.GetLocalForcedDisconnects(),
+				},
+			},
 		}
 	}
 

--- a/server/api/stats_test.go
+++ b/server/api/stats_test.go
@@ -82,6 +82,14 @@ func TestStatsAMQPOnly(t *testing.T) {
 	ab.GetStats().IncrementMessagesReceived()
 	ab.GetStats().IncrementChannels()
 	ab.GetStats().IncrementConsumers()
+	ab.GetStats().IncrementLocalConnections()
+	ab.GetStats().IncrementLocalAuthSuccess()
+	ab.GetStats().IncrementLocalAuthFailures()
+	ab.GetStats().IncrementLocalPublishDenials()
+	ab.GetStats().IncrementLocalOperationDenials()
+	ab.GetStats().IncrementLocalReloadSuccess()
+	ab.GetStats().IncrementLocalReloadFailures()
+	ab.GetStats().AddLocalForcedDisconnects(2)
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/stats", nil)
 	rec := httptest.NewRecorder()
@@ -113,6 +121,19 @@ func TestStatsAMQPOnly(t *testing.T) {
 	}
 	if resp.ByProtocol.AMQP.Consumers != 1 {
 		t.Fatalf("expected amqp consumers 1, got %d", resp.ByProtocol.AMQP.Consumers)
+	}
+	local := resp.ByProtocol.AMQP.LocalPrincipals
+	if local.ActiveConnections != 1 {
+		t.Fatalf("expected one active local-principal connection, got %d", local.ActiveConnections)
+	}
+	if local.Authentication.Success != 1 || local.Authentication.Failure != 1 {
+		t.Fatalf("unexpected local authentication stats: %+v", local.Authentication)
+	}
+	if local.Authorization.PublishDenied != 1 || local.Authorization.OperationDenied != 1 {
+		t.Fatalf("unexpected local authorization stats: %+v", local.Authorization)
+	}
+	if local.Reloads.Success != 1 || local.Reloads.Failure != 1 || local.Reloads.ForcedDisconnects != 2 {
+		t.Fatalf("unexpected local reload stats: %+v", local.Reloads)
 	}
 }
 

--- a/server/queue/handler.go
+++ b/server/queue/handler.go
@@ -72,6 +72,9 @@ func (h *Handler) CreateQueue(ctx context.Context, req *connect.Request[queuev1.
 	}
 
 	if err := h.manager.CreateQueue(ctx, config); err != nil {
+		if errors.Is(err, queue.ErrProtectedQueueMutation) {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+		}
 		return nil, connect.NewError(connect.CodeAlreadyExists, err)
 	}
 
@@ -146,6 +149,9 @@ func (h *Handler) ListQueues(ctx context.Context, req *connect.Request[queuev1.L
 
 func (h *Handler) DeleteQueue(ctx context.Context, req *connect.Request[queuev1.DeleteQueueRequest]) (*connect.Response[emptypb.Empty], error) {
 	if err := h.manager.DeleteQueue(ctx, req.Msg.Name); err != nil {
+		if errors.Is(err, queue.ErrProtectedQueueMutation) {
+			return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+		}
 		if err == storage.ErrQueueNotFound {
 			return nil, connect.NewError(connect.CodeNotFound, err)
 		}
@@ -171,6 +177,9 @@ func (h *Handler) UpdateQueue(ctx context.Context, req *connect.Request[queuev1.
 
 	if h.manager != nil {
 		if err := h.manager.UpdateQueue(ctx, updated); err != nil {
+			if errors.Is(err, queue.ErrProtectedQueueMutation) {
+				return nil, connect.NewError(connect.CodeFailedPrecondition, err)
+			}
 			if err == storage.ErrQueueNotFound {
 				return nil, connect.NewError(connect.CodeNotFound, err)
 			}

--- a/server/queue/handler_test.go
+++ b/server/queue/handler_test.go
@@ -176,6 +176,49 @@ func TestUpdateQueueAppliesConfig(t *testing.T) {
 	}
 }
 
+func TestProtectedQueueAdminUpdateAndDeleteFailPrecondition(t *testing.T) {
+	ctx := context.Background()
+	store := memlog.New()
+	contract := types.DefaultQueueConfig("atom-audit", "$queue/atom-audit/#")
+	contract.Type = types.QueueTypeStream
+	contract.Reserved = true
+	contract.Retention.RetentionTime = 30 * 24 * time.Hour
+	contract.Retention.RetentionBytes = 10 * 1024 * 1024 * 1024
+	contract.MessageTTL = 30 * 24 * time.Hour
+	managerConfig := queuepkg.DefaultConfig()
+	managerConfig.ProtectedQueueContracts = []types.QueueConfig{contract}
+	manager := queuepkg.NewManager(store, noopGroupStore{}, nil, managerConfig, nil, nil)
+	if err := manager.CreateQueue(ctx, contract); err != nil {
+		t.Fatalf("create protected queue: %v", err)
+	}
+	h := NewHandler(manager, nil, nil, nil)
+
+	_, err := h.UpdateQueue(ctx, connect.NewRequest(&queuev1.UpdateQueueRequest{
+		Name: contract.Name,
+		Config: &queuev1.QueueConfig{
+			MaxMessageSize: uint32(contract.MaxMessageSize - 1),
+		},
+	}))
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Fatalf("UpdateQueue() code = %s, error = %v, want failed_precondition", got, err)
+	}
+	persisted, getErr := store.GetQueue(ctx, contract.Name)
+	if getErr != nil {
+		t.Fatalf("GetQueue() error = %v", getErr)
+	}
+	if persisted.MaxMessageSize != contract.MaxMessageSize {
+		t.Fatalf("rejected update changed max message size to %d", persisted.MaxMessageSize)
+	}
+
+	_, err = h.DeleteQueue(ctx, connect.NewRequest(&queuev1.DeleteQueueRequest{Name: contract.Name}))
+	if got := connect.CodeOf(err); got != connect.CodeFailedPrecondition {
+		t.Fatalf("DeleteQueue() code = %s, error = %v, want failed_precondition", got, err)
+	}
+	if _, getErr := store.GetQueue(ctx, contract.Name); getErr != nil {
+		t.Fatalf("protected queue was deleted: %v", getErr)
+	}
+}
+
 func TestCreateQueueAppliesReplicationConfig(t *testing.T) {
 	t.Parallel()
 

--- a/tests/smoke/local_principal_test.go
+++ b/tests/smoke/local_principal_test.go
@@ -1,0 +1,852 @@
+//go:build smoke
+
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package smoke_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	amqp091 "github.com/rabbitmq/amqp091-go"
+)
+
+const (
+	localUsername = "atom-audit-publisher"
+	localURISAN   = "spiffe://absmach/atom/audit-publisher"
+	auditQueue    = "atom-audit"
+)
+
+func TestLocalPrincipalRealProcess(t *testing.T) {
+	binary := os.Getenv("FLUXMQ_SMOKE_BINARY")
+	if binary == "" {
+		t.Skip("set FLUXMQ_SMOKE_BINARY to the built FluxMQ binary")
+	}
+	binary, err := filepath.Abs(binary)
+	if err != nil {
+		t.Fatalf("resolve FluxMQ binary: %v", err)
+	}
+	if _, err := os.Stat(binary); err != nil {
+		t.Fatalf("FluxMQ binary %q is unavailable: %v", binary, err)
+	}
+
+	workDir := t.TempDir()
+	pki := newTestPKI(t, workDir)
+	currentSecret := randomSecret(t)
+	previousSecret := randomSecret(t)
+	currentSecretFile := filepath.Join(workDir, "secret-current")
+	previousSecretFile := filepath.Join(workDir, "secret-previous")
+	writeSecret(t, currentSecretFile, currentSecret)
+	writeSecret(t, previousSecretFile, previousSecret)
+
+	callout := newMockCallout(t)
+	defer callout.Close()
+
+	ports := testPorts{
+		remote:   freePort(t),
+		internal: freePort(t),
+		health:   freePort(t),
+	}
+	configPath := filepath.Join(workDir, "fluxmq.yaml")
+	dataDir := filepath.Join(workDir, "data")
+	writeSmokeConfig(t, configPath, smokeConfig{
+		ports:              ports,
+		dataDir:            dataDir,
+		calloutURL:         callout.URL,
+		serverCertFile:     pki.server.certFile,
+		serverKeyFile:      pki.server.keyFile,
+		clientCAFile:       pki.caFile,
+		currentSecretFile:  currentSecretFile,
+		previousSecretFile: previousSecretFile,
+	})
+
+	broker := startBroker(t, binary, configPath, ports)
+	// Capture the variable, not the first process method value: the test replaces
+	// broker after the persistence restart and that process must also be stopped
+	// when a later assertion fails.
+	t.Cleanup(func() { broker.stop() })
+
+	validTLS := pki.clientTLS(t, pki.validClient)
+	wrongSANTLS := pki.clientTLS(t, pki.wrongSANClient)
+	untrustedTLS := pki.clientTLS(t, pki.untrustedClient)
+
+	oldConn, oldChannel := dialPublisher(t, ports.internal, validTLS, currentSecret)
+	t.Cleanup(func() {
+		_ = oldChannel.Close()
+		_ = oldConn.Close()
+	})
+	publishConfirmed(t, oldChannel, []byte(`{"id":"audit-1","action":"entity.create"}`))
+
+	assertDialRejected(t, ports.internal, validTLS, localUsername, "wrong-secret")
+	assertDialRejected(t, ports.internal, validTLS, "unknown-local-principal", currentSecret)
+	assertDialRejected(t, ports.internal, wrongSANTLS, localUsername, currentSecret)
+	assertDialRejected(t, ports.internal, untrustedTLS, localUsername, currentSecret)
+	assertSubscribeDenied(t, ports.internal, validTLS, currentSecret)
+	assertTopologyDenied(t, ports.internal, validTLS, currentSecret)
+	assertPublishDenied(t, ports.internal, validTLS, currentSecret, "", "not-atom-audit")
+	assertPublishDenied(t, ports.internal, validTLS, currentSecret, "events", auditQueue)
+
+	if got := callout.total(); got != 0 {
+		t.Fatalf("internal traffic reached external callouts: calls=%d", got)
+	}
+
+	callout.available.Store(false)
+	outageConn, outageChannel := dialPublisher(t, ports.internal, validTLS, currentSecret)
+	publishConfirmed(t, outageChannel, []byte(`{"id":"audit-2","action":"entity.update"}`))
+	_ = outageChannel.Close()
+	_ = outageConn.Close()
+	if got := callout.total(); got != 0 {
+		t.Fatalf("internal publication during external outage made callouts: calls=%d", got)
+	}
+	callout.available.Store(true)
+
+	// Rotate from currentSecret to nextSecret while retaining currentSecret as
+	// the overlap credential. Both old and new connections must remain valid.
+	nextSecret := randomSecret(t)
+	writeSecret(t, currentSecretFile, nextSecret)
+	writeSecret(t, previousSecretFile, currentSecret)
+	signalReload(t, broker)
+
+	nextConn, nextChannel := dialPublisherEventually(t, ports.internal, validTLS, nextSecret)
+	t.Cleanup(func() {
+		_ = nextChannel.Close()
+		_ = nextConn.Close()
+	})
+	publishConfirmed(t, nextChannel, []byte(`{"id":"audit-3","action":"entity.delete"}`))
+	publishConfirmed(t, oldChannel, []byte(`{"id":"audit-4","action":"entity.restore"}`))
+
+	// End the overlap by removing previous_secret_file from the config. The old
+	// session must be disconnected while the new credential remains usable.
+	writeSmokeConfig(t, configPath, smokeConfig{
+		ports:             ports,
+		dataDir:           dataDir,
+		calloutURL:        callout.URL,
+		serverCertFile:    pki.server.certFile,
+		serverKeyFile:     pki.server.keyFile,
+		clientCAFile:      pki.caFile,
+		currentSecretFile: currentSecretFile,
+	})
+	signalReload(t, broker)
+	waitForConnectionClose(t, oldConn)
+	publishConfirmed(t, nextChannel, []byte(`{"id":"audit-5","action":"entity.purge"}`))
+	assertDialRejected(t, ports.internal, validTLS, localUsername, currentSecret)
+
+	broker.stop()
+	broker = startBroker(t, binary, configPath, ports)
+
+	callout.resetCounts()
+	remoteConn := dialAMQPEventually(t, remoteURL(ports.remote, "remote-reader", "remote-secret"), nil)
+	defer remoteConn.Close()
+	remoteChannel, err := remoteConn.Channel()
+	if err != nil {
+		t.Fatalf("open remote channel: %v", err)
+	}
+	defer remoteChannel.Close()
+
+	deliveries, err := remoteChannel.Consume(
+		auditQueue,
+		"smoke-replay",
+		true,
+		false,
+		false,
+		false,
+		amqp091.Table{
+			"x-stream-offset":  "first",
+			"x-consumer-group": "smoke-replay",
+		},
+	)
+	if err != nil {
+		t.Fatalf("consume persisted audit stream: %v", err)
+	}
+
+	select {
+	case delivery := <-deliveries:
+		if !strings.Contains(string(delivery.Body), `"id":"audit-1"`) {
+			t.Fatalf("unexpected first replayed event: %s", delivery.Body)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("timed out replaying persisted audit event")
+	}
+
+	if callout.authn.Load() == 0 || callout.authz.Load() == 0 || callout.hooks.Load() == 0 {
+		t.Fatalf(
+			"remote path did not use all external services: authn=%d authz=%d hooks=%d",
+			callout.authn.Load(),
+			callout.authz.Load(),
+			callout.hooks.Load(),
+		)
+	}
+}
+
+type smokeConfig struct {
+	ports              testPorts
+	dataDir            string
+	calloutURL         string
+	serverCertFile     string
+	serverKeyFile      string
+	clientCAFile       string
+	currentSecretFile  string
+	previousSecretFile string
+}
+
+func writeSmokeConfig(t *testing.T, path string, cfg smokeConfig) {
+	t.Helper()
+	previous := ""
+	if cfg.previousSecretFile != "" {
+		previous = fmt.Sprintf("\n      previous_secret_file: %q", cfg.previousSecretFile)
+	}
+
+	contents := fmt.Sprintf(`server:
+  tcp:
+    v3: {addr: ""}
+    v5: {addr: ""}
+  websocket:
+    v3: {addr: ""}
+    v5: {addr: ""}
+  http:
+    plain: {addr: ""}
+  coap:
+    plain: {addr: ""}
+  amqp:
+    plain: {addr: ""}
+  amqp091:
+    plain:
+      addr: "127.0.0.1:%d"
+      max_connections: 32
+    internal:
+      addr: "127.0.0.1:%d"
+      max_connections: 8
+      cert_file: %q
+      key_file: %q
+      ca_file: %q
+      client_auth: "require"
+      min_version: "TLS1.2"
+  health_enabled: true
+  health_addr: "127.0.0.1:%d"
+  admin_api_addr: ""
+  shutdown_timeout: "5s"
+
+broker:
+  max_message_size: 1048576
+
+storage:
+  type: "badger"
+  badger_dir: %q
+  sync_writes: true
+
+cluster:
+  enabled: false
+
+auth:
+  external:
+    url: %q
+    transport: "http"
+    timeout: "500ms"
+    protocols:
+      amqp091: true
+  local_principals:
+    - name: %q
+      certificate_uri_san: %q
+      current_secret_file: %q%s
+      permissions:
+        publish:
+          - exchange: ""
+            routing_key: %q
+        subscribe: []
+
+hooks:
+  url: %q
+  transport: "http"
+  timeout: "500ms"
+  fail_mode: "deny"
+  protocols:
+    amqp091: true
+
+queues:
+  - name: %q
+    topics:
+      - "$queue/atom-audit/#"
+    reserved: true
+    type: "stream"
+    retention:
+      max_age: "720h"
+      max_length_bytes: 10737418240
+    limits:
+      max_message_size: 1048576
+      message_ttl: "720h"
+
+log:
+  level: "debug"
+  format: "text"
+`,
+		cfg.ports.remote,
+		cfg.ports.internal,
+		cfg.serverCertFile,
+		cfg.serverKeyFile,
+		cfg.clientCAFile,
+		cfg.ports.health,
+		cfg.dataDir,
+		cfg.calloutURL,
+		localUsername,
+		localURISAN,
+		cfg.currentSecretFile,
+		previous,
+		auditQueue,
+		cfg.calloutURL,
+		auditQueue,
+	)
+
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write smoke config: %v", err)
+	}
+}
+
+type testPorts struct {
+	remote   int
+	internal int
+	health   int
+}
+
+func freePort(t *testing.T) int {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("reserve free port: %v", err)
+	}
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port
+}
+
+type brokerProcess struct {
+	cmd      *exec.Cmd
+	done     chan struct{}
+	logs     *lockedBuffer
+	stopOnce sync.Once
+	waitMu   sync.Mutex
+	waitErr  error
+}
+
+func startBroker(t *testing.T, binary, configPath string, ports testPorts) *brokerProcess {
+	t.Helper()
+	logs := &lockedBuffer{}
+	cmd := exec.Command(binary, "-config", configPath)
+	cmd.Stdout = logs
+	cmd.Stderr = logs
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start FluxMQ: %v", err)
+	}
+
+	process := &brokerProcess{
+		cmd:  cmd,
+		done: make(chan struct{}),
+		logs: logs,
+	}
+	go func() {
+		err := cmd.Wait()
+		process.waitMu.Lock()
+		process.waitErr = err
+		process.waitMu.Unlock()
+		close(process.done)
+	}()
+
+	for _, port := range []int{ports.remote, ports.internal, ports.health} {
+		if err := waitForTCP(process, port, 15*time.Second); err != nil {
+			process.stop()
+			t.Fatalf("FluxMQ did not become ready on port %d: %v\n%s", port, err, logs.String())
+		}
+	}
+	return process
+}
+
+func (p *brokerProcess) stop() {
+	if p == nil {
+		return
+	}
+	p.stopOnce.Do(func() {
+		_ = p.cmd.Process.Signal(syscall.SIGTERM)
+		select {
+		case <-p.done:
+		case <-time.After(10 * time.Second):
+			_ = p.cmd.Process.Kill()
+			<-p.done
+		}
+	})
+}
+
+func (p *brokerProcess) err() error {
+	p.waitMu.Lock()
+	defer p.waitMu.Unlock()
+	return p.waitErr
+}
+
+func waitForTCP(process *brokerProcess, port int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		select {
+		case <-process.done:
+			return fmt.Errorf("process exited early: %w", process.err())
+		default:
+		}
+
+		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 100*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return fmt.Errorf("timeout after %s", timeout)
+}
+
+func signalReload(t *testing.T, broker *brokerProcess) {
+	t.Helper()
+	if err := broker.cmd.Process.Signal(syscall.SIGHUP); err != nil {
+		t.Fatalf("send SIGHUP: %v", err)
+	}
+	// Reload is asynchronous. Authentication below is retried until the new
+	// immutable snapshot is visible.
+	time.Sleep(100 * time.Millisecond)
+}
+
+func internalURL(port int, username, secret string) string {
+	return (&url.URL{
+		Scheme: "amqps",
+		User:   url.UserPassword(username, secret),
+		Host:   fmt.Sprintf("127.0.0.1:%d", port),
+		Path:   "/",
+	}).String()
+}
+
+func remoteURL(port int, username, secret string) string {
+	return (&url.URL{
+		Scheme: "amqp",
+		User:   url.UserPassword(username, secret),
+		Host:   fmt.Sprintf("127.0.0.1:%d", port),
+		Path:   "/",
+	}).String()
+}
+
+func dialPublisher(t *testing.T, port int, tlsConfig *tls.Config, secret string) (*amqp091.Connection, *amqp091.Channel) {
+	t.Helper()
+	conn, err := amqp091.DialConfig(internalURL(port, localUsername, secret), amqp091.Config{TLSClientConfig: tlsConfig})
+	if err != nil {
+		t.Fatalf("dial internal AMQP: %v", err)
+	}
+	channel, err := conn.Channel()
+	if err != nil {
+		_ = conn.Close()
+		t.Fatalf("open internal channel: %v", err)
+	}
+	if err := channel.Confirm(false); err != nil {
+		_ = channel.Close()
+		_ = conn.Close()
+		t.Fatalf("enable publisher confirms: %v", err)
+	}
+	return conn, channel
+}
+
+func dialPublisherEventually(t *testing.T, port int, tlsConfig *tls.Config, secret string) (*amqp091.Connection, *amqp091.Channel) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := amqp091.DialConfig(internalURL(port, localUsername, secret), amqp091.Config{TLSClientConfig: tlsConfig})
+		if err == nil {
+			channel, channelErr := conn.Channel()
+			if channelErr == nil {
+				if confirmErr := channel.Confirm(false); confirmErr == nil {
+					return conn, channel
+				} else {
+					lastErr = confirmErr
+				}
+			} else {
+				lastErr = channelErr
+			}
+			_ = conn.Close()
+		} else {
+			lastErr = err
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("dial internal AMQP after reload: %v", lastErr)
+	return nil, nil
+}
+
+func dialAMQPEventually(t *testing.T, rawURL string, tlsConfig *tls.Config) *amqp091.Connection {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := amqp091.DialConfig(rawURL, amqp091.Config{TLSClientConfig: tlsConfig})
+		if err == nil {
+			return conn
+		}
+		lastErr = err
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("dial AMQP: %v", lastErr)
+	return nil
+}
+
+func publishConfirmed(t *testing.T, channel *amqp091.Channel, body []byte) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	confirmation, err := channel.PublishWithDeferredConfirmWithContext(ctx, "", auditQueue, false, false, amqp091.Publishing{
+		ContentType:  "application/json",
+		DeliveryMode: amqp091.Persistent,
+		Body:         body,
+	})
+	if err != nil {
+		t.Fatalf("publish audit event: %v", err)
+	}
+	if confirmation == nil {
+		t.Fatal("publisher confirm mode did not return a deferred confirmation")
+	}
+	acknowledged, err := confirmation.WaitContext(ctx)
+	if err != nil {
+		t.Fatalf("wait for publisher confirmation: %v", err)
+	}
+	if !acknowledged {
+		t.Fatal("broker negatively acknowledged audit publication")
+	}
+}
+
+func assertDialRejected(t *testing.T, port int, tlsConfig *tls.Config, username, secret string) {
+	t.Helper()
+	conn, err := amqp091.DialConfig(internalURL(port, username, secret), amqp091.Config{
+		TLSClientConfig: tlsConfig,
+		Dial:            amqp091.DefaultDial(2 * time.Second),
+	})
+	if err == nil {
+		_ = conn.Close()
+		t.Fatalf("expected internal authentication for username %q to be rejected", username)
+	}
+}
+
+func assertSubscribeDenied(t *testing.T, port int, tlsConfig *tls.Config, secret string) {
+	t.Helper()
+	conn, channel := dialPublisher(t, port, tlsConfig, secret)
+	defer conn.Close()
+	defer channel.Close()
+	_, err := channel.Consume(auditQueue, "forbidden", true, false, false, false, nil)
+	assertAMQPAccessRefused(t, err)
+}
+
+func assertTopologyDenied(t *testing.T, port int, tlsConfig *tls.Config, secret string) {
+	t.Helper()
+	conn, channel := dialPublisher(t, port, tlsConfig, secret)
+	defer conn.Close()
+	defer channel.Close()
+	_, err := channel.QueueDeclare("forbidden", false, false, false, false, nil)
+	assertAMQPAccessRefused(t, err)
+}
+
+func assertPublishDenied(t *testing.T, port int, tlsConfig *tls.Config, secret, exchange, routingKey string) {
+	t.Helper()
+	conn, channel := dialPublisher(t, port, tlsConfig, secret)
+	defer conn.Close()
+	defer channel.Close()
+	closed := channel.NotifyClose(make(chan *amqp091.Error, 1))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = channel.PublishWithContext(ctx, exchange, routingKey, false, false, amqp091.Publishing{Body: []byte("denied")})
+	select {
+	case amqpErr := <-closed:
+		if amqpErr == nil || amqpErr.Code != 403 {
+			t.Fatalf("expected AMQP 403, got %#v", amqpErr)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for unauthorized publish rejection")
+	}
+}
+
+func assertAMQPAccessRefused(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected AMQP 403 Access Refused")
+	}
+	amqpErr, ok := err.(*amqp091.Error)
+	if !ok || amqpErr.Code != 403 {
+		t.Fatalf("expected AMQP 403 Access Refused, got %T: %v", err, err)
+	}
+}
+
+func waitForConnectionClose(t *testing.T, conn *amqp091.Connection) {
+	t.Helper()
+	closed := conn.NotifyClose(make(chan *amqp091.Error, 1))
+	select {
+	case <-closed:
+	case <-time.After(10 * time.Second):
+		t.Fatal("connection authenticated with removed secret was not disconnected")
+	}
+}
+
+type mockCallout struct {
+	*httptest.Server
+	available atomic.Bool
+	authn     atomic.Int64
+	authz     atomic.Int64
+	hooks     atomic.Int64
+}
+
+func newMockCallout(t *testing.T) *mockCallout {
+	t.Helper()
+	mock := &mockCallout{}
+	mock.available.Store(true)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/auth/authenticate", func(writer http.ResponseWriter, request *http.Request) {
+		mock.authn.Add(1)
+		if !mock.available.Load() {
+			http.Error(writer, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		writeJSON(writer, map[string]any{"authenticated": true, "id": "remote-reader"})
+	})
+	mux.HandleFunc("/auth/authorize", func(writer http.ResponseWriter, request *http.Request) {
+		mock.authz.Add(1)
+		if !mock.available.Load() {
+			http.Error(writer, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		writeJSON(writer, map[string]any{"authorized": true})
+	})
+	mux.HandleFunc("/hooks", func(writer http.ResponseWriter, request *http.Request) {
+		mock.hooks.Add(1)
+		if !mock.available.Load() {
+			http.Error(writer, "unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		writeJSON(writer, map[string]any{"result": "ok"})
+	})
+	mock.Server = httptest.NewServer(mux)
+	return mock
+}
+
+func (m *mockCallout) total() int64 {
+	return m.authn.Load() + m.authz.Load() + m.hooks.Load()
+}
+
+func (m *mockCallout) resetCounts() {
+	m.authn.Store(0)
+	m.authz.Store(0)
+	m.hooks.Store(0)
+}
+
+func writeJSON(writer http.ResponseWriter, value any) {
+	writer.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(writer).Encode(value)
+}
+
+type testPKI struct {
+	ca              certificateFiles
+	caFile          string
+	server          certificateFiles
+	validClient     certificateFiles
+	wrongSANClient  certificateFiles
+	untrustedClient certificateFiles
+}
+
+type certificateFiles struct {
+	certFile string
+	keyFile  string
+}
+
+type certificateAuthority struct {
+	cert *x509.Certificate
+	key  *ecdsa.PrivateKey
+	pem  []byte
+}
+
+func newTestPKI(t *testing.T, dir string) testPKI {
+	t.Helper()
+	ca := createCA(t, "FluxMQ smoke CA")
+	untrustedCA := createCA(t, "Untrusted smoke CA")
+	return testPKI{
+		ca:              writeCertificate(t, dir, "ca", ca.pem, nil),
+		caFile:          writePEM(t, filepath.Join(dir, "ca.crt"), ca.pem, 0o644),
+		server:          issueCertificate(t, dir, "server", ca, true, ""),
+		validClient:     issueCertificate(t, dir, "atom", ca, false, localURISAN),
+		wrongSANClient:  issueCertificate(t, dir, "wrong-san", ca, false, "spiffe://absmach/atom/not-audit-publisher"),
+		untrustedClient: issueCertificate(t, dir, "untrusted", untrustedCA, false, localURISAN),
+	}
+}
+
+func createCA(t *testing.T, commonName string) certificateAuthority {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber:          randomSerial(t),
+		Subject:               pkix.Name{CommonName: commonName},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create CA: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse CA: %v", err)
+	}
+	return certificateAuthority{
+		cert: cert,
+		key:  key,
+		pem:  pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+	}
+}
+
+func issueCertificate(t *testing.T, dir, name string, ca certificateAuthority, server bool, uriSAN string) certificateFiles {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate %s key: %v", name, err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: randomSerial(t),
+		Subject:      pkix.Name{CommonName: name},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	if server {
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}
+		template.DNSNames = []string{"localhost"}
+		template.IPAddresses = []net.IP{net.ParseIP("127.0.0.1")}
+	} else {
+		template.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}
+		parsedURI, err := url.Parse(uriSAN)
+		if err != nil {
+			t.Fatalf("parse client URI SAN: %v", err)
+		}
+		template.URIs = []*url.URL{parsedURI}
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, ca.cert, &key.PublicKey, ca.key)
+	if err != nil {
+		t.Fatalf("issue %s certificate: %v", name, err)
+	}
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal %s key: %v", name, err)
+	}
+	return writeCertificate(
+		t,
+		dir,
+		name,
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}),
+	)
+}
+
+func writeCertificate(t *testing.T, dir, name string, certPEM, keyPEM []byte) certificateFiles {
+	t.Helper()
+	files := certificateFiles{certFile: writePEM(t, filepath.Join(dir, name+".crt"), certPEM, 0o644)}
+	if len(keyPEM) != 0 {
+		files.keyFile = writePEM(t, filepath.Join(dir, name+".key"), keyPEM, 0o600)
+	}
+	return files
+}
+
+func writePEM(t *testing.T, path string, value []byte, mode os.FileMode) string {
+	t.Helper()
+	if err := os.WriteFile(path, value, mode); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+func (p testPKI) clientTLS(t *testing.T, client certificateFiles) *tls.Config {
+	t.Helper()
+	cert, err := tls.LoadX509KeyPair(client.certFile, client.keyFile)
+	if err != nil {
+		t.Fatalf("load client key pair: %v", err)
+	}
+	caPEM, err := os.ReadFile(p.caFile)
+	if err != nil {
+		t.Fatalf("read CA: %v", err)
+	}
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(caPEM) {
+		t.Fatal("append server CA")
+	}
+	return &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		ServerName:   "localhost",
+		RootCAs:      roots,
+		Certificates: []tls.Certificate{cert},
+	}
+}
+
+func randomSerial(t *testing.T) *big.Int {
+	t.Helper()
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, limit)
+	if err != nil {
+		t.Fatalf("generate serial: %v", err)
+	}
+	return serial
+}
+
+func randomSecret(t *testing.T) string {
+	t.Helper()
+	value := make([]byte, 32)
+	if _, err := rand.Read(value); err != nil {
+		t.Fatalf("generate secret: %v", err)
+	}
+	return hex.EncodeToString(value)
+}
+
+func writeSecret(t *testing.T, path, secret string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(secret+"\n"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+}
+
+type lockedBuffer struct {
+	mu      sync.Mutex
+	builder strings.Builder
+}
+
+func (b *lockedBuffer) Write(value []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.builder.Write(value)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.builder.String()
+}


### PR DESCRIPTION
## Summary

Add a dedicated AMQP 0.9.1 listener for broker-local service principals so Atom can publish audit events without sending those publications through Atom-backed external authentication.

This PR adds:

- strict listener separation between remote AMQP clients and local principals;
- nested `auth.external` and `auth.local_principals` configuration;
- mTLS + SASL authentication for `atom-audit-publisher`;
- an exact publish-only ACL for the default exchange and `atom-audit` routing key;
- reloadable current/previous secrets with active-session revocation on `SIGHUP`;
- a protected, pre-provisioned `atom-audit` stream with 30-day retention;
- publisher ACKs only after the exact append and durable storage sync complete;
- runtime protection against stream mutation and out-of-band contract drift;
- bounded local-principal statistics and structured security logs;
- a production-shaped Docker Compose overlay, operational documentation, and a real-process acceptance smoke test.

## Why

FluxMQ's existing AMQP authentication path calls an external authorization service backed by Atom. Sending Atom's own audit publications through that path can add remote-auth latency and can create a feedback loop:

```text
Atom audit -> FluxMQ publish -> FluxMQ external auth -> Atom auth audit -> ...
```

The new listener creates two explicit trust domains in one FluxMQ process:

```text
remote clients -> AMQP :5682 -> auth.external -> shared queues/storage
Atom publisher -> AMQP :5683 -> auth.local_principals -> shared queues/storage
```

There is no identity lookup or fallback between the paths. Remote traffic never checks local principals. Internal traffic never calls external authentication, authorization, or blocking hooks.

## Configuration impact

This is an intentional breaking configuration change. The old flat `auth` form is removed and external settings move under `auth.external`:

```yaml
auth:
  external:
    url: "https://fluxmq-auth:8181"
    transport: "http"
    protocols:
      amqp091: true

  local_principals:
    - name: "atom-audit-publisher"
      certificate_uri_san: "spiffe://absmach/atom/audit-publisher"
      current_secret_file: "/run/secrets/atom_audit_secret_current"
      previous_secret_file: "/run/secrets/atom_audit_secret_previous"
      permissions:
        publish:
          - exchange: ""
            routing_key: "atom-audit"
        subscribe: []
```

The internal listener requires all three credentials to match the same principal:

1. SASL username;
2. high-entropy secret loaded from a mounted file;
3. client certificate URI SAN verified by the configured CA.

See `deployments/docker/config-local-principal.yaml` for the full production-shaped example.

## Security and delivery guarantees

- Port `5683` is mTLS-only, publish-only, and has no remote-auth fallback.
- The local principal can publish only through exchange `""` to the exact routing key `atom-audit`.
- Consume/get, queue and exchange topology, binding, purge/delete, and transactions are denied with AMQP `403`.
- Unknown identities, wrong secrets, wrong URI SANs, and untrusted certificates fail closed.
- Local definitions and secret files reload atomically on `SIGHUP`; rejected reloads keep the previous snapshot active.
- Removing a principal, URI SAN, secret, or permission disconnects sessions that are no longer valid.
- Protected stream create/update/delete/redeclare operations fail explicitly.
- Publish-time contract validation rejects out-of-band topic, retention, TTL, size-limit, durability, or replication drift.
- A publisher confirm ACK is emitted only after append and per-queue durable sync succeed; failures produce a NACK.
- Delivery remains at least once. Atom must reuse a stable event ID on retry, and consumers must deduplicate it.
- Local durable confirms are deliberately limited to single-node, non-replicated streams until a cluster quorum durability barrier exists.

Both listeners share process CPU, memory, queue management, and storage. This PR separates the authentication path and trust boundary; it does not claim resource isolation.

FluxMQ's native admin API remains a separate privileged control plane. The Compose overlay keeps it off host-published ports and requires operators to keep the management network trusted.

## Observability

`GET /api/v1/stats` now exposes bounded local-principal counters under:

```text
by_protocol.amqp.local_principals
```

Counters cover active connections, authentication success/failure, publish and operation denials, reload success/failure, and forced disconnects. Principal names, secrets, hashes, and certificates are not metric labels or log payloads.

## Validation performed

The following checks pass on this commit:

```bash
gofmt -l amqp broker cmd config logstorage queue reload server tests
git diff --check
go test -short ./...
go vet ./...
go test -race \
  ./broker/localauth \
  ./amqp/broker \
  ./server/amqp \
  ./server/queue \
  ./reload \
  ./cmd \
  ./config \
  ./queue \
  ./logstorage \
  ./server/api
make smoke-local-auth
```

Compose validation also passes:

```bash
FLUXMQ_SERVER_CERT_FILE=/tmp/fluxmq-server.crt \
FLUXMQ_SERVER_KEY_FILE=/tmp/fluxmq-server.key \
ATOM_CLIENT_CA_FILE=/tmp/atom-client-ca.crt \
ATOM_AUDIT_SECRET_CURRENT_FILE=/tmp/atom-current \
ATOM_AUDIT_SECRET_PREVIOUS_FILE=/tmp/atom-previous \
docker compose \
  -f deployments/docker/compose.yaml \
  -f deployments/docker/compose.local-principal.yaml \
  config --quiet
```

The real-process smoke starts an actual FluxMQ binary, creates temporary PKI, exercises both listeners and negative credentials/ACLs, rotates and revokes secrets, restarts FluxMQ, and replays the persisted stream record. Latest result:

```text
--- PASS: TestLocalPrincipalRealProcess (2.70s)
PASS
```

## Rabtap acceptance test

The manual test was run against a branch-built FluxMQ container using `rabtap` v1.44.1:

- exact `atom-audit` publish with `--confirms --mandatory`: exit `0`;
- broker stats after publish: one accepted message and successful local authentication;
- publish to `not-atom-audit`: non-zero exit and `publish_denied` increment;
- subscribe through internal port `5683`: non-zero exit and `operation_denied` increment;
- graceful FluxMQ restart;
- replay through remote port `5682`: exit `0`, with the exact pre-restart event body;
- external auth logs: one remote authenticate call and one remote subscribe authorization call, with no internal-publication callout.

Reviewers and bots can reproduce the complete procedure, including certificate requirements, positive and negative commands, restart/replay, listener-isolation checks, expected exit codes, and evidence collection, in:

[`docs/content/docs/deployment/internal-amqp-local-principals.md`](docs/content/docs/deployment/internal-amqp-local-principals.md#manual-rabtap-deployment-smoke)

## Review checklist

- [ ] Confirm remote AMQP always uses `auth.external` and never performs a local-principal lookup.
- [ ] Confirm internal AMQP never calls external auth or blocking hooks.
- [ ] Confirm authentication binds SASL username + secret + verified URI SAN to one principal.
- [ ] Confirm every internal operation outside exact publish is denied.
- [ ] Confirm publisher ACK occurs only after append and durable sync.
- [ ] Confirm protected stream drift fails closed before ACK.
- [ ] Confirm `SIGHUP` replacement is atomic and removed credentials disconnect active sessions.
- [ ] Run `make smoke-local-auth`.
- [ ] Run the documented rabtap publish/deny/restart/replay procedure when Docker, test PKI, and an external-auth fixture are available.
- [ ] Validate the rendered deployment does not publish ports `5683` or `8082` to the host.

## Deployment notes

1. Deploy the nested `auth.external` configuration first with the internal listener disabled and verify remote traffic.
2. Mount server PKI, Atom client CA, and current/previous local secrets.
3. Pre-provision the protected `atom-audit` stream.
4. Enable port `5683` only on the private network shared with Atom.
5. Run the automated smoke and deployment rabtap smoke.
6. Validate container startup, health/readiness, network policy, external-auth TLS, and environment-specific latency/load budgets.
7. Enable the Atom audit publisher in a separate deployment change.

This PR does not add the Atom audit outbox/publisher itself; it provides the FluxMQ ingress, authentication, authorization, durability, operations, and deployment contract that publisher requires.
