### PR TITLE
Derive local-principal capability from roles, not listeners

### DIFF
--- a/amqp/broker/channel.go
+++ b/amqp/broker/channel.go
@@ -276,8 +276,6 @@ func (ch *Channel) authorizeLocalMethod(decoded any) (bool, error) {
 		return ch.authorizeLocalSubscribe(method.Queue, principalID, decoded)
 	case *codec.BasicConsume:
 		return ch.authorizeLocalSubscribe(method.Queue, principalID, decoded)
-	case *codec.BasicGet:
-		return ch.authorizeLocalSubscribe(method.Queue, principalID, decoded)
 	case *codec.BasicQos, *codec.BasicCancel, *codec.BasicAck, *codec.BasicNack, *codec.BasicReject:
 		// Channel-scoped consumer lifecycle. These name no queue of their own;
 		// they can only affect a consumer the subscribe ACL already allowed.
@@ -303,14 +301,26 @@ func (ch *Channel) authorizeLocalMethod(decoded any) (bool, error) {
 	}
 }
 
-// authorizeLocalSubscribe admits a queue-scoped consumer operation only on a
-// listener that permits consumers and only for a queue the principal's own
-// subscribe ACL names.
+// authorizeLocalSubscribe admits a queue-scoped consumer operation only for a
+// principal whose role permits consumers and whose subscribe ACL names the
+// queue.
+//
+// The ACL names queues, so the wire value is resolved first and the resolved
+// queue name is what gets authorized: a client addresses "$queue/m" while the
+// ACL says "m", and comparing the two directly would refuse every legitimate
+// consumer. A filter that resolves to no queue is refused rather than admitted
+// as a pub/sub subscription, because no ACL entry grants one.
 func (ch *Channel) authorizeLocalSubscribe(queue, principalID string, decoded any) (bool, error) {
 	if !ch.conn.permitsConsumers() {
 		return ch.denyLocalMethod(decoded, principalID)
 	}
-	if ch.conn.canSubscribeLocal(queue) {
+
+	route := ch.conn.broker.routeResolver.Resolve(queue)
+	reason := "subscribe_acl_mismatch"
+	switch {
+	case route.Kind != corebroker.RouteQueue:
+		reason = "not_a_queue_address"
+	case ch.conn.canSubscribeLocal(route.QueueName):
 		return true, nil
 	}
 
@@ -319,9 +329,10 @@ func (ch *Channel) authorizeLocalSubscribe(queue, principalID string, decoded an
 	ch.conn.logger.Warn("amqp091_local_authorization",
 		"auth_mode", "local",
 		"outcome", "denied",
-		"reason", "subscribe_acl_mismatch",
+		"reason", reason,
 		"principal_id", principalID,
-		"queue", queue)
+		"queue", queue,
+		"resolved_queue", route.QueueName)
 	return false, ch.sendChannelClose(codec.AccessRefused, "subscribe not authorized", classID, methodID)
 }
 
@@ -627,6 +638,15 @@ func (ch *Channel) completePublish() {
 
 	// Route through resolver for default-exchange queue operations.
 	resolver := ch.conn.broker.routeResolver
+	// A prefix grant is checked against no queues entry, so it must not be able
+	// to reach one. Without this it could route into a queue two ways: a routing
+	// key under a "$queue/"-shaped prefix, or one that happens to name a
+	// configured stream. Both would write to a queue on a permission that never
+	// established the durability contract a queue publish carries.
+	if grant == LocalPublishGrantPrefix {
+		ch.publishToPubSub(topics.AMQPTopicToMQTT(topic), body, props, method, header)
+		return
+	}
 	if exchangeName == "" {
 		route := resolver.Resolve(topic)
 		switch route.Kind {
@@ -700,26 +720,39 @@ func (ch *Channel) completePublish() {
 		if exchangeName == "" {
 			pubsubTopic = topics.AMQPTopicToMQTT(topic)
 		}
-		// Publish to the topic-based router (pub/sub)
-		if method.Mandatory {
-			subs, err := ch.conn.broker.router.Match(pubsubTopic)
-			if err != nil || len(subs) == 0 {
-				if err != nil {
-					ch.conn.logger.Error("router match failed", "topic", pubsubTopic, "error", err)
-				}
-				ch.sendBasicReturn(method, header, body)
-				if ch.confirmMode {
-					ch.sendPublisherAck()
-				}
-				return
-			}
-		}
-		if err := ch.conn.broker.Publish(pubsubTopic, body, props); err != nil {
-			publishFailed = true
-		}
+		ch.publishToPubSub(pubsubTopic, body, props, method, header)
+		return
 	}
 
 	// Publisher confirms
+	if ch.confirmMode {
+		if publishFailed {
+			ch.sendPublisherNack()
+		} else {
+			ch.sendPublisherAck()
+		}
+	}
+}
+
+// publishToPubSub delivers through the topic router and settles the publisher
+// confirm. It is the only delivery path a routing-key-prefix grant may take,
+// because such a grant is authorized against no queue.
+func (ch *Channel) publishToPubSub(pubsubTopic string, body []byte, props map[string]string, method *codec.BasicPublish, header *codec.ContentHeader) {
+	if method.Mandatory {
+		subs, err := ch.conn.broker.router.Match(pubsubTopic)
+		if err != nil || len(subs) == 0 {
+			if err != nil {
+				ch.conn.logger.Error("router match failed", "topic", pubsubTopic, "error", err)
+			}
+			ch.sendBasicReturn(method, header, body)
+			if ch.confirmMode {
+				ch.sendPublisherAck()
+			}
+			return
+		}
+	}
+
+	publishFailed := ch.conn.broker.Publish(pubsubTopic, body, props) != nil
 	if ch.confirmMode {
 		if publishFailed {
 			ch.sendPublisherNack()
@@ -1149,12 +1182,33 @@ func (ch *Channel) handleExchangeUnbind(m *codec.ExchangeUnbind) error {
 
 // Queue methods
 
+// queueExists reports whether a passive declaration should succeed. The
+// channel-local map only holds queues this channel declared, so a
+// pre-provisioned queue — the only kind a local principal may consume — is
+// found through the queue manager instead.
+func (ch *Channel) queueExists(name string) bool {
+	if name == "" {
+		return false
+	}
+
+	ch.exchangeMu.RLock()
+	_, declared := ch.queues[name]
+	ch.exchangeMu.RUnlock()
+	if declared {
+		return true
+	}
+
+	qm := ch.conn.broker.queueManager
+	if qm == nil {
+		return false
+	}
+	cfg, err := qm.GetQueue(context.Background(), name)
+	return err == nil && cfg != nil
+}
+
 func (ch *Channel) handleQueueDeclare(m *codec.QueueDeclare) error {
 	if m.Passive {
-		ch.exchangeMu.RLock()
-		_, exists := ch.queues[m.Queue]
-		ch.exchangeMu.RUnlock()
-		if !exists {
+		if !ch.queueExists(m.Queue) {
 			return ch.sendChannelClose(codec.NotFound,
 				"queue not found", codec.ClassQueue, codec.MethodQueueDeclare)
 		}

--- a/amqp/broker/channel.go
+++ b/amqp/broker/channel.go
@@ -22,6 +22,7 @@ import (
 	corebroker "github.com/absmach/fluxmq/broker"
 	"github.com/absmach/fluxmq/internal/bufpool"
 	queuepkg "github.com/absmach/fluxmq/queue"
+	qstorage "github.com/absmach/fluxmq/queue/storage"
 	qtypes "github.com/absmach/fluxmq/queue/types"
 	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/topics"
@@ -273,7 +274,7 @@ func (ch *Channel) authorizeLocalMethod(decoded any) (bool, error) {
 		if !method.Passive {
 			return ch.denyLocalMethod(decoded, principalID)
 		}
-		return ch.authorizeLocalSubscribe(method.Queue, principalID, decoded)
+		return ch.authorizeLocalQueueName(method.Queue, principalID, decoded)
 	case *codec.BasicConsume:
 		return ch.authorizeLocalSubscribe(method.Queue, principalID, decoded)
 	case *codec.BasicQos, *codec.BasicCancel, *codec.BasicAck, *codec.BasicNack, *codec.BasicReject:
@@ -299,6 +300,29 @@ func (ch *Channel) authorizeLocalMethod(decoded any) (bool, error) {
 	default:
 		return ch.denyLocalMethod(decoded, principalID)
 	}
+}
+
+// authorizeLocalQueueName authorizes AMQP methods whose queue field is the
+// queue name itself. Queue.Declare uses the bare name "m"; unlike
+// Basic.Consume, its field is not a "$queue/m" subscription address.
+func (ch *Channel) authorizeLocalQueueName(queue, principalID string, decoded any) (bool, error) {
+	if !ch.conn.permitsConsumers() {
+		return ch.denyLocalMethod(decoded, principalID)
+	}
+	if queue != "" && ch.conn.canSubscribeLocal(queue) {
+		return true, nil
+	}
+
+	classID, methodID := methodIdentifier(decoded)
+	ch.conn.broker.stats.IncrementLocalSubscribeDenials()
+	ch.conn.logger.Warn("amqp091_local_authorization",
+		"auth_mode", "local",
+		"outcome", "denied",
+		"reason", "subscribe_acl_mismatch",
+		"principal_id", principalID,
+		"queue", queue,
+		"resolved_queue", queue)
+	return false, ch.sendChannelClose(codec.AccessRefused, "subscribe not authorized", classID, methodID)
 }
 
 // authorizeLocalSubscribe admits a queue-scoped consumer operation only for a
@@ -1434,13 +1458,7 @@ func (ch *Channel) handleBasicConsume(m *codec.BasicConsume) error {
 		groupID = tag
 	}
 
-	ch.consumersMu.Lock()
-	if _, exists := ch.consumers[tag]; exists {
-		ch.consumersMu.Unlock()
-		return ch.sendChannelClose(codec.NotAllowed,
-			fmt.Sprintf("consumer tag %q already exists", tag), codec.ClassBasic, codec.MethodBasicConsume)
-	}
-	ch.consumers[tag] = &consumer{
+	cons := &consumer{
 		tag:        tag,
 		queue:      queueFilter,
 		mqttFilter: mqttFilter,
@@ -1450,14 +1468,41 @@ func (ch *Channel) handleBasicConsume(m *codec.BasicConsume) error {
 		noAck:      m.NoAck,
 		exclusive:  m.Exclusive,
 	}
+
+	ch.consumersMu.Lock()
+	if _, exists := ch.consumers[tag]; exists {
+		ch.consumersMu.Unlock()
+		return ch.sendChannelClose(codec.NotAllowed,
+			fmt.Sprintf("consumer tag %q already exists", tag), codec.ClassBasic, codec.MethodBasicConsume)
+	}
+	// Reserve the consumer before subscribing because queue delivery can begin
+	// as soon as the manager registers it. A failed subscription removes this
+	// reservation before the channel reports the failure.
+	ch.consumers[tag] = cons
 	ch.consumersMu.Unlock()
 
 	ch.conn.broker.stats.IncrementConsumers()
+	rollbackConsumer := func() {
+		ch.consumersMu.Lock()
+		if current, exists := ch.consumers[tag]; exists && current == cons {
+			delete(ch.consumers, tag)
+			ch.conn.broker.stats.DecrementConsumers()
+		}
+		ch.consumersMu.Unlock()
+	}
 
 	// Subscribe to the queue via queue manager
-	if qm != nil && (isQueue || isStream) && queueName != "" {
-		clientID := PrefixedClientID(ch.conn.connID)
+	if (isQueue || isStream) && queueName != "" {
+		if qm == nil {
+			rollbackConsumer()
+			return ch.sendChannelClose(codec.InternalError, "queue manager unavailable", codec.ClassBasic, codec.MethodBasicConsume)
+		}
+
 		subGroupID := groupID
+		var (
+			subscribeErr        error
+			subscriptionStarted bool
+		)
 		if isStream {
 			cursor := streamCursor
 			if cursor == nil {
@@ -1467,11 +1512,47 @@ func (ch *Channel) handleBasicConsume(m *codec.BasicConsume) error {
 			if autoCommit := extractAutoCommit(m.Arguments); autoCommit != nil {
 				cursor.AutoCommit = autoCommit
 			}
-			if err := qm.SubscribeWithCursor(context.Background(), queueName, pattern, clientID, subGroupID, "", cursor); err != nil {
-				ch.conn.logger.Error("queue subscribe with cursor failed", "queue", queueName, "error", err)
+			if ch.conn.connectionPolicy().usesLocalPrincipalAuth() {
+				existing, ok := qm.(corebroker.ExistingQueueSubscriber)
+				if !ok {
+					subscribeErr = fmt.Errorf("queue manager does not support non-mutating subscriptions")
+				} else {
+					subscriptionStarted = true
+					subscribeErr = existing.SubscribeExistingWithCursor(context.Background(), queueName, pattern, clientID, subGroupID, "", cursor)
+				}
+			} else {
+				subscriptionStarted = true
+				subscribeErr = qm.SubscribeWithCursor(context.Background(), queueName, pattern, clientID, subGroupID, "", cursor)
 			}
-		} else if err := qm.Subscribe(context.Background(), queueName, pattern, clientID, subGroupID, ""); err != nil {
-			ch.conn.logger.Error("queue subscribe failed", "queue", queueName, "error", err)
+		} else if ch.conn.connectionPolicy().usesLocalPrincipalAuth() {
+			existing, ok := qm.(corebroker.ExistingQueueSubscriber)
+			if !ok {
+				subscribeErr = fmt.Errorf("queue manager does not support non-mutating subscriptions")
+			} else {
+				subscriptionStarted = true
+				subscribeErr = existing.SubscribeExisting(context.Background(), queueName, pattern, clientID, subGroupID, "")
+			}
+		} else {
+			subscriptionStarted = true
+			subscribeErr = qm.Subscribe(context.Background(), queueName, pattern, clientID, subGroupID, "")
+		}
+
+		if subscribeErr != nil {
+			rollbackConsumer()
+			// A manager can fail after partially registering group state. Cleanup is
+			// best effort; errors raised before registration need no cleanup.
+			if subscriptionStarted && !errors.Is(subscribeErr, qstorage.ErrQueueNotFound) && !errors.Is(subscribeErr, queuepkg.ErrQueueNotStream) {
+				_ = qm.Unsubscribe(context.Background(), queueName, pattern, clientID, subGroupID)
+			}
+			ch.conn.logger.Error("queue subscribe failed", "queue", queueName, "error", subscribeErr)
+			switch {
+			case errors.Is(subscribeErr, qstorage.ErrQueueNotFound):
+				return ch.sendChannelClose(codec.NotFound, "queue not found", codec.ClassBasic, codec.MethodBasicConsume)
+			case errors.Is(subscribeErr, queuepkg.ErrQueueNotStream):
+				return ch.sendChannelClose(codec.PreconditionFailed, "queue is not a stream", codec.ClassBasic, codec.MethodBasicConsume)
+			default:
+				return ch.sendChannelClose(codec.InternalError, "queue subscription failed", codec.ClassBasic, codec.MethodBasicConsume)
+			}
 		}
 	}
 

--- a/amqp/broker/channel.go
+++ b/amqp/broker/channel.go
@@ -1482,13 +1482,25 @@ func (ch *Channel) handleBasicConsume(m *codec.BasicConsume) error {
 	ch.consumersMu.Unlock()
 
 	ch.conn.broker.stats.IncrementConsumers()
-	rollbackConsumer := func() {
+	// rollbackConsumer drops the reservation and reports whether another
+	// consumer on this channel still holds the same registration. The manager
+	// unregisters a client from a queue and group rather than a single consumer,
+	// so compensating for a failed subscribe while a sibling remains would stop
+	// delivering to that sibling without telling anyone.
+	rollbackConsumer := func() (siblingRemains bool) {
 		ch.consumersMu.Lock()
+		defer ch.consumersMu.Unlock()
+
 		if current, exists := ch.consumers[tag]; exists && current == cons {
 			delete(ch.consumers, tag)
 			ch.conn.broker.stats.DecrementConsumers()
 		}
-		ch.consumersMu.Unlock()
+		for _, other := range ch.consumers {
+			if other.queueName == queueName && other.groupID == groupID && other.pattern == pattern {
+				return true
+			}
+		}
+		return false
 	}
 
 	// Subscribe to the queue via queue manager
@@ -1538,10 +1550,12 @@ func (ch *Channel) handleBasicConsume(m *codec.BasicConsume) error {
 		}
 
 		if subscribeErr != nil {
-			rollbackConsumer()
+			siblingRemains := rollbackConsumer()
 			// A manager can fail after partially registering group state. Cleanup is
-			// best effort; errors raised before registration need no cleanup.
-			if subscriptionStarted && !errors.Is(subscribeErr, qstorage.ErrQueueNotFound) && !errors.Is(subscribeErr, queuepkg.ErrQueueNotStream) {
+			// best effort; errors raised before registration need no cleanup, and a
+			// sibling consumer sharing this registration owns it now.
+			if subscriptionStarted && !siblingRemains &&
+				!errors.Is(subscribeErr, qstorage.ErrQueueNotFound) && !errors.Is(subscribeErr, queuepkg.ErrQueueNotStream) {
 				_ = qm.Unsubscribe(context.Background(), queueName, pattern, clientID, subGroupID)
 			}
 			ch.conn.logger.Error("queue subscribe failed", "queue", queueName, "error", subscribeErr)

--- a/amqp/broker/channel.go
+++ b/amqp/broker/channel.go
@@ -473,19 +473,41 @@ func (ch *Channel) completePublish() {
 	}
 
 	clientID := PrefixedClientID(ch.conn.connID)
-	if ch.conn.connectionPolicy().mode == ConnectionPolicyLocalPublishOnly {
-		if principalID := ch.conn.externalID(clientID); principalID != "" {
-			props[corebroker.ExternalIDProperty] = principalID
-		}
-	} else if v, ok := header.Properties.Headers[corebroker.ExternalIDProperty].(string); ok && v != "" {
-		props[corebroker.ExternalIDProperty] = v
+	policy := ch.conn.connectionPolicy()
+
+	// A relayed origin identity is honored only from a trusted service. Anyone
+	// else gets their own authenticated identity stamped, so a publisher cannot
+	// attribute a message to another principal or to another protocol.
+	relayedID := ""
+	if policy.propagatesOriginIdentity() {
+		relayedID, _ = header.Properties.Headers[corebroker.ExternalIDProperty].(string)
+	}
+	if relayedID != "" {
+		props[corebroker.ExternalIDProperty] = relayedID
 	} else if externalID := ch.conn.externalID(clientID); externalID != "" {
 		props[corebroker.ExternalIDProperty] = externalID
 	}
-	if v, ok := header.Properties.Headers[corebroker.ProtocolProperty].(string); ok && v != "" {
-		props[corebroker.ProtocolProperty] = v
-	} else {
-		props[corebroker.ProtocolProperty] = corebroker.ProtocolAMQP091
+
+	props[corebroker.ProtocolProperty] = corebroker.ProtocolAMQP091
+	if policy.propagatesOriginIdentity() {
+		if v, ok := header.Properties.Headers[corebroker.ProtocolProperty].(string); ok && v != "" {
+			props[corebroker.ProtocolProperty] = v
+		}
+	}
+
+	// Broker-internal properties are accepted only from a trusted listener.
+	// An externally authenticated client is a tenant or device regardless of
+	// which protocol it speaks, so its reserved headers are dropped here rather
+	// than forwarded as broker state.
+	if policy.carriesReservedProperties() {
+		for key, value := range header.Properties.Headers {
+			if !corebroker.IsReservedProperty(key) {
+				continue
+			}
+			if v, ok := value.(string); ok {
+				props[key] = v
+			}
+		}
 	}
 
 	exchangeName := normalizeExchange(method.Exchange)
@@ -500,7 +522,6 @@ func (ch *Channel) completePublish() {
 	props = corebroker.AddClientIDProperty(props, clientID)
 	originalTopic := topic
 
-	policy := ch.conn.connectionPolicy()
 	if policy.mode == ConnectionPolicyLocalPublishOnly {
 		// Re-evaluate at completion so an ACL reduction made while content frames
 		// are in flight takes effect immediately.
@@ -818,8 +839,15 @@ func (ch *Channel) sendDelivery(cons *consumer, topic string, payload []byte, pr
 		return err
 	}
 
+	// Broker-internal properties are revealed only to a trusted listener, so an
+	// externally authenticated consumer cannot observe state another service set.
+	carryReserved := ch.conn.connectionPolicy().carriesReservedProperties()
+
 	headers := make(map[string]any)
 	for k, v := range props {
+		if !carryReserved && corebroker.IsReservedProperty(k) {
+			continue
+		}
 		switch k {
 		case "content-type", "content-encoding", "correlation-id", "reply-to", qtypes.PropMessageID, "type":
 			continue

--- a/amqp/broker/channel.go
+++ b/amqp/broker/channel.go
@@ -148,7 +148,7 @@ func (ch *Channel) handleMethod(decoded any) error {
 		}
 	}
 
-	if ch.conn.connectionPolicy().mode == ConnectionPolicyLocalPublishOnly {
+	if ch.conn.connectionPolicy().usesLocalPrincipalAuth() {
 		allowed, err := ch.authorizeLocalMethod(decoded)
 		if err != nil {
 			return err
@@ -264,6 +264,17 @@ func (ch *Channel) authorizeLocalMethod(decoded any) (bool, error) {
 	switch method := decoded.(type) {
 	case *codec.ChannelFlow, *codec.ChannelClose, *codec.ChannelCloseOk, *codec.ConfirmSelect:
 		return true, nil
+	case *codec.QueueDeclare:
+		return ch.authorizeLocalSubscribe(method.Queue, principalID, decoded)
+	case *codec.BasicConsume:
+		return ch.authorizeLocalSubscribe(method.Queue, principalID, decoded)
+	case *codec.BasicQos, *codec.BasicCancel, *codec.BasicAck, *codec.BasicNack, *codec.BasicReject:
+		// Channel-scoped consumer lifecycle. These name no queue of their own;
+		// they can only affect a consumer the subscribe ACL already allowed.
+		if ch.conn.connectionPolicy().permitsConsumers() {
+			return true, nil
+		}
+		return ch.denyLocalMethod(decoded, principalID)
 	case *codec.BasicPublish:
 		if ch.conn.canPublishLocal(method.Exchange, method.RoutingKey) {
 			return true, nil
@@ -278,17 +289,43 @@ func (ch *Channel) authorizeLocalMethod(decoded any) (bool, error) {
 			"routing_key", method.RoutingKey)
 		return false, ch.sendChannelClose(codec.AccessRefused, "publish not authorized", codec.ClassBasic, codec.MethodBasicPublish)
 	default:
-		classID, methodID := methodIdentifier(decoded)
-		ch.conn.broker.stats.IncrementLocalOperationDenials()
-		ch.conn.logger.Warn("amqp091_local_authorization",
-			"auth_mode", "local",
-			"outcome", "denied",
-			"reason", "operation_not_permitted",
-			"principal_id", principalID,
-			"class_id", classID,
-			"method_id", methodID)
-		return false, ch.sendChannelClose(codec.AccessRefused, "operation not permitted for local publisher", classID, methodID)
+		return ch.denyLocalMethod(decoded, principalID)
 	}
+}
+
+// authorizeLocalSubscribe admits a queue-scoped consumer operation only on a
+// listener that permits consumers and only for a queue the principal's own
+// subscribe ACL names.
+func (ch *Channel) authorizeLocalSubscribe(queue, principalID string, decoded any) (bool, error) {
+	if !ch.conn.connectionPolicy().permitsConsumers() {
+		return ch.denyLocalMethod(decoded, principalID)
+	}
+	if ch.conn.canSubscribeLocal(queue) {
+		return true, nil
+	}
+
+	classID, methodID := methodIdentifier(decoded)
+	ch.conn.broker.stats.IncrementLocalSubscribeDenials()
+	ch.conn.logger.Warn("amqp091_local_authorization",
+		"auth_mode", "local",
+		"outcome", "denied",
+		"reason", "subscribe_acl_mismatch",
+		"principal_id", principalID,
+		"queue", queue)
+	return false, ch.sendChannelClose(codec.AccessRefused, "subscribe not authorized", classID, methodID)
+}
+
+func (ch *Channel) denyLocalMethod(decoded any, principalID string) (bool, error) {
+	classID, methodID := methodIdentifier(decoded)
+	ch.conn.broker.stats.IncrementLocalOperationDenials()
+	ch.conn.logger.Warn("amqp091_local_authorization",
+		"auth_mode", "local",
+		"outcome", "denied",
+		"reason", "operation_not_permitted",
+		"principal_id", principalID,
+		"class_id", classID,
+		"method_id", methodID)
+	return false, ch.sendChannelClose(codec.AccessRefused, "operation not permitted for local principal", classID, methodID)
 }
 
 func (ch *Channel) sendChannelClose(code uint16, text string, classID, methodID uint16) error {
@@ -522,7 +559,7 @@ func (ch *Channel) completePublish() {
 	props = corebroker.AddClientIDProperty(props, clientID)
 	originalTopic := topic
 
-	if policy.mode == ConnectionPolicyLocalPublishOnly {
+	if policy.usesLocalPrincipalAuth() {
 		// Re-evaluate at completion so an ACL reduction made while content frames
 		// are in flight takes effect immediately.
 		if !ch.conn.canPublishLocal(method.Exchange, method.RoutingKey) {

--- a/amqp/broker/channel.go
+++ b/amqp/broker/channel.go
@@ -281,7 +281,7 @@ func (ch *Channel) authorizeLocalMethod(decoded any) (bool, error) {
 	case *codec.BasicQos, *codec.BasicCancel, *codec.BasicAck, *codec.BasicNack, *codec.BasicReject:
 		// Channel-scoped consumer lifecycle. These name no queue of their own;
 		// they can only affect a consumer the subscribe ACL already allowed.
-		if ch.conn.connectionPolicy().permitsConsumers() {
+		if ch.conn.permitsConsumers() {
 			return true, nil
 		}
 		return ch.denyLocalMethod(decoded, principalID)
@@ -307,7 +307,7 @@ func (ch *Channel) authorizeLocalMethod(decoded any) (bool, error) {
 // listener that permits consumers and only for a queue the principal's own
 // subscribe ACL names.
 func (ch *Channel) authorizeLocalSubscribe(queue, principalID string, decoded any) (bool, error) {
-	if !ch.conn.connectionPolicy().permitsConsumers() {
+	if !ch.conn.permitsConsumers() {
 		return ch.denyLocalMethod(decoded, principalID)
 	}
 	if ch.conn.canSubscribeLocal(queue) {
@@ -526,7 +526,7 @@ func (ch *Channel) completePublish() {
 	// else gets their own authenticated identity stamped, so a publisher cannot
 	// attribute a message to another principal or to another protocol.
 	relayedID := ""
-	if policy.propagatesOriginIdentity() {
+	if ch.conn.propagatesOriginIdentity() {
 		relayedID, _ = header.Properties.Headers[corebroker.ExternalIDProperty].(string)
 	}
 	if relayedID != "" {
@@ -536,7 +536,7 @@ func (ch *Channel) completePublish() {
 	}
 
 	props[corebroker.ProtocolProperty] = corebroker.ProtocolAMQP091
-	if policy.propagatesOriginIdentity() {
+	if ch.conn.propagatesOriginIdentity() {
 		if v, ok := header.Properties.Headers[corebroker.ProtocolProperty].(string); ok && v != "" {
 			props[corebroker.ProtocolProperty] = v
 		}

--- a/amqp/broker/channel.go
+++ b/amqp/broker/channel.go
@@ -1867,7 +1867,11 @@ func (ch *Channel) cancelConsumerByQueue(queueName, groupID string) {
 	ch.consumersMu.Lock()
 	var toCancel []*consumer
 	for tag, cons := range ch.consumers {
-		if cons.queueName == queueName && cons.groupID == groupID {
+		// The manager reports the group it registered, which a pattern
+		// qualifies. Comparing the raw group would never match a patterned
+		// consumer, leaving it uncancelled and its registration held.
+		if cons.queueName == queueName &&
+			corebroker.EffectiveConsumerGroupID(cons.groupID, cons.pattern) == groupID {
 			toCancel = append(toCancel, cons)
 			delete(ch.consumers, tag)
 		}

--- a/amqp/broker/channel.go
+++ b/amqp/broker/channel.go
@@ -1457,6 +1457,9 @@ func (ch *Channel) handleBasicConsume(m *codec.BasicConsume) error {
 	if isStream && groupID == "" {
 		groupID = tag
 	}
+	if queueName != "" && groupID == "" {
+		groupID = queuepkg.DefaultConsumerGroupID(clientID)
+	}
 
 	cons := &consumer{
 		tag:        tag,
@@ -1479,28 +1482,26 @@ func (ch *Channel) handleBasicConsume(m *codec.BasicConsume) error {
 	// as soon as the manager registers it. A failed subscription removes this
 	// reservation before the channel reports the failure.
 	ch.consumers[tag] = cons
+	ch.conn.retainQueueRegistration(cons)
+	ch.conn.broker.stats.IncrementConsumers()
 	ch.consumersMu.Unlock()
 
-	ch.conn.broker.stats.IncrementConsumers()
-	// rollbackConsumer drops the reservation and reports whether another
-	// consumer on this channel still holds the same registration. The manager
-	// unregisters a client from a queue and group rather than a single consumer,
-	// so compensating for a failed subscribe while a sibling remains would stop
-	// delivering to that sibling without telling anyone.
-	rollbackConsumer := func() (siblingRemains bool) {
+	// rollbackConsumer drops the reservation and reports whether it released the
+	// last owner of the connection-level queue-manager registration.
+	rollbackConsumer := func() (registrationUnused bool) {
 		ch.consumersMu.Lock()
-		defer ch.consumersMu.Unlock()
-
+		removed := false
 		if current, exists := ch.consumers[tag]; exists && current == cons {
 			delete(ch.consumers, tag)
-			ch.conn.broker.stats.DecrementConsumers()
+			removed = true
 		}
-		for _, other := range ch.consumers {
-			if other.queueName == queueName && other.groupID == groupID && other.pattern == pattern {
-				return true
-			}
+		ch.consumersMu.Unlock()
+		if !removed {
+			return false
 		}
-		return false
+
+		ch.conn.broker.stats.DecrementConsumers()
+		return ch.conn.releaseQueueRegistration(cons)
 	}
 
 	// Subscribe to the queue via queue manager
@@ -1550,11 +1551,11 @@ func (ch *Channel) handleBasicConsume(m *codec.BasicConsume) error {
 		}
 
 		if subscribeErr != nil {
-			siblingRemains := rollbackConsumer()
+			registrationUnused := rollbackConsumer()
 			// A manager can fail after partially registering group state. Cleanup is
-			// best effort; errors raised before registration need no cleanup, and a
-			// sibling consumer sharing this registration owns it now.
-			if subscriptionStarted && !siblingRemains &&
+			// best effort; errors raised before registration need no cleanup, and an
+			// in-use connection registration must remain intact.
+			if subscriptionStarted && registrationUnused &&
 				!errors.Is(subscribeErr, qstorage.ErrQueueNotFound) && !errors.Is(subscribeErr, queuepkg.ErrQueueNotStream) {
 				_ = qm.Unsubscribe(context.Background(), queueName, pattern, clientID, subGroupID)
 			}
@@ -1603,8 +1604,10 @@ func (ch *Channel) handleBasicCancel(m *codec.BasicCancel) error {
 		defer cancel()
 
 		qm := ch.conn.broker.queueManager
-		if qm != nil && cons.queueName != "" {
-			qm.Unsubscribe(ctx, cons.queueName, cons.pattern, clientID, cons.groupID) //nolint:errcheck // best-effort cleanup on consumer cancel
+		if cons.queueName != "" {
+			if registrationUnused := ch.conn.releaseQueueRegistration(cons); registrationUnused && qm != nil {
+				qm.Unsubscribe(ctx, cons.queueName, cons.pattern, clientID, cons.groupID) //nolint:errcheck // best-effort cleanup on final consumer cancel
+			}
 		}
 
 		if cons.queueName == "" {
@@ -1829,8 +1832,10 @@ func (ch *Channel) cleanup() {
 
 	for _, cons := range consumers {
 		ch.conn.broker.stats.DecrementConsumers()
-		if qm != nil && cons.queueName != "" {
-			qm.Unsubscribe(ctx, cons.queueName, cons.pattern, clientID, cons.groupID) //nolint:errcheck // best-effort cleanup during channel close
+		if cons.queueName != "" {
+			if registrationUnused := ch.conn.releaseQueueRegistration(cons); registrationUnused && qm != nil {
+				qm.Unsubscribe(ctx, cons.queueName, cons.pattern, clientID, cons.groupID) //nolint:errcheck // best-effort cleanup for the final owner during channel close
+			}
 		}
 		if cons.queueName == "" {
 			if cons.mqttFilter == "" {
@@ -1860,23 +1865,24 @@ func (ch *Channel) cancelConsumerByQueue(queueName, groupID string) {
 	}
 
 	ch.consumersMu.Lock()
-	var toCancel []string
+	var toCancel []*consumer
 	for tag, cons := range ch.consumers {
 		if cons.queueName == queueName && cons.groupID == groupID {
-			toCancel = append(toCancel, tag)
+			toCancel = append(toCancel, cons)
 			delete(ch.consumers, tag)
 		}
 	}
 	ch.consumersMu.Unlock()
 
-	for _, tag := range toCancel {
+	for _, cons := range toCancel {
+		ch.conn.releaseQueueRegistration(cons)
 		ch.conn.broker.stats.DecrementConsumers()
 		if err := ch.conn.writeMethod(ch.id, &codec.BasicCancel{
-			ConsumerTag: tag,
+			ConsumerTag: cons.tag,
 			NoWait:      true,
 		}); err != nil {
 			ch.conn.logger.Warn("failed to send server-initiated basic.cancel",
-				slog.String("consumer_tag", tag),
+				slog.String("consumer_tag", cons.tag),
 				slog.String("queue", queueName),
 				slog.String("error", err.Error()))
 		}

--- a/amqp/broker/channel.go
+++ b/amqp/broker/channel.go
@@ -265,8 +265,18 @@ func (ch *Channel) authorizeLocalMethod(decoded any) (bool, error) {
 	case *codec.ChannelFlow, *codec.ChannelClose, *codec.ChannelCloseOk, *codec.ConfirmSelect:
 		return true, nil
 	case *codec.QueueDeclare:
+		// A non-passive declare creates the queue and, when it already exists,
+		// rewrites its type, retention, TTL and durability. That is a
+		// configuration write, and the subscribe ACL grants reads: a principal
+		// permitted to consume a queue must not be able to reshape it. Services
+		// consume pre-provisioned queues, so they only need to assert existence.
+		if !method.Passive {
+			return ch.denyLocalMethod(decoded, principalID)
+		}
 		return ch.authorizeLocalSubscribe(method.Queue, principalID, decoded)
 	case *codec.BasicConsume:
+		return ch.authorizeLocalSubscribe(method.Queue, principalID, decoded)
+	case *codec.BasicGet:
 		return ch.authorizeLocalSubscribe(method.Queue, principalID, decoded)
 	case *codec.BasicQos, *codec.BasicCancel, *codec.BasicAck, *codec.BasicNack, *codec.BasicReject:
 		// Channel-scoped consumer lifecycle. These name no queue of their own;
@@ -276,7 +286,7 @@ func (ch *Channel) authorizeLocalMethod(decoded any) (bool, error) {
 		}
 		return ch.denyLocalMethod(decoded, principalID)
 	case *codec.BasicPublish:
-		if ch.conn.canPublishLocal(method.Exchange, method.RoutingKey) {
+		if ch.conn.canPublishLocal(method.Exchange, method.RoutingKey).Allowed() {
 			return true, nil
 		}
 		ch.conn.broker.stats.IncrementLocalPublishDenials()
@@ -559,10 +569,13 @@ func (ch *Channel) completePublish() {
 	props = corebroker.AddClientIDProperty(props, clientID)
 	originalTopic := topic
 
+	grant := LocalPublishGrantNone
 	if policy.usesLocalPrincipalAuth() {
 		// Re-evaluate at completion so an ACL reduction made while content frames
-		// are in flight takes effect immediately.
-		if !ch.conn.canPublishLocal(method.Exchange, method.RoutingKey) {
+		// are in flight takes effect immediately. The grant this returns is also
+		// what selects the delivery path below, so both come from one snapshot.
+		grant = ch.conn.canPublishLocal(method.Exchange, method.RoutingKey)
+		if !grant.Allowed() {
 			ch.conn.broker.stats.IncrementLocalPublishDenials()
 			ch.conn.logger.Warn("amqp091_local_authorization",
 				"auth_mode", "local",
@@ -597,7 +610,13 @@ func (ch *Channel) completePublish() {
 			}
 		}
 	}
-	if policy.mode == ConnectionPolicyLocalPublishOnly {
+	// The permission that authorized the publication decides how it is routed,
+	// not the listener it arrived on. An exact routing key names a protected
+	// durable stream and is appended and synced before the publisher is
+	// confirmed; a prefix names no queue and is an ordinary topic publish. Both
+	// listeners must agree, or one permissions.publish entry would mean two
+	// different delivery contracts depending on which port the principal used.
+	if grant == LocalPublishGrantExactTarget {
 		if exchangeName != "" {
 			ch.rejectLocalStreamPublish(fmt.Errorf("local durable stream publish requires the default exchange"))
 			return

--- a/amqp/broker/channel_test.go
+++ b/amqp/broker/channel_test.go
@@ -26,6 +26,7 @@ const (
 	eventsExchange   = "events"
 	testRuleTrace    = `["rule-a"]`
 	testCustomHeader = "x-custom"
+	testOtherTarget  = "other"
 	testHeaderValue  = "value"
 )
 
@@ -1058,6 +1059,18 @@ func TestDeliveryReservedHeadersEgressTrustBoundary(t *testing.T) {
 			want:   map[string]any{reserved: testRuleTrace, testCustomHeader: testHeaderValue},
 		},
 		{
+			name: "service policy reveals reserved property to a first-party consumer",
+			// The reason the boundary has an inward direction at all: without a
+			// consumer that may read them, reserved properties would be write-only.
+			policy: NewLocalServiceConnectionPolicy(nil, nil, nil, 0),
+			want:   map[string]any{reserved: testRuleTrace, testCustomHeader: testHeaderValue},
+		},
+		{
+			name:   "publish-only policy still reveals nothing it cannot consume",
+			policy: NewLocalPublishOnlyConnectionPolicy(nil, nil, nil, 0),
+			want:   map[string]any{reserved: testRuleTrace, testCustomHeader: testHeaderValue},
+		},
+		{
 			name:   "external policy hides reserved property",
 			policy: NewExternalConnectionPolicy(nil, nil, 0),
 			want:   map[string]any{testCustomHeader: testHeaderValue},
@@ -1205,4 +1218,105 @@ func TestCancelConsumerByQueue(t *testing.T) {
 			t.Fatal("expected no frames to be written on closed channel")
 		}
 	})
+}
+
+// The consumer lifecycle is admitted only on a listener that permits consumers,
+// and only for a queue the principal's own subscribe ACL names. A publish-only
+// principal keeps its existing, narrower method set.
+func TestAuthorizeLocalMethodConsumerLifecycle(t *testing.T) {
+	const allowedQueue = "m"
+
+	servicePolicy := func(authz LocalPrincipalAuthorizer) *ConnectionPolicy {
+		return NewLocalServiceConnectionPolicy(nil, authz, nil, 0)
+	}
+	publishOnlyPolicy := func(authz LocalPrincipalAuthorizer) *ConnectionPolicy {
+		return NewLocalPublishOnlyConnectionPolicy(nil, authz, nil, 0)
+	}
+
+	tests := []struct {
+		name        string
+		policy      func(LocalPrincipalAuthorizer) *ConnectionPolicy
+		method      any
+		wantAllowed bool
+	}{
+		{
+			name:        "service consumes a permitted queue",
+			policy:      servicePolicy,
+			method:      &codec.BasicConsume{Queue: allowedQueue},
+			wantAllowed: true,
+		},
+		{
+			name:   "service is refused a queue outside its ACL",
+			policy: servicePolicy,
+			method: &codec.BasicConsume{Queue: testOtherTarget},
+		},
+		{
+			name:        "service declares a permitted queue",
+			policy:      servicePolicy,
+			method:      &codec.QueueDeclare{Queue: allowedQueue},
+			wantAllowed: true,
+		},
+		{
+			name:   "service is refused declaring a queue outside its ACL",
+			policy: servicePolicy,
+			method: &codec.QueueDeclare{Queue: testOtherTarget},
+		},
+		{
+			name:        "service acknowledges a delivery",
+			policy:      servicePolicy,
+			method:      &codec.BasicAck{},
+			wantAllowed: true,
+		},
+		{
+			name:   "publish-only principal may not consume",
+			policy: publishOnlyPolicy,
+			method: &codec.BasicConsume{Queue: allowedQueue},
+		},
+		{
+			name:   "publish-only principal may not declare a queue",
+			policy: publishOnlyPolicy,
+			method: &codec.QueueDeclare{Queue: allowedQueue},
+		},
+		{
+			name:   "publish-only principal may not acknowledge",
+			policy: publishOnlyPolicy,
+			method: &codec.BasicAck{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			authz := &localAuthorizerStub{allowQueue: allowedQueue}
+			ch, _ := newTestChannelWithPolicy(t, tc.policy(authz))
+			ch.conn.localIdentity = &LocalSessionIdentity{PrincipalID: "rules-engine"}
+
+			allowed, err := ch.authorizeLocalMethod(tc.method)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantAllowed, allowed)
+		})
+	}
+}
+
+// A service listener is trusted, so it exchanges reserved properties, and it
+// relays origin identity because the messages it republishes are not its own.
+func TestLocalServicePolicyTrust(t *testing.T) {
+	policy := NewLocalServiceConnectionPolicy(nil, nil, nil, 0)
+
+	assert.True(t, policy.carriesReservedProperties())
+	assert.True(t, policy.usesLocalPrincipalAuth())
+	assert.True(t, policy.permitsConsumers())
+	assert.True(t, policy.propagatesOriginIdentity(),
+		"a service relays messages it did not originate, so it may state their true origin")
+}
+
+// The publish-only listener stays exactly as it was: trusted for reserved
+// properties, but never a consumer and never able to relay an origin.
+func TestLocalPublishOnlyPolicyUnchanged(t *testing.T) {
+	policy := NewLocalPublishOnlyConnectionPolicy(nil, nil, nil, 0)
+
+	assert.True(t, policy.carriesReservedProperties())
+	assert.True(t, policy.usesLocalPrincipalAuth())
+	assert.False(t, policy.permitsConsumers())
+	assert.False(t, policy.propagatesOriginIdentity(),
+		"an audit publisher must not attribute its records to another origin")
 }

--- a/amqp/broker/channel_test.go
+++ b/amqp/broker/channel_test.go
@@ -18,9 +18,16 @@ import (
 	qstorage "github.com/absmach/fluxmq/queue/storage"
 	qtypes "github.com/absmach/fluxmq/queue/types"
 	"github.com/absmach/fluxmq/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-const eventsExchange = "events"
+const (
+	eventsExchange   = "events"
+	testRuleTrace    = `["rule-a"]`
+	testCustomHeader = "x-custom"
+	testHeaderValue  = "value"
+)
 
 type mockChannelQueueManager struct {
 	lastCursor        *qtypes.CursorOption
@@ -112,7 +119,18 @@ func (n *normalizingHookProvider) HandleHook(_ context.Context, req corebroker.B
 	}
 }
 
+// newTestChannel builds a channel with no listener policy, which
+// Connection.connectionPolicy resolves to the untrusted external mode.
 func newTestChannel(t *testing.T) (*Channel, *bytes.Buffer) {
+	t.Helper()
+	return newTestChannelWithPolicy(t, nil)
+}
+
+// newTestChannelWithPolicy builds a channel served under policy. Trust is set
+// on the policy directly rather than through a constructor so the reserved
+// property boundary can be exercised independently of the local-principal
+// authentication and publish-only machinery.
+func newTestChannelWithPolicy(t *testing.T, policy *ConnectionPolicy) (*Channel, *bytes.Buffer) {
 	t.Helper()
 
 	buf := &bytes.Buffer{}
@@ -120,6 +138,7 @@ func newTestChannel(t *testing.T) (*Channel, *bytes.Buffer) {
 	b := New(nil, logger)
 	c := &Connection{
 		broker:   b,
+		policy:   policy,
 		writer:   bufio.NewWriter(buf),
 		frameMax: defaultFrameMax,
 		logger:   logger,
@@ -128,6 +147,12 @@ func newTestChannel(t *testing.T) (*Channel, *bytes.Buffer) {
 	}
 	ch := newChannel(c, 1)
 	return ch, buf
+}
+
+// trustedTestPolicy marks a connection as service-to-service without making it
+// publish-only, matching the decoupling of trust from operation mode.
+func trustedTestPolicy() *ConnectionPolicy {
+	return &ConnectionPolicy{mode: ConnectionPolicyExternal, trusted: true}
 }
 
 func readFramesFrom(t *testing.T, buf *bytes.Buffer, start int) []*codec.Frame {
@@ -836,62 +861,253 @@ func TestQueueRedeclareProtectedQueueClosesChannel(t *testing.T) {
 	}
 }
 
-func TestPublishCustomHeadersPropagatedToCrossDeliver(t *testing.T) {
-	ch, _ := newTestChannel(t)
+// A trusted service relaying a message may state the identity and protocol it
+// came from. Anyone else is stamped with their own authenticated identity, so a
+// publisher cannot attribute a message to another principal or protocol. See
+// TestPublishReservedHeadersIngressTrustBoundary for the reserved-prefix
+// headers under the same boundary.
+func TestPublishOriginHeadersTrustBoundary(t *testing.T) {
+	const (
+		relayedID = "pub-123"
+		authedID  = "amqp-tenant-7"
+	)
 
-	if err := ch.conn.broker.router.Subscribe("mqtt-client", testTelemetryRoom1, 1, storage.SubscribeOptions{}); err != nil {
-		t.Fatalf("subscribe failed: %v", err)
-	}
-
-	var gotProps map[string]string
-	ch.conn.broker.SetCrossDeliver(func(_ context.Context, _ string, _ string, _ []byte, _ byte, props map[string]string) {
-		gotProps = props
-	})
-
-	if err := ch.handleMethod(&codec.BasicPublish{
-		Exchange:   "",
-		RoutingKey: testTelemetryRoom1AM,
-	}); err != nil {
-		t.Fatalf("handleMethod failed: %v", err)
-	}
-
-	payload := []byte("hello")
-	header := &codec.ContentHeader{
-		ClassID:  codec.ClassBasic,
-		Weight:   0,
-		BodySize: uint64(len(payload)),
-		Properties: codec.BasicProperties{
-			Headers: map[string]any{
-				corebroker.ExternalIDProperty: "pub-123",
-				corebroker.ProtocolProperty:   "http",
-			},
+	tests := []struct {
+		name         string
+		policy       *ConnectionPolicy
+		wantID       string
+		wantProtocol string
+	}{
+		{
+			name:         "trusted policy relays origin identity and protocol",
+			policy:       trustedTestPolicy(),
+			wantID:       relayedID,
+			wantProtocol: corebroker.ProtocolHTTP,
+		},
+		{
+			name:         "external policy stamps authenticated identity",
+			policy:       NewExternalConnectionPolicy(nil, nil, 0),
+			wantID:       authedID,
+			wantProtocol: corebroker.ProtocolAMQP091,
+		},
+		{
+			name:         "absent policy stamps authenticated identity",
+			policy:       nil,
+			wantID:       authedID,
+			wantProtocol: corebroker.ProtocolAMQP091,
 		},
 	}
-	var headerBuf bytes.Buffer
-	if err := header.WriteContentHeader(&headerBuf); err != nil {
-		t.Fatalf("WriteContentHeader failed: %v", err)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ch, _ := newTestChannelWithPolicy(t, tc.policy)
+			clientID := PrefixedClientID(ch.conn.connID)
+
+			// Both identity sources are populated so the assertion shows which one
+			// the publish path chose rather than which one happened to be set.
+			engine := corebroker.NewAuthEngine(nil, nil)
+			engine.SetExternalID(clientID, authedID)
+			ch.conn.broker.SetAuthEngine(engine)
+			if tc.policy != nil {
+				tc.policy.externalAuth = engine
+			}
+
+			require.NoError(t, ch.conn.broker.router.Subscribe("mqtt-client", testTelemetryRoom1, 1, storage.SubscribeOptions{}))
+
+			var gotProps map[string]string
+			ch.conn.broker.SetCrossDeliver(func(_ context.Context, _ string, _ string, _ []byte, _ byte, props map[string]string) {
+				gotProps = props
+			})
+			require.NoError(t, ch.handleMethod(&codec.BasicPublish{Exchange: "", RoutingKey: testTelemetryRoom1AM}))
+
+			payload := []byte("hello")
+			header := &codec.ContentHeader{
+				ClassID:  codec.ClassBasic,
+				Weight:   0,
+				BodySize: uint64(len(payload)),
+				Properties: codec.BasicProperties{
+					Headers: map[string]any{
+						corebroker.ExternalIDProperty: relayedID,
+						corebroker.ProtocolProperty:   corebroker.ProtocolHTTP,
+					},
+				},
+			}
+			var headerBuf bytes.Buffer
+			require.NoError(t, header.WriteContentHeader(&headerBuf))
+
+			ch.handleHeaderFrame(&codec.Frame{Type: codec.FrameHeader, Channel: 1, Payload: headerBuf.Bytes()})
+			ch.handleBodyFrame(&codec.Frame{Type: codec.FrameBody, Channel: 1, Payload: payload})
+
+			require.NotNil(t, gotProps, "expected cross-deliver call")
+			assert.Equal(t, tc.wantID, gotProps[corebroker.ExternalIDProperty])
+			assert.Equal(t, tc.wantProtocol, gotProps[corebroker.ProtocolProperty])
+		})
+	}
+}
+
+// A trusted listener carries reserved properties inward so a service can pass
+// internal state to whichever service consumes the message next. An externally
+// authenticated publisher is a tenant or device whatever protocol it speaks, so
+// its reserved headers are dropped and cannot be forged. Everything else a
+// client sets stays out of the property bag either way.
+func TestPublishReservedHeadersIngressTrustBoundary(t *testing.T) {
+	reserved := corebroker.ReservedPropertyPrefix + "re.trace"
+
+	tests := []struct {
+		name    string
+		policy  *ConnectionPolicy
+		headers map[string]any
+		want    map[string]string
+		absent  []string
+	}{
+		{
+			name:    "trusted policy carries reserved header",
+			policy:  trustedTestPolicy(),
+			headers: map[string]any{reserved: testRuleTrace},
+			want:    map[string]string{reserved: testRuleTrace},
+		},
+		{
+			name:    "trusted policy drops unreserved header",
+			policy:  trustedTestPolicy(),
+			headers: map[string]any{testCustomHeader: testHeaderValue},
+			absent:  []string{testCustomHeader},
+		},
+		{
+			name:    "trusted policy drops non-string reserved header",
+			policy:  trustedTestPolicy(),
+			headers: map[string]any{reserved: int64(1)},
+			absent:  []string{reserved},
+		},
+		{
+			name:    "trusted policy carries reserved alongside dropped custom header",
+			policy:  trustedTestPolicy(),
+			headers: map[string]any{reserved: testRuleTrace, testCustomHeader: testHeaderValue},
+			want:    map[string]string{reserved: testRuleTrace},
+			absent:  []string{testCustomHeader},
+		},
+		{
+			name:    "external policy drops forged reserved header",
+			policy:  NewExternalConnectionPolicy(nil, nil, 0),
+			headers: map[string]any{reserved: testRuleTrace},
+			absent:  []string{reserved},
+		},
+		{
+			name:    "external policy drops forged reserved header alongside custom header",
+			policy:  NewExternalConnectionPolicy(nil, nil, 0),
+			headers: map[string]any{reserved: testRuleTrace, testCustomHeader: testHeaderValue},
+			absent:  []string{reserved, testCustomHeader},
+		},
+		{
+			name:    "absent policy drops forged reserved header",
+			policy:  nil,
+			headers: map[string]any{reserved: testRuleTrace},
+			absent:  []string{reserved},
+		},
 	}
 
-	ch.handleHeaderFrame(&codec.Frame{
-		Type:    codec.FrameHeader,
-		Channel: 1,
-		Payload: headerBuf.Bytes(),
-	})
-	ch.handleBodyFrame(&codec.Frame{
-		Type:    codec.FrameBody,
-		Channel: 1,
-		Payload: payload,
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ch, _ := newTestChannelWithPolicy(t, tc.policy)
+			require.NoError(t, ch.conn.broker.router.Subscribe("mqtt-client", testTelemetryRoom1, 1, storage.SubscribeOptions{}))
 
-	if gotProps == nil {
-		t.Fatal("expected cross-deliver call, got none")
+			var gotProps map[string]string
+			ch.conn.broker.SetCrossDeliver(func(_ context.Context, _ string, _ string, _ []byte, _ byte, props map[string]string) {
+				gotProps = props
+			})
+			require.NoError(t, ch.handleMethod(&codec.BasicPublish{Exchange: "", RoutingKey: testTelemetryRoom1AM}))
+
+			payload := []byte("hello")
+			header := &codec.ContentHeader{
+				ClassID:    codec.ClassBasic,
+				Weight:     0,
+				BodySize:   uint64(len(payload)),
+				Properties: codec.BasicProperties{Headers: tc.headers},
+			}
+			var headerBuf bytes.Buffer
+			require.NoError(t, header.WriteContentHeader(&headerBuf))
+
+			ch.handleHeaderFrame(&codec.Frame{Type: codec.FrameHeader, Channel: 1, Payload: headerBuf.Bytes()})
+			ch.handleBodyFrame(&codec.Frame{Type: codec.FrameBody, Channel: 1, Payload: payload})
+
+			require.NotNil(t, gotProps, "expected cross-deliver call")
+			for key, value := range tc.want {
+				assert.Equal(t, value, gotProps[key])
+			}
+			for _, key := range tc.absent {
+				assert.NotContains(t, gotProps, key)
+			}
+		})
 	}
-	if gotProps[corebroker.ExternalIDProperty] != "pub-123" {
-		t.Fatalf("expected external_id=%q, got %q", "pub-123", gotProps[corebroker.ExternalIDProperty])
+}
+
+// Egress mirrors ingress: an externally authenticated consumer must not observe
+// broker-internal state another service set, while ordinary properties are
+// delivered as headers to everyone.
+func TestDeliveryReservedHeadersEgressTrustBoundary(t *testing.T) {
+	reserved := corebroker.ReservedPropertyPrefix + "re.trace"
+
+	tests := []struct {
+		name   string
+		policy *ConnectionPolicy
+		want   map[string]any
+		absent []string
+	}{
+		{
+			name:   "trusted policy reveals reserved property",
+			policy: trustedTestPolicy(),
+			want:   map[string]any{reserved: testRuleTrace, testCustomHeader: testHeaderValue},
+		},
+		{
+			name:   "external policy hides reserved property",
+			policy: NewExternalConnectionPolicy(nil, nil, 0),
+			want:   map[string]any{testCustomHeader: testHeaderValue},
+			absent: []string{reserved},
+		},
+		{
+			name:   "absent policy hides reserved property",
+			policy: nil,
+			want:   map[string]any{testCustomHeader: testHeaderValue},
+			absent: []string{reserved},
+		},
 	}
-	if gotProps[corebroker.ProtocolProperty] != "http" {
-		t.Fatalf("expected protocol=%q, got %q", "http", gotProps[corebroker.ProtocolProperty])
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ch, buf := newTestChannelWithPolicy(t, tc.policy)
+			cons := &consumer{tag: testCtag1, noAck: true}
+
+			props := map[string]string{
+				reserved:         testRuleTrace,
+				testCustomHeader: testHeaderValue,
+			}
+			require.NoError(t, ch.sendDelivery(cons, testTelemetryRoom1, []byte("hello"), props))
+			require.NoError(t, ch.conn.writer.Flush())
+
+			headers := deliveryHeadersFrom(t, buf)
+			for key, value := range tc.want {
+				assert.Equal(t, value, headers[key])
+			}
+			for _, key := range tc.absent {
+				assert.NotContains(t, headers, key)
+			}
+		})
 	}
+}
+
+// deliveryHeadersFrom decodes the content header frame of a single BasicDeliver
+// written to buf and returns its application headers.
+func deliveryHeadersFrom(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+
+	frames := readFramesFrom(t, buf, 0)
+	require.GreaterOrEqual(t, len(frames), 2, "expected method and header frames")
+	require.Equal(t, codec.FrameHeader, frames[1].Type)
+
+	decoded, err := frames[1].Decode()
+	require.NoError(t, err)
+	header, ok := decoded.(*codec.ContentHeader)
+	require.True(t, ok, "expected content header, got %T", decoded)
+	return header.Properties.Headers
 }
 
 func TestCancelConsumerByQueue(t *testing.T) {

--- a/amqp/broker/channel_test.go
+++ b/amqp/broker/channel_test.go
@@ -1059,15 +1059,12 @@ func TestDeliveryReservedHeadersEgressTrustBoundary(t *testing.T) {
 			want:   map[string]any{reserved: testRuleTrace, testCustomHeader: testHeaderValue},
 		},
 		{
-			name: "service policy reveals reserved property to a first-party consumer",
 			// The reason the boundary has an inward direction at all: without a
-			// consumer that may read them, reserved properties would be write-only.
-			policy: NewLocalServiceConnectionPolicy(nil, nil, nil, 0),
-			want:   map[string]any{reserved: testRuleTrace, testCustomHeader: testHeaderValue},
-		},
-		{
-			name:   "publish-only policy still reveals nothing it cannot consume",
-			policy: NewLocalPublishOnlyConnectionPolicy(nil, nil, nil, 0),
+			// first-party consumer that may read them, reserved properties would
+			// be write-only. Trust is the listener's, so both roles see them; the
+			// role decides only whether a consumer can be run in the first place.
+			name:   "local policy reveals reserved property to a first-party consumer",
+			policy: NewLocalConnectionPolicy(nil, nil, nil, 0),
 			want:   map[string]any{reserved: testRuleTrace, testCustomHeader: testHeaderValue},
 		},
 		{
@@ -1220,89 +1217,82 @@ func TestCancelConsumerByQueue(t *testing.T) {
 	})
 }
 
-// The consumer lifecycle is admitted only on a listener that permits consumers,
-// and only for a queue the principal's own subscribe ACL names. A publish-only
-// principal keeps its existing, narrower method set.
+// The consumer lifecycle is admitted only to a principal whose role permits
+// consumers, and only for a queue its own subscribe ACL names. Both roles run on
+// the same listener policy, so the capability comes from the principal alone.
 func TestAuthorizeLocalMethodConsumerLifecycle(t *testing.T) {
 	const allowedQueue = "m"
 
-	servicePolicy := func(authz LocalPrincipalAuthorizer) *ConnectionPolicy {
-		return NewLocalServiceConnectionPolicy(nil, authz, nil, 0)
-	}
-	publishOnlyPolicy := func(authz LocalPrincipalAuthorizer) *ConnectionPolicy {
-		return NewLocalPublishOnlyConnectionPolicy(nil, authz, nil, 0)
-	}
-
 	tests := []struct {
 		name        string
-		policy      func(LocalPrincipalAuthorizer) *ConnectionPolicy
+		role        LocalPrincipalRole
 		method      any
 		wantAllowed bool
 	}{
 		{
 			name:        "service consumes a permitted queue",
-			policy:      servicePolicy,
+			role:        LocalRoleService,
 			method:      &codec.BasicConsume{Queue: allowedQueue},
 			wantAllowed: true,
 		},
 		{
 			name:   "service is refused a queue outside its ACL",
-			policy: servicePolicy,
+			role:   LocalRoleService,
 			method: &codec.BasicConsume{Queue: testOtherTarget},
 		},
 		{
 			name:        "service gets from a permitted queue",
-			policy:      servicePolicy,
+			role:        LocalRoleService,
 			method:      &codec.BasicGet{Queue: allowedQueue},
 			wantAllowed: true,
 		},
 		{
 			name:   "service is refused getting from a queue outside its ACL",
-			policy: servicePolicy,
+			role:   LocalRoleService,
 			method: &codec.BasicGet{Queue: testOtherTarget},
 		},
 		{
 			name:        "service passively declares a permitted queue",
-			policy:      servicePolicy,
+			role:        LocalRoleService,
 			method:      &codec.QueueDeclare{Queue: allowedQueue, Passive: true},
 			wantAllowed: true,
 		},
 		{
 			name:   "service is refused passively declaring a queue outside its ACL",
-			policy: servicePolicy,
+			role:   LocalRoleService,
 			method: &codec.QueueDeclare{Queue: testOtherTarget, Passive: true},
 		},
 		{
 			// A non-passive declare rewrites queue configuration, which the
 			// subscribe ACL does not grant even for a queue it names.
 			name:   "service is refused declaring a permitted queue non-passively",
-			policy: servicePolicy,
+			role:   LocalRoleService,
 			method: &codec.QueueDeclare{Queue: allowedQueue},
 		},
 		{
 			name:        "service acknowledges a delivery",
-			policy:      servicePolicy,
+			role:        LocalRoleService,
 			method:      &codec.BasicAck{},
 			wantAllowed: true,
 		},
 		{
 			name:   "publish-only principal may not consume",
-			policy: publishOnlyPolicy,
+			role:   LocalRolePublisher,
 			method: &codec.BasicConsume{Queue: allowedQueue},
 		},
 		{
 			name:   "publish-only principal may not declare a queue",
-			policy: publishOnlyPolicy,
+			role:   LocalRolePublisher,
 			method: &codec.QueueDeclare{Queue: allowedQueue, Passive: true},
 		},
 		{
 			name:   "publish-only principal may not get",
-			policy: publishOnlyPolicy,
+			role:   LocalRolePublisher,
 			method: &codec.BasicGet{Queue: allowedQueue},
 		},
 		{
 			name:   "publish-only principal may not acknowledge",
-			policy: publishOnlyPolicy,
+			role:   LocalRolePublisher,
 			method: &codec.BasicAck{},
 		},
 	}
@@ -1310,8 +1300,8 @@ func TestAuthorizeLocalMethodConsumerLifecycle(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			authz := &localAuthorizerStub{allowQueue: allowedQueue}
-			ch, _ := newTestChannelWithPolicy(t, tc.policy(authz))
-			ch.conn.localIdentity = &LocalSessionIdentity{PrincipalID: "rules-engine"}
+			ch, _ := newTestChannelWithPolicy(t, NewLocalConnectionPolicy(nil, authz, nil, 0))
+			ch.conn.localIdentity = &LocalSessionIdentity{PrincipalID: "rules-engine", Role: tc.role}
 
 			allowed, err := ch.authorizeLocalMethod(tc.method)
 			require.NoError(t, err)
@@ -1320,26 +1310,69 @@ func TestAuthorizeLocalMethodConsumerLifecycle(t *testing.T) {
 	}
 }
 
-// A service listener is trusted, so it exchanges reserved properties, and it
-// relays origin identity because the messages it republishes are not its own.
-func TestLocalServicePolicyTrust(t *testing.T) {
-	policy := NewLocalServiceConnectionPolicy(nil, nil, nil, 0)
-
+// Capability is carried by the authenticated principal, so the same connection
+// policy yields different answers per role. The listener contributes only trust
+// and the choice of credential store.
+func TestLocalRoleCapabilities(t *testing.T) {
+	policy := NewLocalConnectionPolicy(nil, nil, nil, 0)
 	assert.True(t, policy.carriesReservedProperties())
 	assert.True(t, policy.usesLocalPrincipalAuth())
-	assert.True(t, policy.permitsConsumers())
-	assert.True(t, policy.propagatesOriginIdentity(),
-		"a service relays messages it did not originate, so it may state their true origin")
+
+	tests := []struct {
+		name                string
+		role                LocalPrincipalRole
+		wantConsumers       bool
+		wantPropagateOrigin bool
+	}{
+		{
+			name:                "service consumes and relays origin",
+			role:                LocalRoleService,
+			wantConsumers:       true,
+			wantPropagateOrigin: true,
+		},
+		{
+			name: "publisher does neither",
+			role: LocalRolePublisher,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ch, _ := newTestChannelWithPolicy(t, policy)
+			ch.conn.localIdentity = &LocalSessionIdentity{PrincipalID: testLocalPrincipal, Role: tc.role}
+
+			assert.Equal(t, tc.wantConsumers, ch.conn.permitsConsumers())
+			assert.Equal(t, tc.wantPropagateOrigin, ch.conn.propagatesOriginIdentity(),
+				"an audit publisher must not attribute its records to another origin")
+		})
+	}
 }
 
-// The publish-only listener stays exactly as it was: trusted for reserved
-// properties, but never a consumer and never able to relay an origin.
-func TestLocalPublishOnlyPolicyUnchanged(t *testing.T) {
-	policy := NewLocalPublishOnlyConnectionPolicy(nil, nil, nil, 0)
+// Nothing binds a principal to a listener, so a capability the listener granted
+// would be granted to every principal able to reach that port. A publisher must
+// therefore stay a publisher on whichever local listener it authenticates to.
+func TestLocalCapabilityIsIndependentOfListener(t *testing.T) {
+	listeners := map[string]*ConnectionPolicy{
+		"first local listener":  NewLocalConnectionPolicy(nil, nil, nil, 0),
+		"second local listener": NewLocalConnectionPolicy(nil, nil, nil, 0),
+	}
 
-	assert.True(t, policy.carriesReservedProperties())
-	assert.True(t, policy.usesLocalPrincipalAuth())
-	assert.False(t, policy.permitsConsumers())
-	assert.False(t, policy.propagatesOriginIdentity(),
-		"an audit publisher must not attribute its records to another origin")
+	for name, policy := range listeners {
+		t.Run(name, func(t *testing.T) {
+			ch, _ := newTestChannelWithPolicy(t, policy)
+			ch.conn.localIdentity = &LocalSessionIdentity{PrincipalID: testLocalPrincipal, Role: LocalRolePublisher}
+
+			assert.False(t, ch.conn.permitsConsumers())
+			assert.False(t, ch.conn.propagatesOriginIdentity())
+		})
+	}
+}
+
+// An unauthenticated connection has no role, and the zero value is the least
+// privileged one, so a capability cannot be reached before authentication.
+func TestLocalCapabilityDeniedWithoutIdentity(t *testing.T) {
+	ch, _ := newTestChannelWithPolicy(t, NewLocalConnectionPolicy(nil, nil, nil, 0))
+
+	assert.False(t, ch.conn.permitsConsumers())
+	assert.False(t, ch.conn.propagatesOriginIdentity())
 }

--- a/amqp/broker/channel_test.go
+++ b/amqp/broker/channel_test.go
@@ -844,7 +844,7 @@ func TestQueueDeclareStreamWithTTL(t *testing.T) {
 
 func TestQueueRedeclareProtectedQueueClosesChannel(t *testing.T) {
 	ch, buf := newTestChannel(t)
-	existing := qtypes.DefaultQueueConfig("atom-audit", "$queue/atom-audit/#")
+	existing := qtypes.DefaultQueueConfig("atom.events", "$queue/atom.events/#")
 	existing.Type = qtypes.QueueTypeStream
 	existing.Reserved = true
 	mockQM := &mockChannelQueueManager{

--- a/amqp/broker/channel_test.go
+++ b/amqp/broker/channel_test.go
@@ -1191,6 +1191,46 @@ func TestCancelConsumerByQueue(t *testing.T) {
 		}
 	})
 
+	// A pattern qualifies the group the manager registers, so stale cleanup
+	// reports "group@pattern". Matching the raw group would leave a patterned
+	// consumer uncancelled, still holding its registration and refcount.
+	t.Run("cancels a pattern-scoped consumer by its effective group", func(t *testing.T) {
+		ch, buf := newTestChannel(t)
+
+		ch.consumers[testCtag1] = &consumer{
+			tag:       testCtag1,
+			queueName: testEvents,
+			groupID:   testWorkers,
+			pattern:   "images",
+		}
+		// Same queue and group, no pattern: a distinct registration that the
+		// manager reports under the bare group and must not be swept up here.
+		ch.consumers["ctag-2"] = &consumer{
+			tag:       "ctag-2",
+			queueName: testEvents,
+			groupID:   testWorkers,
+		}
+
+		beforeLen := buf.Len()
+		ch.cancelConsumerByQueue(testEvents, testWorkers+"@images")
+
+		ch.consumersMu.RLock()
+		_, patterned := ch.consumers[testCtag1]
+		_, unpatterned := ch.consumers["ctag-2"]
+		ch.consumersMu.RUnlock()
+
+		assert.False(t, patterned, "the pattern-scoped consumer must be cancelled")
+		assert.True(t, unpatterned, "the unpatterned consumer is a different group")
+
+		frames := readFramesFrom(t, buf, beforeLen)
+		require.Len(t, frames, 1, "expected one basic.cancel")
+		decoded, err := frames[0].Decode()
+		require.NoError(t, err)
+		cancel, ok := decoded.(*codec.BasicCancel)
+		require.True(t, ok, "expected *codec.BasicCancel, got %T", decoded)
+		assert.Equal(t, testCtag1, cancel.ConsumerTag)
+	})
+
 	t.Run("no-op when no consumers match", func(t *testing.T) {
 		ch, buf := newTestChannel(t)
 

--- a/amqp/broker/channel_test.go
+++ b/amqp/broker/channel_test.go
@@ -1221,7 +1221,12 @@ func TestCancelConsumerByQueue(t *testing.T) {
 // consumers, and only for a queue its own subscribe ACL names. Both roles run on
 // the same listener policy, so the capability comes from the principal alone.
 func TestAuthorizeLocalMethodConsumerLifecycle(t *testing.T) {
-	const allowedQueue = "m"
+	// The ACL names a queue; a client addresses it through the queue prefix, and
+	// authorization resolves the wire value before comparing.
+	const (
+		allowedQueue   = "m"
+		allowedAddress = "$queue/m"
+	)
 
 	tests := []struct {
 		name        string
@@ -1232,42 +1237,45 @@ func TestAuthorizeLocalMethodConsumerLifecycle(t *testing.T) {
 		{
 			name:        "service consumes a permitted queue",
 			role:        LocalRoleService,
-			method:      &codec.BasicConsume{Queue: allowedQueue},
+			method:      &codec.BasicConsume{Queue: allowedAddress},
 			wantAllowed: true,
 		},
 		{
 			name:   "service is refused a queue outside its ACL",
 			role:   LocalRoleService,
-			method: &codec.BasicConsume{Queue: testOtherTarget},
+			method: &codec.BasicConsume{Queue: "$queue/" + testOtherTarget},
 		},
 		{
-			name:        "service gets from a permitted queue",
-			role:        LocalRoleService,
-			method:      &codec.BasicGet{Queue: allowedQueue},
-			wantAllowed: true,
-		},
-		{
-			name:   "service is refused getting from a queue outside its ACL",
+			// basic.get is not implemented and always answers empty, so it is
+			// refused rather than advertised as an authorized read.
+			name:   "service is refused basic.get while it is unimplemented",
 			role:   LocalRoleService,
-			method: &codec.BasicGet{Queue: testOtherTarget},
+			method: &codec.BasicGet{Queue: allowedAddress},
+		},
+		{
+			// The ACL grants queues, so a filter that resolves to no queue has
+			// nothing that could authorize it.
+			name:   "service is refused a bare name that is not a queue address",
+			role:   LocalRoleService,
+			method: &codec.BasicConsume{Queue: allowedQueue},
 		},
 		{
 			name:        "service passively declares a permitted queue",
 			role:        LocalRoleService,
-			method:      &codec.QueueDeclare{Queue: allowedQueue, Passive: true},
+			method:      &codec.QueueDeclare{Queue: allowedAddress, Passive: true},
 			wantAllowed: true,
 		},
 		{
 			name:   "service is refused passively declaring a queue outside its ACL",
 			role:   LocalRoleService,
-			method: &codec.QueueDeclare{Queue: testOtherTarget, Passive: true},
+			method: &codec.QueueDeclare{Queue: "$queue/" + testOtherTarget, Passive: true},
 		},
 		{
 			// A non-passive declare rewrites queue configuration, which the
 			// subscribe ACL does not grant even for a queue it names.
 			name:   "service is refused declaring a permitted queue non-passively",
 			role:   LocalRoleService,
-			method: &codec.QueueDeclare{Queue: allowedQueue},
+			method: &codec.QueueDeclare{Queue: allowedAddress},
 		},
 		{
 			name:        "service acknowledges a delivery",
@@ -1278,17 +1286,17 @@ func TestAuthorizeLocalMethodConsumerLifecycle(t *testing.T) {
 		{
 			name:   "publish-only principal may not consume",
 			role:   LocalRolePublisher,
-			method: &codec.BasicConsume{Queue: allowedQueue},
+			method: &codec.BasicConsume{Queue: allowedAddress},
 		},
 		{
 			name:   "publish-only principal may not declare a queue",
 			role:   LocalRolePublisher,
-			method: &codec.QueueDeclare{Queue: allowedQueue, Passive: true},
+			method: &codec.QueueDeclare{Queue: allowedAddress, Passive: true},
 		},
 		{
 			name:   "publish-only principal may not get",
 			role:   LocalRolePublisher,
-			method: &codec.BasicGet{Queue: allowedQueue},
+			method: &codec.BasicGet{Queue: allowedAddress},
 		},
 		{
 			name:   "publish-only principal may not acknowledge",

--- a/amqp/broker/channel_test.go
+++ b/amqp/broker/channel_test.go
@@ -47,6 +47,7 @@ type mockChannelQueueManager struct {
 	existingSubErr       error
 	existingSubs         int
 	existingCursorSubs   int
+	unsubscribes         []string
 	createdQueues        []qtypes.QueueConfig
 	updatedQueues        []qtypes.QueueConfig
 	createQueueErr       error
@@ -92,7 +93,8 @@ func (m *mockChannelQueueManager) SubscribeExistingWithCursor(_ context.Context,
 	return m.existingSubErr
 }
 
-func (m *mockChannelQueueManager) Unsubscribe(context.Context, string, string, string, string) error {
+func (m *mockChannelQueueManager) Unsubscribe(_ context.Context, queueName, _, _, groupID string) error {
+	m.unsubscribes = append(m.unsubscribes, queueName+"/"+groupID)
 	return nil
 }
 

--- a/amqp/broker/channel_test.go
+++ b/amqp/broker/channel_test.go
@@ -31,19 +31,26 @@ const (
 )
 
 type mockChannelQueueManager struct {
-	lastCursor        *qtypes.CursorOption
-	lastPublish       qtypes.PublishRequest
-	publishCalls      int
-	exactStreamName   string
-	exactPublish      qtypes.PublishRequest
-	exactPublishCalls int
-	exactPublishErr   error
-	exactPublishCtx   context.Context
-	queueCfg          *qtypes.QueueConfig
-	createdQueues     []qtypes.QueueConfig
-	updatedQueues     []qtypes.QueueConfig
-	createQueueErr    error
-	updateQueueErr    error
+	lastCursor           *qtypes.CursorOption
+	lastPublish          qtypes.PublishRequest
+	publishCalls         int
+	exactStreamName      string
+	exactPublish         qtypes.PublishRequest
+	exactPublishCalls    int
+	exactPublishErr      error
+	exactPublishCtx      context.Context
+	queueCfg             *qtypes.QueueConfig
+	getQueueErr          error
+	subscribeErr         error
+	subscribeCalls       int
+	cursorSubscribeCalls int
+	existingSubErr       error
+	existingSubs         int
+	existingCursorSubs   int
+	createdQueues        []qtypes.QueueConfig
+	updatedQueues        []qtypes.QueueConfig
+	createQueueErr       error
+	updateQueueErr       error
 }
 
 func (m *mockChannelQueueManager) Publish(_ context.Context, publish qtypes.PublishRequest) error {
@@ -64,12 +71,25 @@ func (m *mockChannelQueueManager) PublishToDurableStream(ctx context.Context, qu
 }
 
 func (m *mockChannelQueueManager) Subscribe(context.Context, string, string, string, string, string) error {
-	return nil
+	m.subscribeCalls++
+	return m.subscribeErr
 }
 
 func (m *mockChannelQueueManager) SubscribeWithCursor(_ context.Context, _ string, _ string, _ string, _ string, _ string, cursor *qtypes.CursorOption) error {
+	m.cursorSubscribeCalls++
 	m.lastCursor = cursor
-	return nil
+	return m.subscribeErr
+}
+
+func (m *mockChannelQueueManager) SubscribeExisting(context.Context, string, string, string, string, string) error {
+	m.existingSubs++
+	return m.existingSubErr
+}
+
+func (m *mockChannelQueueManager) SubscribeExistingWithCursor(_ context.Context, _ string, _ string, _ string, _ string, _ string, cursor *qtypes.CursorOption) error {
+	m.existingCursorSubs++
+	m.lastCursor = cursor
+	return m.existingSubErr
 }
 
 func (m *mockChannelQueueManager) Unsubscribe(context.Context, string, string, string, string) error {
@@ -94,7 +114,7 @@ func (m *mockChannelQueueManager) CreateQueue(_ context.Context, cfg qtypes.Queu
 }
 
 func (m *mockChannelQueueManager) GetQueue(context.Context, string) (*qtypes.QueueConfig, error) {
-	return m.queueCfg, nil
+	return m.queueCfg, m.getQueueErr
 }
 
 func (m *mockChannelQueueManager) UpdateQueue(_ context.Context, cfg qtypes.QueueConfig) error {
@@ -1221,8 +1241,9 @@ func TestCancelConsumerByQueue(t *testing.T) {
 // consumers, and only for a queue its own subscribe ACL names. Both roles run on
 // the same listener policy, so the capability comes from the principal alone.
 func TestAuthorizeLocalMethodConsumerLifecycle(t *testing.T) {
-	// The ACL names a queue; a client addresses it through the queue prefix, and
-	// authorization resolves the wire value before comparing.
+	// The ACL names a queue. Basic.Consume addresses it through the queue prefix
+	// and is resolved before comparison; passive Queue.Declare uses the bare AMQP
+	// queue name.
 	const (
 		allowedQueue   = "m"
 		allowedAddress = "$queue/m"
@@ -1262,20 +1283,20 @@ func TestAuthorizeLocalMethodConsumerLifecycle(t *testing.T) {
 		{
 			name:        "service passively declares a permitted queue",
 			role:        LocalRoleService,
-			method:      &codec.QueueDeclare{Queue: allowedAddress, Passive: true},
+			method:      &codec.QueueDeclare{Queue: allowedQueue, Passive: true},
 			wantAllowed: true,
 		},
 		{
 			name:   "service is refused passively declaring a queue outside its ACL",
 			role:   LocalRoleService,
-			method: &codec.QueueDeclare{Queue: "$queue/" + testOtherTarget, Passive: true},
+			method: &codec.QueueDeclare{Queue: testOtherTarget, Passive: true},
 		},
 		{
 			// A non-passive declare rewrites queue configuration, which the
 			// subscribe ACL does not grant even for a queue it names.
 			name:   "service is refused declaring a permitted queue non-passively",
 			role:   LocalRoleService,
-			method: &codec.QueueDeclare{Queue: allowedAddress},
+			method: &codec.QueueDeclare{Queue: allowedQueue},
 		},
 		{
 			name:        "service acknowledges a delivery",
@@ -1291,7 +1312,7 @@ func TestAuthorizeLocalMethodConsumerLifecycle(t *testing.T) {
 		{
 			name:   "publish-only principal may not declare a queue",
 			role:   LocalRolePublisher,
-			method: &codec.QueueDeclare{Queue: allowedAddress, Passive: true},
+			method: &codec.QueueDeclare{Queue: allowedQueue, Passive: true},
 		},
 		{
 			name:   "publish-only principal may not get",

--- a/amqp/broker/channel_test.go
+++ b/amqp/broker/channel_test.go
@@ -1251,15 +1251,33 @@ func TestAuthorizeLocalMethodConsumerLifecycle(t *testing.T) {
 			method: &codec.BasicConsume{Queue: testOtherTarget},
 		},
 		{
-			name:        "service declares a permitted queue",
+			name:        "service gets from a permitted queue",
 			policy:      servicePolicy,
-			method:      &codec.QueueDeclare{Queue: allowedQueue},
+			method:      &codec.BasicGet{Queue: allowedQueue},
 			wantAllowed: true,
 		},
 		{
-			name:   "service is refused declaring a queue outside its ACL",
+			name:   "service is refused getting from a queue outside its ACL",
 			policy: servicePolicy,
-			method: &codec.QueueDeclare{Queue: testOtherTarget},
+			method: &codec.BasicGet{Queue: testOtherTarget},
+		},
+		{
+			name:        "service passively declares a permitted queue",
+			policy:      servicePolicy,
+			method:      &codec.QueueDeclare{Queue: allowedQueue, Passive: true},
+			wantAllowed: true,
+		},
+		{
+			name:   "service is refused passively declaring a queue outside its ACL",
+			policy: servicePolicy,
+			method: &codec.QueueDeclare{Queue: testOtherTarget, Passive: true},
+		},
+		{
+			// A non-passive declare rewrites queue configuration, which the
+			// subscribe ACL does not grant even for a queue it names.
+			name:   "service is refused declaring a permitted queue non-passively",
+			policy: servicePolicy,
+			method: &codec.QueueDeclare{Queue: allowedQueue},
 		},
 		{
 			name:        "service acknowledges a delivery",
@@ -1275,7 +1293,12 @@ func TestAuthorizeLocalMethodConsumerLifecycle(t *testing.T) {
 		{
 			name:   "publish-only principal may not declare a queue",
 			policy: publishOnlyPolicy,
-			method: &codec.QueueDeclare{Queue: allowedQueue},
+			method: &codec.QueueDeclare{Queue: allowedQueue, Passive: true},
+		},
+		{
+			name:   "publish-only principal may not get",
+			policy: publishOnlyPolicy,
+			method: &codec.BasicGet{Queue: allowedQueue},
 		},
 		{
 			name:   "publish-only principal may not acknowledge",

--- a/amqp/broker/connection.go
+++ b/amqp/broker/connection.go
@@ -160,12 +160,35 @@ func (c *Connection) canPublishLocal(exchange, routingKey string) LocalPublishGr
 	return policy.localAuthz.CanPublishLocal(*c.localIdentity, normalizeExchange(exchange), routingKey)
 }
 
+// localRole returns the capability bound to this session at authentication.
+// An unauthenticated connection gets the zero value, the least privileged role.
+func (c *Connection) localRole() LocalPrincipalRole {
+	if c.localIdentity == nil {
+		return LocalRolePublisher
+	}
+	return c.localIdentity.Role
+}
+
+// permitsConsumers reports whether this session's principal may run consumers
+// at all. It is a property of the authenticated principal, not of the listener,
+// so the same principal has the same answer on every local listener.
+func (c *Connection) permitsConsumers() bool {
+	return c.connectionPolicy().usesLocalPrincipalAuth() && c.localRole().PermitsConsumers()
+}
+
+// propagatesOriginIdentity reports whether this session may relay the origin
+// identity of a message rather than having its own stamped on it.
+func (c *Connection) propagatesOriginIdentity() bool {
+	return c.connectionPolicy().carriesReservedProperties() &&
+		(!c.connectionPolicy().usesLocalPrincipalAuth() || c.localRole().PropagatesOriginIdentity())
+}
+
 // canSubscribeLocal authorizes a consumer for a local-principal session. A
-// principal that declares no subscribe permission is refused here even on a
-// listener whose policy permits consumers at all.
+// principal whose role permits consumers is still refused a queue its own
+// subscribe ACL does not name.
 func (c *Connection) canSubscribeLocal(queue string) bool {
 	policy := c.connectionPolicy()
-	if !policy.permitsConsumers() || policy.localAuthz == nil || c.localIdentity == nil {
+	if !c.permitsConsumers() || policy.localAuthz == nil || c.localIdentity == nil {
 		return false
 	}
 	return policy.localAuthz.CanSubscribeLocal(*c.localIdentity, queue)
@@ -407,7 +430,7 @@ func (c *Connection) authenticateCredentials(mechanism, username, password strin
 			_ = c.sendConnectionClose(codec.AccessRefused, "authentication failed", codec.ClassConnection, codec.MethodConnectionStartOk)
 			return fmt.Errorf("%s local auth unavailable", mechanism)
 		}
-		principalID, credentialFingerprint, permissionsFingerprint, certificateURI, ok, err := policy.localAuth.AuthenticateLocal(
+		authentication, ok, err := policy.localAuth.AuthenticateLocal(
 			c.ctx, clientID, username, password, c.peer,
 		)
 		if err != nil {
@@ -420,17 +443,19 @@ func (c *Connection) authenticateCredentials(mechanism, username, password strin
 			_ = c.sendConnectionClose(codec.AccessRefused, "authentication failed", codec.ClassConnection, codec.MethodConnectionStartOk)
 			return fmt.Errorf("%s local auth rejected for user %q", mechanism, username)
 		}
-		if principalID == "" || credentialFingerprint == "" || permissionsFingerprint == "" || certificateURI == "" ||
-			c.peer.CertificateFingerprint == "" || !containsURISAN(c.peer, certificateURI) {
+		if authentication.PrincipalID == "" || authentication.CredentialFingerprint == "" ||
+			authentication.PermissionsFingerprint == "" || authentication.CertificateURI == "" ||
+			c.peer.CertificateFingerprint == "" || !containsURISAN(c.peer, authentication.CertificateURI) {
 			c.recordLocalAuthFailure("identity_binding_rejected")
 			_ = c.sendConnectionClose(codec.AccessRefused, "authentication failed", codec.ClassConnection, codec.MethodConnectionStartOk)
 			return fmt.Errorf("%s local auth rejected for user %q", mechanism, username)
 		}
 		c.localIdentity = &LocalSessionIdentity{
-			PrincipalID:            principalID,
-			CredentialFingerprint:  credentialFingerprint,
-			PermissionsFingerprint: permissionsFingerprint,
-			CertificateURI:         certificateURI,
+			PrincipalID:            authentication.PrincipalID,
+			Role:                   authentication.Role,
+			CredentialFingerprint:  authentication.CredentialFingerprint,
+			PermissionsFingerprint: authentication.PermissionsFingerprint,
+			CertificateURI:         authentication.CertificateURI,
 			CertificateFingerprint: c.peer.CertificateFingerprint,
 		}
 		c.broker.stats.IncrementLocalAuthSuccess()
@@ -439,7 +464,8 @@ func (c *Connection) authenticateCredentials(mechanism, username, password strin
 			"outcome", "success",
 			"reason", "credentials_and_certificate_verified",
 			"client_id", clientID,
-			"principal_id", principalID)
+			"principal_id", authentication.PrincipalID,
+			"role", authentication.Role.String())
 		return nil
 	}
 

--- a/amqp/broker/connection.go
+++ b/amqp/broker/connection.go
@@ -91,7 +91,7 @@ func newConnection(ctx context.Context, b *Broker, netConn net.Conn, policy *Con
 		logger:     b.logger,
 	}
 	c.connID = b.nextConnectionID(netConn.RemoteAddr())
-	if policy != nil && policy.mode == ConnectionPolicyLocalPublishOnly {
+	if policy.usesLocalPrincipalAuth() {
 		if tlsConn, ok := netConn.(*tls.Conn); ok {
 			c.peer = verifiedPeerIdentity(tlsConn)
 		}
@@ -154,10 +154,21 @@ func (c *Connection) localSessionIdentity() (LocalSessionIdentity, bool) {
 // disagree about which exchange a publication targets.
 func (c *Connection) canPublishLocal(exchange, routingKey string) bool {
 	policy := c.connectionPolicy()
-	if policy.mode != ConnectionPolicyLocalPublishOnly || policy.localAuthz == nil || c.localIdentity == nil {
+	if !policy.usesLocalPrincipalAuth() || policy.localAuthz == nil || c.localIdentity == nil {
 		return false
 	}
 	return policy.localAuthz.CanPublishLocal(*c.localIdentity, normalizeExchange(exchange), routingKey)
+}
+
+// canSubscribeLocal authorizes a consumer for a local-principal session. A
+// principal that declares no subscribe permission is refused here even on a
+// listener whose policy permits consumers at all.
+func (c *Connection) canSubscribeLocal(queue string) bool {
+	policy := c.connectionPolicy()
+	if !policy.permitsConsumers() || policy.localAuthz == nil || c.localIdentity == nil {
+		return false
+	}
+	return policy.localAuthz.CanSubscribeLocal(*c.localIdentity, queue)
 }
 
 func (c *Connection) registerAndValidate() error {
@@ -165,7 +176,7 @@ func (c *Connection) registerAndValidate() error {
 	c.registered = true
 	c.broker.stats.IncrementConnections()
 
-	if c.connectionPolicy().mode != ConnectionPolicyLocalPublishOnly {
+	if !c.connectionPolicy().usesLocalPrincipalAuth() {
 		return nil
 	}
 	c.broker.stats.IncrementLocalConnections()
@@ -370,7 +381,7 @@ func (c *Connection) authenticate(start *codec.ConnectionStartOk) error {
 	case saslMechanismPlain, saslMechanismAMQPlain:
 		_, username, password, err := sasl.ParsePLAIN([]byte(start.Response))
 		if err != nil {
-			if policy.mode == ConnectionPolicyLocalPublishOnly {
+			if policy.usesLocalPrincipalAuth() {
 				c.recordLocalAuthFailure("invalid_sasl_response")
 			}
 			_ = c.sendConnectionClose(codec.AccessRefused, "invalid auth response", codec.ClassConnection, codec.MethodConnectionStartOk)
@@ -379,7 +390,7 @@ func (c *Connection) authenticate(start *codec.ConnectionStartOk) error {
 
 		return c.authenticateCredentials(mechanism, username, password)
 	default:
-		if policy.mode == ConnectionPolicyLocalPublishOnly {
+		if policy.usesLocalPrincipalAuth() {
 			c.recordLocalAuthFailure("unsupported_sasl_mechanism")
 		}
 		_ = c.sendConnectionClose(codec.CommandInvalid, "unsupported auth mechanism", codec.ClassConnection, codec.MethodConnectionStartOk)
@@ -390,7 +401,7 @@ func (c *Connection) authenticate(start *codec.ConnectionStartOk) error {
 func (c *Connection) authenticateCredentials(mechanism, username, password string) error {
 	policy := c.connectionPolicy()
 	clientID := PrefixedClientID(c.connID)
-	if policy.mode == ConnectionPolicyLocalPublishOnly {
+	if policy.usesLocalPrincipalAuth() {
 		if policy.localAuth == nil {
 			c.recordLocalAuthFailure("authenticator_unavailable")
 			_ = c.sendConnectionClose(codec.AccessRefused, "authentication failed", codec.ClassConnection, codec.MethodConnectionStartOk)

--- a/amqp/broker/connection.go
+++ b/amqp/broker/connection.go
@@ -65,6 +65,9 @@ type Connection struct {
 	channels   map[uint16]*Channel
 	channelsMu sync.RWMutex
 
+	queueRegistrations   map[queueRegistration]int
+	queueRegistrationsMu sync.Mutex
+
 	writeMu   sync.Mutex
 	closed    atomic.Bool
 	closeCh   chan struct{}
@@ -75,20 +78,30 @@ type Connection struct {
 	logger *slog.Logger
 }
 
+// queueRegistration identifies the queue-manager registration shared by all
+// matching Basic.Consume instances on one AMQP connection. The queue manager
+// registers the connection client ID, not an AMQP channel or consumer tag.
+type queueRegistration struct {
+	queueName string
+	pattern   string
+	groupID   string
+}
+
 func newConnection(ctx context.Context, b *Broker, netConn net.Conn, policy *ConnectionPolicy) *Connection {
 	c := &Connection{
-		broker:     b,
-		conn:       netConn,
-		reader:     bufio.NewReaderSize(netConn, 65536),
-		writer:     bufio.NewWriterSize(netConn, 65536),
-		ctx:        ctx,
-		policy:     policy,
-		frameMax:   defaultFrameMax,
-		channelMax: defaultChannelMax,
-		heartbeat:  defaultHeartbeat,
-		channels:   make(map[uint16]*Channel),
-		closeCh:    make(chan struct{}),
-		logger:     b.logger,
+		broker:             b,
+		conn:               netConn,
+		reader:             bufio.NewReaderSize(netConn, 65536),
+		writer:             bufio.NewWriterSize(netConn, 65536),
+		ctx:                ctx,
+		policy:             policy,
+		frameMax:           defaultFrameMax,
+		channelMax:         defaultChannelMax,
+		heartbeat:          defaultHeartbeat,
+		channels:           make(map[uint16]*Channel),
+		queueRegistrations: make(map[queueRegistration]int),
+		closeCh:            make(chan struct{}),
+		logger:             b.logger,
 	}
 	c.connID = b.nextConnectionID(netConn.RemoteAddr())
 	if policy.usesLocalPrincipalAuth() {
@@ -97,6 +110,43 @@ func newConnection(ctx context.Context, b *Broker, netConn net.Conn, policy *Con
 		}
 	}
 	return c
+}
+
+func (c *Connection) retainQueueRegistration(cons *consumer) {
+	if cons == nil || cons.queueName == "" {
+		return
+	}
+
+	key := queueRegistration{queueName: cons.queueName, pattern: cons.pattern, groupID: cons.groupID}
+	c.queueRegistrationsMu.Lock()
+	if c.queueRegistrations == nil {
+		c.queueRegistrations = make(map[queueRegistration]int)
+	}
+	c.queueRegistrations[key]++
+	c.queueRegistrationsMu.Unlock()
+}
+
+// releaseQueueRegistration reports whether the released consumer was the last
+// owner of the connection-level queue-manager registration.
+func (c *Connection) releaseQueueRegistration(cons *consumer) bool {
+	if cons == nil || cons.queueName == "" {
+		return false
+	}
+
+	key := queueRegistration{queueName: cons.queueName, pattern: cons.pattern, groupID: cons.groupID}
+	c.queueRegistrationsMu.Lock()
+	defer c.queueRegistrationsMu.Unlock()
+
+	owners, exists := c.queueRegistrations[key]
+	if !exists {
+		return false
+	}
+	if owners > 1 {
+		c.queueRegistrations[key] = owners - 1
+		return false
+	}
+	delete(c.queueRegistrations, key)
+	return true
 }
 
 func (c *Connection) connectionPolicy() *ConnectionPolicy {

--- a/amqp/broker/connection.go
+++ b/amqp/broker/connection.go
@@ -152,10 +152,10 @@ func (c *Connection) localSessionIdentity() (LocalSessionIdentity, bool) {
 // canPublishLocal authorizes the exchange name the router will actually use.
 // Authorizing the raw wire value would let the ACL and the routing decision
 // disagree about which exchange a publication targets.
-func (c *Connection) canPublishLocal(exchange, routingKey string) bool {
+func (c *Connection) canPublishLocal(exchange, routingKey string) LocalPublishGrant {
 	policy := c.connectionPolicy()
 	if !policy.usesLocalPrincipalAuth() || policy.localAuthz == nil || c.localIdentity == nil {
-		return false
+		return LocalPublishGrantNone
 	}
 	return policy.localAuthz.CanPublishLocal(*c.localIdentity, normalizeExchange(exchange), routingKey)
 }

--- a/amqp/broker/policy.go
+++ b/amqp/broker/policy.go
@@ -23,6 +23,12 @@ const (
 	// ConnectionPolicyLocalPublishOnly enables local-principal authentication
 	// and restricts the connection to publisher lifecycle operations.
 	ConnectionPolicyLocalPublishOnly
+	// ConnectionPolicyLocalService enables local-principal authentication and
+	// additionally permits the consumer lifecycle, so a first-party service can
+	// both publish and subscribe. Every operation remains authorized against the
+	// principal's own ACL, so a principal declaring no subscribe permission is
+	// still refused a consumer.
+	ConnectionPolicyLocalService
 )
 
 // VerifiedPeerIdentity contains identity material from a TLS certificate chain
@@ -41,11 +47,12 @@ type LocalPrincipalAuthenticator interface {
 	AuthenticateLocal(ctx context.Context, clientID, username, secret string, peer VerifiedPeerIdentity) (principalID, credentialFingerprint, permissionsFingerprint, certificateURI string, authenticated bool, err error)
 }
 
-// LocalPrincipalAuthorizer makes exact AMQP publish decisions for a fully
-// authenticated local session. Implementations must validate both the bound
-// session credential and the target against one current policy snapshot.
+// LocalPrincipalAuthorizer makes exact AMQP publish and subscribe decisions for
+// a fully authenticated local session. Implementations must validate both the
+// bound session credential and the target against one current policy snapshot.
 type LocalPrincipalAuthorizer interface {
 	CanPublishLocal(identity LocalSessionIdentity, exchange, routingKey string) bool
+	CanSubscribeLocal(identity LocalSessionIdentity, queue string) bool
 }
 
 // LocalSessionValidator checks whether the immutable credential, permissions,
@@ -93,6 +100,24 @@ func (p *ConnectionPolicy) carriesReservedProperties() bool {
 	return p != nil && p.trusted
 }
 
+// usesLocalPrincipalAuth reports whether connections under this policy
+// authenticate against the local-principal store rather than the external auth
+// engine. It is the authentication boundary, distinct from which operations the
+// resulting session may perform.
+func (p *ConnectionPolicy) usesLocalPrincipalAuth() bool {
+	if p == nil {
+		return false
+	}
+	return p.mode == ConnectionPolicyLocalPublishOnly || p.mode == ConnectionPolicyLocalService
+}
+
+// permitsConsumers reports whether a session under this policy may run the
+// consumer lifecycle. Whether it may consume any particular queue is a separate
+// per-principal ACL decision.
+func (p *ConnectionPolicy) permitsConsumers() bool {
+	return p != nil && p.mode == ConnectionPolicyLocalService
+}
+
 // propagatesOriginIdentity reports whether a publisher under this policy may
 // state the external identity and origin protocol of a message it relays,
 // rather than having its own authenticated identity stamped on it.
@@ -104,6 +129,31 @@ func (p *ConnectionPolicy) carriesReservedProperties() bool {
 // that actually authenticated.
 func (p *ConnectionPolicy) propagatesOriginIdentity() bool {
 	return p.carriesReservedProperties() && p.mode != ConnectionPolicyLocalPublishOnly
+}
+
+// NewLocalServiceConnectionPolicy constructs a fail-closed local-principal
+// policy that also permits the consumer lifecycle. It never invokes an external
+// auth engine or blocking hook.
+//
+// The policy is trusted on the same grounds as the publish-only one: the
+// listener admits only mTLS peers whose verified certificate URI SAN matches a
+// principal declared in FluxMQ's own configuration. Unlike an audit publisher, a
+// service relays messages it did not originate, so it may state their true
+// origin rather than having its own identity stamped on them.
+func NewLocalServiceConnectionPolicy(
+	auth LocalPrincipalAuthenticator,
+	authz LocalPrincipalAuthorizer,
+	sessions LocalSessionValidator,
+	maxMessageSize uint64,
+) *ConnectionPolicy {
+	return &ConnectionPolicy{
+		mode:           ConnectionPolicyLocalService,
+		trusted:        true,
+		localAuth:      auth,
+		localAuthz:     authz,
+		localSessions:  sessions,
+		maxMessageSize: maxMessageSize,
+	}
 }
 
 // NewExternalConnectionPolicy constructs a policy using only the existing

--- a/amqp/broker/policy.go
+++ b/amqp/broker/policy.go
@@ -72,6 +72,7 @@ type LocalSessionIdentity struct {
 // NewLocalPublishOnlyConnectionPolicy and do not mutate them after serving.
 type ConnectionPolicy struct {
 	mode           ConnectionPolicyMode
+	trusted        bool
 	externalAuth   *corebroker.AuthEngine
 	hooks          *corebroker.BlockingHookEngine
 	localAuth      LocalPrincipalAuthenticator
@@ -80,11 +81,37 @@ type ConnectionPolicy struct {
 	maxMessageSize uint64
 }
 
+// carriesReservedProperties reports whether connections under this policy may
+// exchange broker-internal properties with the broker.
+//
+// This is deliberately a field of its own rather than a test on mode: trust is
+// a statement about who authenticated the peer, while mode is a statement about
+// which operations the peer may perform. A future listener may be trusted and
+// still permit subscribe. A nil policy is the embedded-caller compatibility
+// path and is never trusted.
+func (p *ConnectionPolicy) carriesReservedProperties() bool {
+	return p != nil && p.trusted
+}
+
+// propagatesOriginIdentity reports whether a publisher under this policy may
+// state the external identity and origin protocol of a message it relays,
+// rather than having its own authenticated identity stamped on it.
+//
+// Only a trusted service may: for an externally authenticated client, naming
+// another principal is impersonation. A local principal may not either. Its
+// identity is fixed by FluxMQ's configuration and its publications are audit
+// records, so a relayed origin would make the record disagree with the peer
+// that actually authenticated.
+func (p *ConnectionPolicy) propagatesOriginIdentity() bool {
+	return p.carriesReservedProperties() && p.mode != ConnectionPolicyLocalPublishOnly
+}
+
 // NewExternalConnectionPolicy constructs a policy using only the existing
 // external auth engine and blocking hooks.
 func NewExternalConnectionPolicy(auth *corebroker.AuthEngine, hooks *corebroker.BlockingHookEngine, maxMessageSize uint64) *ConnectionPolicy {
 	return &ConnectionPolicy{
 		mode:           ConnectionPolicyExternal,
+		trusted:        false,
 		externalAuth:   auth,
 		hooks:          hooks,
 		maxMessageSize: maxMessageSize,
@@ -93,6 +120,11 @@ func NewExternalConnectionPolicy(auth *corebroker.AuthEngine, hooks *corebroker.
 
 // NewLocalPublishOnlyConnectionPolicy constructs a fail-closed local-principal
 // policy. It never invokes an external auth engine or blocking hook.
+//
+// The policy is trusted: the listener admits only mTLS peers whose verified
+// certificate URI SAN matches a principal declared in FluxMQ's own
+// configuration, so a reserved property arriving on it came from a first-party
+// service rather than from a tenant or device.
 func NewLocalPublishOnlyConnectionPolicy(
 	auth LocalPrincipalAuthenticator,
 	authz LocalPrincipalAuthorizer,
@@ -101,6 +133,7 @@ func NewLocalPublishOnlyConnectionPolicy(
 ) *ConnectionPolicy {
 	return &ConnectionPolicy{
 		mode:           ConnectionPolicyLocalPublishOnly,
+		trusted:        true,
 		localAuth:      auth,
 		localAuthz:     authz,
 		localSessions:  sessions,

--- a/amqp/broker/policy.go
+++ b/amqp/broker/policy.go
@@ -47,11 +47,38 @@ type LocalPrincipalAuthenticator interface {
 	AuthenticateLocal(ctx context.Context, clientID, username, secret string, peer VerifiedPeerIdentity) (principalID, credentialFingerprint, permissionsFingerprint, certificateURI string, authenticated bool, err error)
 }
 
+// LocalPublishGrant reports which kind of publish permission authorized a
+// publication. The two kinds carry different delivery contracts, so the grant
+// decides how the publication is routed.
+type LocalPublishGrant uint8
+
+const (
+	// LocalPublishGrantNone means no permission matched and the publish is denied.
+	LocalPublishGrantNone LocalPublishGrant = iota
+	// LocalPublishGrantExactTarget matched an exact routing key. It names a
+	// protected durable stream, so the publication is appended and synced before
+	// the publisher is confirmed.
+	LocalPublishGrantExactTarget
+	// LocalPublishGrantPrefix matched a routing-key prefix. It names no queue and
+	// is checked against no durability contract, so the publication is routed as
+	// an ordinary topic publish.
+	LocalPublishGrantPrefix
+)
+
+// Allowed reports whether the grant authorizes the publication at all.
+func (g LocalPublishGrant) Allowed() bool {
+	return g != LocalPublishGrantNone
+}
+
 // LocalPrincipalAuthorizer makes exact AMQP publish and subscribe decisions for
 // a fully authenticated local session. Implementations must validate both the
 // bound session credential and the target against one current policy snapshot.
+//
+// CanPublishLocal returns the matching grant rather than a bare bool so the
+// caller can route by permission kind without a second lookup, which would
+// reopen the revocation race a single snapshot read closes.
 type LocalPrincipalAuthorizer interface {
-	CanPublishLocal(identity LocalSessionIdentity, exchange, routingKey string) bool
+	CanPublishLocal(identity LocalSessionIdentity, exchange, routingKey string) LocalPublishGrant
 	CanSubscribeLocal(identity LocalSessionIdentity, queue string) bool
 }
 

--- a/amqp/broker/policy.go
+++ b/amqp/broker/policy.go
@@ -20,16 +20,51 @@ const (
 	// ConnectionPolicyExternal preserves the existing remote auth-callout and
 	// blocking-hook behavior.
 	ConnectionPolicyExternal ConnectionPolicyMode = iota
-	// ConnectionPolicyLocalPublishOnly enables local-principal authentication
-	// and restricts the connection to publisher lifecycle operations.
-	ConnectionPolicyLocalPublishOnly
-	// ConnectionPolicyLocalService enables local-principal authentication and
-	// additionally permits the consumer lifecycle, so a first-party service can
-	// both publish and subscribe. Every operation remains authorized against the
-	// principal's own ACL, so a principal declaring no subscribe permission is
-	// still refused a consumer.
-	ConnectionPolicyLocalService
+	// ConnectionPolicyLocal enables local-principal authentication. It selects
+	// the credential store, not the capability: what a session may then do comes
+	// from the authenticated principal's own role, so a listener cannot widen a
+	// principal and a principal cannot be widened by choosing a listener.
+	ConnectionPolicyLocal
 )
+
+// LocalPrincipalRole is the capability carried by an authenticated local
+// principal. It is bound to the session at authentication and travels with it,
+// because nothing binds a principal to a listener: a capability granted by a
+// port would be granted to every principal able to reach that port.
+type LocalPrincipalRole uint8
+
+const (
+	// LocalRolePublisher may publish only. It is the zero value, so an
+	// unspecified role is the least privileged one.
+	LocalRolePublisher LocalPrincipalRole = iota
+	// LocalRoleService may additionally run consumers, subject to its own
+	// subscribe ACL.
+	LocalRoleService
+)
+
+// String returns the role name used in configuration and diagnostics.
+func (r LocalPrincipalRole) String() string {
+	if r == LocalRoleService {
+		return "service"
+	}
+	return "publisher"
+}
+
+// PermitsConsumers reports whether the role may run the consumer lifecycle.
+// Whether it may consume a particular queue is a separate ACL decision.
+func (r LocalPrincipalRole) PermitsConsumers() bool {
+	return r == LocalRoleService
+}
+
+// PropagatesOriginIdentity reports whether the role may state the external
+// identity and origin protocol of a message it relays.
+//
+// A service relays messages it did not author, so it may name their true
+// origin. A publisher may not: its publications are its own records, and a
+// relayed origin would make one disagree with the principal that authenticated.
+func (r LocalPrincipalRole) PropagatesOriginIdentity() bool {
+	return r == LocalRoleService
+}
 
 // VerifiedPeerIdentity contains identity material from a TLS certificate chain
 // that was successfully verified by the listener. Unverified peer certificate
@@ -39,12 +74,23 @@ type VerifiedPeerIdentity struct {
 	CertificateFingerprint string
 }
 
+// LocalAuthentication is what a local-principal authenticator establishes about
+// a peer. CertificateURI must name a URI SAN the listener already verified;
+// the caller rejects any other value. CredentialFingerprint and
+// PermissionsFingerprint are opaque, non-secret identifiers used to revoke
+// sessions after a credential, role, or ACL change.
+type LocalAuthentication struct {
+	PrincipalID            string
+	Role                   LocalPrincipalRole
+	CredentialFingerprint  string
+	PermissionsFingerprint string
+	CertificateURI         string
+}
+
 // LocalPrincipalAuthenticator authenticates credentials against a verified TLS
-// peer identity. certificateURI must name the URI SAN selected from peer.URISANs.
-// credentialFingerprint and permissionsFingerprint are opaque, non-secret
-// identifiers used to revoke sessions after credential or publish-ACL changes.
+// peer identity.
 type LocalPrincipalAuthenticator interface {
-	AuthenticateLocal(ctx context.Context, clientID, username, secret string, peer VerifiedPeerIdentity) (principalID, credentialFingerprint, permissionsFingerprint, certificateURI string, authenticated bool, err error)
+	AuthenticateLocal(ctx context.Context, clientID, username, secret string, peer VerifiedPeerIdentity) (LocalAuthentication, bool, error)
 }
 
 // LocalPublishGrant reports which kind of publish permission authorized a
@@ -92,9 +138,11 @@ type LocalSessionValidator interface {
 }
 
 // LocalSessionIdentity is the immutable security identity bound to a local
-// AMQP connection after authentication.
+// AMQP connection after authentication. Role is part of it, so a session's
+// capability is fixed by who authenticated rather than by where they connected.
 type LocalSessionIdentity struct {
 	PrincipalID            string
+	Role                   LocalPrincipalRole
 	CredentialFingerprint  string
 	PermissionsFingerprint string
 	CertificateURI         string
@@ -103,7 +151,7 @@ type LocalSessionIdentity struct {
 
 // ConnectionPolicy is an immutable listener-scoped AMQP security policy.
 // Construct policies with NewExternalConnectionPolicy or
-// NewLocalPublishOnlyConnectionPolicy and do not mutate them after serving.
+// NewLocalConnectionPolicy and do not mutate them after serving.
 type ConnectionPolicy struct {
 	mode           ConnectionPolicyMode
 	trusted        bool
@@ -129,58 +177,10 @@ func (p *ConnectionPolicy) carriesReservedProperties() bool {
 
 // usesLocalPrincipalAuth reports whether connections under this policy
 // authenticate against the local-principal store rather than the external auth
-// engine. It is the authentication boundary, distinct from which operations the
-// resulting session may perform.
+// engine. It is the authentication boundary; what the resulting session may do
+// comes from the authenticated principal's role, not from here.
 func (p *ConnectionPolicy) usesLocalPrincipalAuth() bool {
-	if p == nil {
-		return false
-	}
-	return p.mode == ConnectionPolicyLocalPublishOnly || p.mode == ConnectionPolicyLocalService
-}
-
-// permitsConsumers reports whether a session under this policy may run the
-// consumer lifecycle. Whether it may consume any particular queue is a separate
-// per-principal ACL decision.
-func (p *ConnectionPolicy) permitsConsumers() bool {
-	return p != nil && p.mode == ConnectionPolicyLocalService
-}
-
-// propagatesOriginIdentity reports whether a publisher under this policy may
-// state the external identity and origin protocol of a message it relays,
-// rather than having its own authenticated identity stamped on it.
-//
-// Only a trusted service may: for an externally authenticated client, naming
-// another principal is impersonation. A local principal may not either. Its
-// identity is fixed by FluxMQ's configuration and its publications are audit
-// records, so a relayed origin would make the record disagree with the peer
-// that actually authenticated.
-func (p *ConnectionPolicy) propagatesOriginIdentity() bool {
-	return p.carriesReservedProperties() && p.mode != ConnectionPolicyLocalPublishOnly
-}
-
-// NewLocalServiceConnectionPolicy constructs a fail-closed local-principal
-// policy that also permits the consumer lifecycle. It never invokes an external
-// auth engine or blocking hook.
-//
-// The policy is trusted on the same grounds as the publish-only one: the
-// listener admits only mTLS peers whose verified certificate URI SAN matches a
-// principal declared in FluxMQ's own configuration. Unlike an audit publisher, a
-// service relays messages it did not originate, so it may state their true
-// origin rather than having its own identity stamped on them.
-func NewLocalServiceConnectionPolicy(
-	auth LocalPrincipalAuthenticator,
-	authz LocalPrincipalAuthorizer,
-	sessions LocalSessionValidator,
-	maxMessageSize uint64,
-) *ConnectionPolicy {
-	return &ConnectionPolicy{
-		mode:           ConnectionPolicyLocalService,
-		trusted:        true,
-		localAuth:      auth,
-		localAuthz:     authz,
-		localSessions:  sessions,
-		maxMessageSize: maxMessageSize,
-	}
+	return p != nil && p.mode == ConnectionPolicyLocal
 }
 
 // NewExternalConnectionPolicy constructs a policy using only the existing
@@ -195,21 +195,26 @@ func NewExternalConnectionPolicy(auth *corebroker.AuthEngine, hooks *corebroker.
 	}
 }
 
-// NewLocalPublishOnlyConnectionPolicy constructs a fail-closed local-principal
-// policy. It never invokes an external auth engine or blocking hook.
+// NewLocalConnectionPolicy constructs a fail-closed local-principal policy. It
+// never invokes an external auth engine or blocking hook.
 //
 // The policy is trusted: the listener admits only mTLS peers whose verified
 // certificate URI SAN matches a principal declared in FluxMQ's own
 // configuration, so a reserved property arriving on it came from a first-party
 // service rather than from a tenant or device.
-func NewLocalPublishOnlyConnectionPolicy(
+//
+// It grants no capability of its own. Publishing, consuming, and relaying an
+// origin identity are decided by the authenticated principal's role and ACLs,
+// so every local listener is equivalent and a principal cannot widen itself by
+// choosing one.
+func NewLocalConnectionPolicy(
 	auth LocalPrincipalAuthenticator,
 	authz LocalPrincipalAuthorizer,
 	sessions LocalSessionValidator,
 	maxMessageSize uint64,
 ) *ConnectionPolicy {
 	return &ConnectionPolicy{
-		mode:           ConnectionPolicyLocalPublishOnly,
+		mode:           ConnectionPolicyLocal,
 		trusted:        true,
 		localAuth:      auth,
 		localAuthz:     authz,

--- a/amqp/broker/policy_test.go
+++ b/amqp/broker/policy_test.go
@@ -345,6 +345,43 @@ func TestLocalPublishRequiresExactExchangeAndRoutingKey(t *testing.T) {
 	}
 }
 
+// A local principal's identity is fixed by configuration, so its publications
+// are stamped with the authenticated principal even though the listener is
+// trusted. Relaying another origin would make an audit record disagree with the
+// peer that actually authenticated.
+func TestLocalPrincipalStampsOwnIdentityOverRelayedOrigin(t *testing.T) {
+	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
+	conn, _ := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	bindLocalIdentity(conn)
+	qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: testAuditQueue, Type: qtypes.QueueTypeStream}}
+	conn.broker.queueManager = qm
+
+	ch := newChannel(conn, 1)
+	ch.pendingMethod = &codec.BasicPublish{RoutingKey: testAuditQueue}
+	ch.pendingHeader = &codec.ContentHeader{
+		ClassID:  codec.ClassBasic,
+		BodySize: 2,
+		Properties: codec.BasicProperties{
+			Headers: map[string]any{
+				corebroker.ExternalIDProperty: "pub-123",
+				corebroker.ProtocolProperty:   corebroker.ProtocolHTTP,
+			},
+		},
+	}
+	ch.pendingBody = []byte("{}")
+	ch.completePublish()
+
+	if qm.exactPublishCalls != 1 {
+		t.Fatalf("exact stream publish calls = %d, want 1", qm.exactPublishCalls)
+	}
+	if got := qm.exactPublish.Properties[corebroker.ExternalIDProperty]; got != testLocalPrincipal {
+		t.Fatalf("external_id = %q, want %q", got, testLocalPrincipal)
+	}
+	if got := qm.exactPublish.Properties[corebroker.ProtocolProperty]; got != corebroker.ProtocolAMQP091 {
+		t.Fatalf("protocol = %q, want %q", got, corebroker.ProtocolAMQP091)
+	}
+}
+
 func TestLocalPolicyBypassesBrokerGlobalHooks(t *testing.T) {
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
 	conn, _ := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
@@ -810,6 +847,50 @@ func TestLocalPublishRejectsCredentialRetiredDuringContent(t *testing.T) {
 	}
 	if got := decodeSingleChannelClose(t, buf); got.ReplyCode != codec.AccessRefused {
 		t.Fatalf("reply code = %d, want %d", got.ReplyCode, codec.AccessRefused)
+	}
+}
+
+// Reserved properties are gated on who authenticated the peer, so only the
+// mTLS internal listener may exchange them. A missing policy is the embedded
+// caller path and must fail closed.
+func TestConnectionPolicyReservedPropertyTrust(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy *ConnectionPolicy
+		want   bool
+	}{
+		{
+			name:   "local publish only policy is trusted",
+			policy: NewLocalPublishOnlyConnectionPolicy(nil, nil, nil, 0),
+			want:   true,
+		},
+		{
+			name:   "external policy is not trusted",
+			policy: NewExternalConnectionPolicy(nil, nil, 0),
+			want:   false,
+		},
+		{
+			name:   "nil policy is not trusted",
+			policy: nil,
+			want:   false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.policy.carriesReservedProperties(); got != tc.want {
+				t.Fatalf("carriesReservedProperties() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A connection with no policy resolves to the untrusted external default, so an
+// embedded caller never silently becomes a trusted service.
+func TestAbsentPolicyResolvesUntrusted(t *testing.T) {
+	conn, _ := newPolicyTestConnection(t, nil)
+	if conn.connectionPolicy().carriesReservedProperties() {
+		t.Fatal("connection with no policy must not carry reserved properties")
 	}
 }
 

--- a/amqp/broker/policy_test.go
+++ b/amqp/broker/policy_test.go
@@ -478,6 +478,92 @@ func TestLocalPublishPathFollowsGrantKind(t *testing.T) {
 	}
 }
 
+// A prefix grant is authorized against no queues entry, so it must never reach
+// a queue. Two routing keys would otherwise carry it there: one under a
+// "$queue/"-shaped prefix, and one that happens to name a configured stream.
+func TestLocalPrefixGrantNeverReachesAQueue(t *testing.T) {
+	const streamQueue = "atom-audit"
+
+	tests := []struct {
+		name       string
+		prefix     string
+		routingKey string
+	}{
+		{
+			name:       "routing key naming a configured stream",
+			prefix:     "atom-",
+			routingKey: streamQueue,
+		},
+		{
+			name:       "routing key under a queue-shaped prefix",
+			prefix:     "$queue/",
+			routingKey: "$queue/" + streamQueue,
+		},
+		{
+			name:       "routing key under a queue-shaped prefix targeting a commit",
+			prefix:     "$queue/",
+			routingKey: "$queue/" + streamQueue + "/$commit",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			authz := &localAuthorizerStub{allowRoutingKeyPrefix: tc.prefix}
+			conn, _ := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
+			bindLocalIdentityAs(conn, LocalRoleService)
+			qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: streamQueue, Type: qtypes.QueueTypeStream}}
+			conn.broker.queueManager = qm
+
+			ch := newChannel(conn, 1)
+			ch.pendingMethod = &codec.BasicPublish{RoutingKey: tc.routingKey}
+			ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
+			ch.pendingBody = []byte("{}")
+			ch.completePublish()
+
+			if qm.exactPublishCalls != 0 {
+				t.Fatalf("durable stream publish calls = %d, want 0", qm.exactPublishCalls)
+			}
+			if qm.publishCalls != 0 {
+				t.Fatalf("queue publish calls = %d, want 0; a prefix grant must stay on the pub/sub path", qm.publishCalls)
+			}
+		})
+	}
+}
+
+// A local principal may only declare passively, and the queues it consumes are
+// pre-provisioned rather than declared on its own channel, so the lookup has to
+// reach global queue state.
+func TestPassiveDeclareResolvesProvisionedQueue(t *testing.T) {
+	const provisioned = "atom-audit"
+
+	authz := &localAuthorizerStub{allowQueue: provisioned}
+	conn, buf := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
+	bindLocalIdentityAs(conn, LocalRoleService)
+	conn.broker.queueManager = &mockChannelQueueManager{
+		queueCfg: &qtypes.QueueConfig{Name: provisioned, Type: qtypes.QueueTypeStream},
+	}
+
+	ch := newChannel(conn, 1)
+	if err := ch.handleQueueDeclare(&codec.QueueDeclare{Queue: provisioned, Passive: true}); err != nil {
+		t.Fatalf("passive declare of a provisioned queue: %v", err)
+	}
+	if err := conn.writer.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	frames := readFramesFrom(t, buf, 0)
+	if len(frames) != 1 {
+		t.Fatalf("expected one frame, got %d", len(frames))
+	}
+	decoded, err := frames[0].Decode()
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := decoded.(*codec.QueueDeclareOk); !ok {
+		t.Fatalf("expected QueueDeclareOk, got %T", decoded)
+	}
+}
+
 func TestLocalPolicyBypassesBrokerGlobalHooks(t *testing.T) {
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
 	conn, _ := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))

--- a/amqp/broker/policy_test.go
+++ b/amqp/broker/policy_test.go
@@ -23,6 +23,8 @@ import (
 	qstorage "github.com/absmach/fluxmq/queue/storage"
 	qtypes "github.com/absmach/fluxmq/queue/types"
 	"github.com/absmach/fluxmq/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -34,6 +36,7 @@ const (
 	testAuditQueue     = "atom-audit"
 	testServiceQueue   = "$queue/m"
 	testConsumerTag    = "reader"
+	testSiblingTag     = "sibling-reader"
 )
 
 type localAuthenticatorStub struct {
@@ -638,6 +641,68 @@ func TestLocalConsumeFailureRollsBackAndClosesChannel(t *testing.T) {
 	}
 	if closeMethod.ClassID != codec.ClassBasic || closeMethod.MethodID != codec.MethodBasicConsume {
 		t.Fatalf("close method = %d/%d, want basic.consume", closeMethod.ClassID, closeMethod.MethodID)
+	}
+}
+
+// The manager unregisters a client from a queue and group, not a single
+// consumer, so a failed consume must not compensate while a sibling consumer
+// still holds that registration. It would otherwise stop delivering to a
+// consumer whose own subscribe succeeded, without reporting anything.
+func TestLocalConsumeFailureKeepsSiblingSubscription(t *testing.T) {
+	const provisioned = "m"
+
+	tests := []struct {
+		name            string
+		withSibling     bool
+		wantUnsubscribe bool
+	}{
+		{
+			name:            "sole consumer compensates",
+			wantUnsubscribe: true,
+		},
+		{
+			name:        "sibling on the same registration is left alone",
+			withSibling: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			authz := &localAuthorizerStub{allowQueue: provisioned}
+			conn, _ := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
+			bindLocalIdentityAs(conn, LocalRoleService)
+			qm := &mockChannelQueueManager{
+				queueCfg: &qtypes.QueueConfig{Name: provisioned, Type: qtypes.QueueTypeClassic},
+			}
+			conn.broker.queueManager = qm
+
+			ch := newChannel(conn, 1)
+			if tc.withSibling {
+				// A consumer whose own subscribe succeeded, sharing the queue and
+				// group the failing one is about to use.
+				require.NoError(t, ch.handleMethod(&codec.BasicConsume{Queue: testServiceQueue, ConsumerTag: testSiblingTag}))
+				require.Empty(t, qm.unsubscribes, "a successful consume must not unsubscribe")
+			}
+
+			// The second subscribe fails after the manager began registering, which
+			// is the only case that still compensates.
+			qm.existingSubErr = errors.New("group store unavailable")
+			require.NoError(t, ch.handleMethod(&codec.BasicConsume{Queue: testServiceQueue, ConsumerTag: testConsumerTag}))
+
+			ch.consumersMu.RLock()
+			_, failedRemains := ch.consumers[testConsumerTag]
+			_, siblingRemains := ch.consumers[testSiblingTag]
+			ch.consumersMu.RUnlock()
+
+			assert.False(t, failedRemains, "the failed consumer must not stay registered")
+			assert.Equal(t, tc.withSibling, siblingRemains, "the sibling must survive its neighbour's failure")
+
+			if tc.wantUnsubscribe {
+				assert.Equal(t, []string{provisioned + "/"}, qm.unsubscribes)
+			} else {
+				assert.Empty(t, qm.unsubscribes, "compensating here would revoke the sibling's registration")
+			}
+		})
 	}
 }
 

--- a/amqp/broker/policy_test.go
+++ b/amqp/broker/policy_test.go
@@ -41,6 +41,7 @@ type localAuthenticatorStub struct {
 	secret         string
 	peer           VerifiedPeerIdentity
 	principalID    string
+	role           LocalPrincipalRole
 	credentialFP   string
 	permissionsFP  string
 	certificateURI string
@@ -48,7 +49,7 @@ type localAuthenticatorStub struct {
 	err            error
 }
 
-func (s *localAuthenticatorStub) AuthenticateLocal(_ context.Context, clientID, username, secret string, peer VerifiedPeerIdentity) (string, string, string, string, bool, error) {
+func (s *localAuthenticatorStub) AuthenticateLocal(_ context.Context, clientID, username, secret string, peer VerifiedPeerIdentity) (LocalAuthentication, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.calls++
@@ -56,7 +57,13 @@ func (s *localAuthenticatorStub) AuthenticateLocal(_ context.Context, clientID, 
 	s.username = username
 	s.secret = secret
 	s.peer = peer
-	return s.principalID, s.credentialFP, s.permissionsFP, s.certificateURI, s.authenticated, s.err
+	return LocalAuthentication{
+		PrincipalID:            s.principalID,
+		Role:                   s.role,
+		CredentialFingerprint:  s.credentialFP,
+		PermissionsFingerprint: s.permissionsFP,
+		CertificateURI:         s.certificateURI,
+	}, s.authenticated, s.err
 }
 
 type localAuthorizerStub struct {
@@ -153,7 +160,14 @@ func newPolicyTestConnection(t *testing.T, policy *ConnectionPolicy) (*Connectio
 }
 
 func bindLocalIdentity(conn *Connection) {
+	bindLocalIdentityAs(conn, LocalRolePublisher)
+}
+
+// bindLocalIdentityAs binds an authenticated identity carrying role, which is
+// what decides a session's capability now that listeners no longer do.
+func bindLocalIdentityAs(conn *Connection, role LocalPrincipalRole) {
 	conn.localIdentity = &LocalSessionIdentity{
+		Role:                   role,
 		PrincipalID:            testLocalPrincipal,
 		CredentialFingerprint:  testCredentialFP,
 		PermissionsFingerprint: testPermissionsFP,
@@ -188,7 +202,7 @@ func TestLocalAuthenticationBindsVerifiedIdentity(t *testing.T) {
 		authenticated:  true,
 	}
 	authz := &localAuthorizerStub{}
-	conn, _ := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(authn, authz, authz, 0))
+	conn, _ := newPolicyTestConnection(t, NewLocalConnectionPolicy(authn, authz, authz, 0))
 	globalExternal := &externalAuthenticatorStub{}
 	conn.broker.SetAuthEngine(corebroker.NewAuthEngine(globalExternal, nil))
 	start := &codec.ConnectionStartOk{Mechanism: saslMechanismPlain, Response: "\x00atom-audit-publisher\x00secret"}
@@ -225,7 +239,7 @@ func TestLocalAuthenticationRejectsUnverifiedSelectedURI(t *testing.T) {
 		authenticated:  true,
 	}
 	authz := &localAuthorizerStub{}
-	conn, _ := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(authn, authz, authz, 0))
+	conn, _ := newPolicyTestConnection(t, NewLocalConnectionPolicy(authn, authz, authz, 0))
 	start := &codec.ConnectionStartOk{Mechanism: saslMechanismPlain, Response: "\x00atom-audit-publisher\x00secret"}
 	if err := conn.authenticate(start); err == nil {
 		t.Fatal("expected authentication rejection")
@@ -275,7 +289,7 @@ func TestLocalPublishOnlyMethodAllowlist(t *testing.T) {
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
 	for _, tc := range denied {
 		t.Run(tc.name, func(t *testing.T) {
-			conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+			conn, buf := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
 			bindLocalIdentity(conn)
 			ch := newChannel(conn, 1)
 			if err := ch.handleMethod(tc.method); err != nil {
@@ -294,7 +308,7 @@ func TestLocalPublishOnlyMethodAllowlist(t *testing.T) {
 
 func TestServerClosedChannelIgnoresPublishAfterDeniedMethod(t *testing.T) {
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
-	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	conn, buf := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
 	ch := newChannel(conn, 1)
 
@@ -341,7 +355,7 @@ func TestLocalPublishRequiresExactExchangeAndRoutingKey(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+			conn, buf := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
 			bindLocalIdentity(conn)
 			ch := newChannel(conn, 1)
 			err := ch.handleMethod(&codec.BasicPublish{Exchange: tc.exchange, RoutingKey: tc.routingKey})
@@ -370,7 +384,7 @@ func TestLocalPublishRequiresExactExchangeAndRoutingKey(t *testing.T) {
 // peer that actually authenticated.
 func TestLocalPrincipalStampsOwnIdentityOverRelayedOrigin(t *testing.T) {
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
-	conn, _ := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	conn, _ := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
 	qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: testAuditQueue, Type: qtypes.QueueTypeStream}}
 	conn.broker.queueManager = qm
@@ -410,35 +424,31 @@ func TestLocalPublishPathFollowsGrantKind(t *testing.T) {
 
 	tests := []struct {
 		name             string
-		policy           func(*localAuthorizerStub) *ConnectionPolicy
+		role             LocalPrincipalRole
 		routingKey       string
 		wantDurableCalls int
 	}{
 		{
-			name: "publish-only exact target appends durably",
-			policy: func(a *localAuthorizerStub) *ConnectionPolicy {
-				return NewLocalPublishOnlyConnectionPolicy(nil, a, a, 0)
-			},
+			name:             "publisher exact target appends durably",
+			role:             LocalRolePublisher,
 			routingKey:       testAuditQueue,
 			wantDurableCalls: 1,
 		},
 		{
 			name:             "service exact target appends durably",
-			policy:           func(a *localAuthorizerStub) *ConnectionPolicy { return NewLocalServiceConnectionPolicy(nil, a, a, 0) },
+			role:             LocalRoleService,
 			routingKey:       testAuditQueue,
 			wantDurableCalls: 1,
 		},
 		{
 			name:             "service prefix publishes as an ordinary topic",
-			policy:           func(a *localAuthorizerStub) *ConnectionPolicy { return NewLocalServiceConnectionPolicy(nil, a, a, 0) },
+			role:             LocalRoleService,
 			routingKey:       prefixedKey,
 			wantDurableCalls: 0,
 		},
 		{
-			name: "publish-only prefix publishes as an ordinary topic",
-			policy: func(a *localAuthorizerStub) *ConnectionPolicy {
-				return NewLocalPublishOnlyConnectionPolicy(nil, a, a, 0)
-			},
+			name:             "publisher prefix publishes as an ordinary topic",
+			role:             LocalRolePublisher,
 			routingKey:       prefixedKey,
 			wantDurableCalls: 0,
 		},
@@ -447,8 +457,8 @@ func TestLocalPublishPathFollowsGrantKind(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue, allowRoutingKeyPrefix: "m."}
-			conn, _ := newPolicyTestConnection(t, tc.policy(authz))
-			bindLocalIdentity(conn)
+			conn, _ := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
+			bindLocalIdentityAs(conn, tc.role)
 			qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: testAuditQueue, Type: qtypes.QueueTypeStream}}
 			conn.broker.queueManager = qm
 
@@ -470,7 +480,7 @@ func TestLocalPublishPathFollowsGrantKind(t *testing.T) {
 
 func TestLocalPolicyBypassesBrokerGlobalHooks(t *testing.T) {
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
-	conn, _ := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	conn, _ := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
 	hook := &hookCounter{}
 	conn.broker.SetBlockingHooks(corebroker.NewBlockingHookEngine(hook, corebroker.HookFailDeny, nil, nil, nil))
@@ -496,7 +506,7 @@ func TestLocalPolicyBypassesBrokerGlobalHooks(t *testing.T) {
 
 func TestLocalDurableStreamAppendFailureNacksConfirm(t *testing.T) {
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
-	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	conn, buf := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
 	qm := &mockChannelQueueManager{exactPublishErr: errors.New("disk full")}
 	conn.broker.queueManager = qm
@@ -526,7 +536,7 @@ func TestLocalDurableStreamAppendFailureNacksConfirm(t *testing.T) {
 
 func TestLocalDurableStreamPublishIsBounded(t *testing.T) {
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
-	conn, _ := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	conn, _ := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
 	qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: testAuditQueue, Type: qtypes.QueueTypeStream}}
 	conn.broker.queueManager = qm
@@ -629,7 +639,7 @@ func TestLocalDurableStreamPublishBoundsAbandonedAppends(t *testing.T) {
 	})
 
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
-	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	conn, buf := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
 	qm := &stalledStreamQueueManager{
 		release: make(chan struct{}),
@@ -719,7 +729,7 @@ func TestLocalDurableStreamPublishNacksWhenBarrierStalls(t *testing.T) {
 	t.Cleanup(func() { localPublishTimeout = previousTimeout })
 
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
-	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	conn, buf := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
 	qm := &blockingStreamQueueManager{
 		entered: make(chan struct{}),
@@ -759,7 +769,7 @@ func TestLocalDurableStreamPublishNacksWhenBarrierStalls(t *testing.T) {
 
 func TestLocalDurableStreamPublishNacksOnConnectionShutdown(t *testing.T) {
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
-	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	conn, buf := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
 	ctx, cancel := context.WithCancel(context.Background())
 	conn.ctx = ctx
@@ -779,7 +789,7 @@ func TestLocalDurableStreamPublishNacksOnConnectionShutdown(t *testing.T) {
 
 func TestLocalDurableStreamOversizeFailureNacksConfirm(t *testing.T) {
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
-	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	conn, buf := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
 	qm := &mockChannelQueueManager{exactPublishErr: queue.ErrQueueMessageTooLarge}
 	conn.broker.queueManager = qm
@@ -809,7 +819,7 @@ func TestLocalDurableStreamOversizeFailureNacksConfirm(t *testing.T) {
 
 func TestLocalDurableStreamSuccessAcksExactQueueOnly(t *testing.T) {
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
-	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	conn, buf := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
 	qm := &mockChannelQueueManager{}
 	conn.broker.queueManager = qm
@@ -839,7 +849,7 @@ func TestLocalDurableStreamSuccessAcksExactQueueOnly(t *testing.T) {
 
 func TestLocalPublishRechecksAuthorizationAfterContent(t *testing.T) {
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
-	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	conn, buf := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
 	qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: testAuditQueue, Type: qtypes.QueueTypeStream}}
 	conn.broker.queueManager = qm
@@ -869,7 +879,7 @@ func TestLocalCredentialRetiredBeforeRegistrationIsUnregistered(t *testing.T) {
 		authenticated:  true,
 	}
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
-	conn, _ := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(authn, authz, authz, 0))
+	conn, _ := newPolicyTestConnection(t, NewLocalConnectionPolicy(authn, authz, authz, 0))
 	transport := &memoryConn{}
 	conn.conn = transport
 	conn.writer = bufio.NewWriter(transport)
@@ -914,7 +924,7 @@ func TestLocalCredentialRetiredBeforeRegistrationIsUnregistered(t *testing.T) {
 
 func TestLocalPublishRejectsCredentialRetiredDuringContent(t *testing.T) {
 	authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue}
-	conn, buf := newPolicyTestConnection(t, NewLocalPublishOnlyConnectionPolicy(nil, authz, authz, 0))
+	conn, buf := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
 	bindLocalIdentity(conn)
 	qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: testAuditQueue, Type: qtypes.QueueTypeStream}}
 	conn.broker.queueManager = qm
@@ -947,7 +957,7 @@ func TestConnectionPolicyReservedPropertyTrust(t *testing.T) {
 	}{
 		{
 			name:   "local publish only policy is trusted",
-			policy: NewLocalPublishOnlyConnectionPolicy(nil, nil, nil, 0),
+			policy: NewLocalConnectionPolicy(nil, nil, nil, 0),
 			want:   true,
 		},
 		{

--- a/amqp/broker/policy_test.go
+++ b/amqp/broker/policy_test.go
@@ -23,6 +23,7 @@ import (
 	qstorage "github.com/absmach/fluxmq/queue/storage"
 	qtypes "github.com/absmach/fluxmq/queue/types"
 	"github.com/absmach/fluxmq/storage"
+	"github.com/absmach/fluxmq/topics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +34,7 @@ const (
 	testPermissionsFP  = "permissions-fingerprint"
 	testCertificateURI = "spiffe://absmach/atom/audit-publisher"
 	testConnectionID   = "test-conn"
-	testAuditQueue     = "atom-audit"
+	testAuditQueue     = "atom.events"
 	testServiceQueue   = "$queue/m"
 	testConsumerTag    = "reader"
 	testSiblingTag     = "sibling-reader"
@@ -488,7 +489,7 @@ func TestLocalPublishPathFollowsGrantKind(t *testing.T) {
 // a queue. Two routing keys would otherwise carry it there: one under a
 // "$queue/"-shaped prefix, and one that happens to name a configured stream.
 func TestLocalPrefixGrantNeverReachesAQueue(t *testing.T) {
-	const streamQueue = "atom-audit"
+	const streamQueue = "atom.events"
 
 	tests := []struct {
 		name       string
@@ -497,7 +498,7 @@ func TestLocalPrefixGrantNeverReachesAQueue(t *testing.T) {
 	}{
 		{
 			name:       "routing key naming a configured stream",
-			prefix:     "atom-",
+			prefix:     "atom.",
 			routingKey: streamQueue,
 		},
 		{
@@ -540,7 +541,7 @@ func TestLocalPrefixGrantNeverReachesAQueue(t *testing.T) {
 // pre-provisioned rather than declared on its own channel, so the lookup has to
 // reach global queue state.
 func TestPassiveDeclareResolvesProvisionedQueue(t *testing.T) {
-	const provisioned = "atom-audit"
+	const provisioned = "atom.events"
 
 	authz := &localAuthorizerStub{allowQueue: provisioned}
 	conn, buf := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
@@ -859,7 +860,7 @@ func TestLocalPolicyBypassesBrokerGlobalHooks(t *testing.T) {
 	if qm.publishCalls != 0 {
 		t.Fatalf("general queue publish calls = %d, want 0", qm.publishCalls)
 	}
-	if qm.exactPublishCalls != 1 || qm.exactStreamName != testAuditQueue || qm.exactPublish.Topic != "$queue/atom-audit" {
+	if qm.exactPublishCalls != 1 || qm.exactStreamName != testAuditQueue || qm.exactPublish.Topic != "$queue/atom.events" {
 		t.Fatalf("unexpected exact stream publish: calls=%d queue=%q request=%+v", qm.exactPublishCalls, qm.exactStreamName, qm.exactPublish)
 	}
 }
@@ -1358,7 +1359,7 @@ func TestExplicitExternalPolicyBypassesBrokerGlobalHooks(t *testing.T) {
 	conn.broker.SetCrossDeliver(func(context.Context, string, string, []byte, byte, map[string]string) {
 		delivered++
 	})
-	if err := conn.broker.router.Subscribe("mqtt-client", testAuditQueue, 1, storage.SubscribeOptions{}); err != nil {
+	if err := conn.broker.router.Subscribe("mqtt-client", topics.AMQPTopicToMQTT(testAuditQueue), 1, storage.SubscribeOptions{}); err != nil {
 		t.Fatalf("subscribe test route: %v", err)
 	}
 

--- a/amqp/broker/policy_test.go
+++ b/amqp/broker/policy_test.go
@@ -698,12 +698,112 @@ func TestLocalConsumeFailureKeepsSiblingSubscription(t *testing.T) {
 			assert.Equal(t, tc.withSibling, siblingRemains, "the sibling must survive its neighbour's failure")
 
 			if tc.wantUnsubscribe {
-				assert.Equal(t, []string{provisioned + "/"}, qm.unsubscribes)
+				defaultGroupID := queue.DefaultConsumerGroupID(PrefixedClientID(testConnectionID))
+				assert.Equal(t, []string{provisioned + "/" + defaultGroupID}, qm.unsubscribes)
 			} else {
 				assert.Empty(t, qm.unsubscribes, "compensating here would revoke the sibling's registration")
 			}
 		})
 	}
+}
+
+// Queue-manager ownership is connection-scoped. The implicit queue-mode group
+// and its explicit spelling are also the same registration, even when the
+// Basic.Consume instances live on different AMQP channels.
+func TestLocalConsumeFailureKeepsCrossChannelImplicitGroupSubscription(t *testing.T) {
+	const provisioned = "m"
+
+	authz := &localAuthorizerStub{allowQueue: provisioned}
+	conn, _ := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
+	bindLocalIdentityAs(conn, LocalRoleService)
+	qm := &mockChannelQueueManager{
+		queueCfg: &qtypes.QueueConfig{Name: provisioned, Type: qtypes.QueueTypeClassic},
+	}
+	conn.broker.queueManager = qm
+
+	siblingChannel := newChannel(conn, 1)
+	failingChannel := newChannel(conn, 2)
+	require.NoError(t, siblingChannel.handleMethod(&codec.BasicConsume{
+		Queue:       testServiceQueue,
+		ConsumerTag: testSiblingTag,
+		NoWait:      true,
+	}))
+
+	qm.existingSubErr = errors.New("group store unavailable")
+	defaultGroupID := queue.DefaultConsumerGroupID(PrefixedClientID(testConnectionID))
+	require.NoError(t, failingChannel.handleMethod(&codec.BasicConsume{
+		Queue:       testServiceQueue,
+		ConsumerTag: testConsumerTag,
+		NoWait:      true,
+		Arguments:   map[string]any{"x-consumer-group": defaultGroupID},
+	}))
+
+	siblingChannel.consumersMu.RLock()
+	_, siblingRemains := siblingChannel.consumers[testSiblingTag]
+	siblingChannel.consumersMu.RUnlock()
+	failingChannel.consumersMu.RLock()
+	_, failedRemains := failingChannel.consumers[testConsumerTag]
+	failingChannel.consumersMu.RUnlock()
+
+	assert.True(t, siblingRemains)
+	assert.False(t, failedRemains)
+	assert.Empty(t, qm.unsubscribes, "the cross-channel sibling still owns the canonical registration")
+	assert.Equal(t, uint64(1), conn.broker.stats.GetConsumers())
+}
+
+func TestSharedQueueRegistrationUnsubscribesOnlyAfterFinalConsumer(t *testing.T) {
+	const provisioned = "m"
+
+	newConsumers := func(t *testing.T) (*Connection, *mockChannelQueueManager, *Channel, *Channel) {
+		t.Helper()
+		authz := &localAuthorizerStub{allowQueue: provisioned}
+		conn, _ := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
+		bindLocalIdentityAs(conn, LocalRoleService)
+		qm := &mockChannelQueueManager{
+			queueCfg: &qtypes.QueueConfig{Name: provisioned, Type: qtypes.QueueTypeClassic},
+		}
+		conn.broker.queueManager = qm
+
+		first := newChannel(conn, 1)
+		second := newChannel(conn, 2)
+		require.NoError(t, first.handleMethod(&codec.BasicConsume{
+			Queue:       testServiceQueue,
+			ConsumerTag: testConsumerTag,
+			NoWait:      true,
+		}))
+		require.NoError(t, second.handleMethod(&codec.BasicConsume{
+			Queue:       testServiceQueue,
+			ConsumerTag: testSiblingTag,
+			NoWait:      true,
+		}))
+		return conn, qm, first, second
+	}
+
+	t.Run("basic cancel", func(t *testing.T) {
+		conn, qm, first, second := newConsumers(t)
+
+		require.NoError(t, first.handleMethod(&codec.BasicCancel{ConsumerTag: testConsumerTag, NoWait: true}))
+		assert.Empty(t, qm.unsubscribes, "the second channel still owns the registration")
+		assert.Equal(t, uint64(1), conn.broker.stats.GetConsumers())
+
+		require.NoError(t, second.handleMethod(&codec.BasicCancel{ConsumerTag: testSiblingTag, NoWait: true}))
+		defaultGroupID := queue.DefaultConsumerGroupID(PrefixedClientID(testConnectionID))
+		assert.Equal(t, []string{provisioned + "/" + defaultGroupID}, qm.unsubscribes)
+		assert.Equal(t, uint64(0), conn.broker.stats.GetConsumers())
+	})
+
+	t.Run("channel cleanup", func(t *testing.T) {
+		conn, qm, first, second := newConsumers(t)
+
+		first.cleanup()
+		assert.Empty(t, qm.unsubscribes, "the second channel still owns the registration")
+		assert.Equal(t, uint64(1), conn.broker.stats.GetConsumers())
+
+		second.cleanup()
+		defaultGroupID := queue.DefaultConsumerGroupID(PrefixedClientID(testConnectionID))
+		assert.Equal(t, []string{provisioned + "/" + defaultGroupID}, qm.unsubscribes)
+		assert.Equal(t, uint64(0), conn.broker.stats.GetConsumers())
+	})
 }
 
 func TestLocalStreamConsumeCannotChangeClassicQueueType(t *testing.T) {

--- a/amqp/broker/policy_test.go
+++ b/amqp/broker/policy_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -59,19 +60,29 @@ func (s *localAuthenticatorStub) AuthenticateLocal(_ context.Context, clientID, 
 }
 
 type localAuthorizerStub struct {
-	allowExchange   string
-	allowRoutingKey string
-	allowQueue      string
-	retired         bool
-	lastIdentity    LocalSessionIdentity
-	calls           int
-	subscribeCalls  int
+	allowExchange         string
+	allowRoutingKey       string
+	allowRoutingKeyPrefix string
+	allowQueue            string
+	retired               bool
+	lastIdentity          LocalSessionIdentity
+	calls                 int
+	subscribeCalls        int
 }
 
-func (s *localAuthorizerStub) CanPublishLocal(identity LocalSessionIdentity, exchange, routingKey string) bool {
+func (s *localAuthorizerStub) CanPublishLocal(identity LocalSessionIdentity, exchange, routingKey string) LocalPublishGrant {
 	s.calls++
 	s.lastIdentity = identity
-	return !s.retired && exchange == s.allowExchange && routingKey == s.allowRoutingKey
+	if s.retired {
+		return LocalPublishGrantNone
+	}
+	if exchange == s.allowExchange && routingKey == s.allowRoutingKey {
+		return LocalPublishGrantExactTarget
+	}
+	if s.allowRoutingKeyPrefix != "" && exchange == "" && strings.HasPrefix(routingKey, s.allowRoutingKeyPrefix) {
+		return LocalPublishGrantPrefix
+	}
+	return LocalPublishGrantNone
 }
 
 func (s *localAuthorizerStub) CanSubscribeLocal(identity LocalSessionIdentity, queue string) bool {
@@ -387,6 +398,73 @@ func TestLocalPrincipalStampsOwnIdentityOverRelayedOrigin(t *testing.T) {
 	}
 	if got := qm.exactPublish.Properties[corebroker.ProtocolProperty]; got != corebroker.ProtocolAMQP091 {
 		t.Fatalf("protocol = %q, want %q", got, corebroker.ProtocolAMQP091)
+	}
+}
+
+// The matched permission, not the listener, selects the delivery path. An exact
+// target names a protected stream and is appended durably; a prefix names no
+// queue and is published as an ordinary topic. Routing by listener instead would
+// make one permissions.publish entry mean two different contracts.
+func TestLocalPublishPathFollowsGrantKind(t *testing.T) {
+	const prefixedKey = "m.domain.c.channel"
+
+	tests := []struct {
+		name             string
+		policy           func(*localAuthorizerStub) *ConnectionPolicy
+		routingKey       string
+		wantDurableCalls int
+	}{
+		{
+			name: "publish-only exact target appends durably",
+			policy: func(a *localAuthorizerStub) *ConnectionPolicy {
+				return NewLocalPublishOnlyConnectionPolicy(nil, a, a, 0)
+			},
+			routingKey:       testAuditQueue,
+			wantDurableCalls: 1,
+		},
+		{
+			name:             "service exact target appends durably",
+			policy:           func(a *localAuthorizerStub) *ConnectionPolicy { return NewLocalServiceConnectionPolicy(nil, a, a, 0) },
+			routingKey:       testAuditQueue,
+			wantDurableCalls: 1,
+		},
+		{
+			name:             "service prefix publishes as an ordinary topic",
+			policy:           func(a *localAuthorizerStub) *ConnectionPolicy { return NewLocalServiceConnectionPolicy(nil, a, a, 0) },
+			routingKey:       prefixedKey,
+			wantDurableCalls: 0,
+		},
+		{
+			name: "publish-only prefix publishes as an ordinary topic",
+			policy: func(a *localAuthorizerStub) *ConnectionPolicy {
+				return NewLocalPublishOnlyConnectionPolicy(nil, a, a, 0)
+			},
+			routingKey:       prefixedKey,
+			wantDurableCalls: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			authz := &localAuthorizerStub{allowRoutingKey: testAuditQueue, allowRoutingKeyPrefix: "m."}
+			conn, _ := newPolicyTestConnection(t, tc.policy(authz))
+			bindLocalIdentity(conn)
+			qm := &mockChannelQueueManager{queueCfg: &qtypes.QueueConfig{Name: testAuditQueue, Type: qtypes.QueueTypeStream}}
+			conn.broker.queueManager = qm
+
+			ch := newChannel(conn, 1)
+			ch.pendingMethod = &codec.BasicPublish{RoutingKey: tc.routingKey}
+			ch.pendingHeader = &codec.ContentHeader{ClassID: codec.ClassBasic, BodySize: 2}
+			ch.pendingBody = []byte("{}")
+			ch.completePublish()
+
+			if qm.exactPublishCalls != tc.wantDurableCalls {
+				t.Fatalf("durable stream publish calls = %d, want %d", qm.exactPublishCalls, tc.wantDurableCalls)
+			}
+			if tc.wantDurableCalls > 0 && qm.exactStreamName != tc.routingKey {
+				t.Fatalf("durable stream = %q, want %q", qm.exactStreamName, tc.routingKey)
+			}
+		})
 	}
 }
 

--- a/amqp/broker/policy_test.go
+++ b/amqp/broker/policy_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/absmach/fluxmq/amqp/codec"
 	corebroker "github.com/absmach/fluxmq/broker"
 	"github.com/absmach/fluxmq/queue"
+	qstorage "github.com/absmach/fluxmq/queue/storage"
 	qtypes "github.com/absmach/fluxmq/queue/types"
 	"github.com/absmach/fluxmq/storage"
 )
@@ -31,6 +32,8 @@ const (
 	testCertificateURI = "spiffe://absmach/atom/audit-publisher"
 	testConnectionID   = "test-conn"
 	testAuditQueue     = "atom-audit"
+	testServiceQueue   = "$queue/m"
+	testConsumerTag    = "reader"
 )
 
 type localAuthenticatorStub struct {
@@ -544,7 +547,7 @@ func TestPassiveDeclareResolvesProvisionedQueue(t *testing.T) {
 	}
 
 	ch := newChannel(conn, 1)
-	if err := ch.handleQueueDeclare(&codec.QueueDeclare{Queue: provisioned, Passive: true}); err != nil {
+	if err := ch.handleMethod(&codec.QueueDeclare{Queue: provisioned, Passive: true}); err != nil {
 		t.Fatalf("passive declare of a provisioned queue: %v", err)
 	}
 	if err := conn.writer.Flush(); err != nil {
@@ -561,6 +564,112 @@ func TestPassiveDeclareResolvesProvisionedQueue(t *testing.T) {
 	}
 	if _, ok := decoded.(*codec.QueueDeclareOk); !ok {
 		t.Fatalf("expected QueueDeclareOk, got %T", decoded)
+	}
+}
+
+func TestLocalConsumeUsesNonMutatingQueueSubscription(t *testing.T) {
+	const provisioned = "m"
+	authz := &localAuthorizerStub{allowQueue: provisioned}
+	conn, buf := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
+	bindLocalIdentityAs(conn, LocalRoleService)
+	qm := &mockChannelQueueManager{
+		queueCfg: &qtypes.QueueConfig{Name: provisioned, Type: qtypes.QueueTypeClassic},
+	}
+	conn.broker.queueManager = qm
+
+	ch := newChannel(conn, 1)
+	if err := ch.handleMethod(&codec.BasicConsume{Queue: testServiceQueue, ConsumerTag: testConsumerTag}); err != nil {
+		t.Fatalf("consume provisioned queue: %v", err)
+	}
+	if err := conn.writer.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	if qm.existingSubs != 1 || qm.existingCursorSubs != 0 {
+		t.Fatalf("existing subscription calls = %d/%d, want 1/0", qm.existingSubs, qm.existingCursorSubs)
+	}
+	if qm.subscribeCalls != 0 || qm.cursorSubscribeCalls != 0 {
+		t.Fatalf("mutating subscription calls = %d/%d, want 0/0", qm.subscribeCalls, qm.cursorSubscribeCalls)
+	}
+	frames := readFramesFrom(t, buf, 0)
+	if len(frames) != 1 {
+		t.Fatalf("frames = %d, want one BasicConsumeOk", len(frames))
+	}
+	decoded, err := frames[0].Decode()
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if _, ok := decoded.(*codec.BasicConsumeOk); !ok {
+		t.Fatalf("method = %T, want *codec.BasicConsumeOk", decoded)
+	}
+}
+
+func TestLocalConsumeFailureRollsBackAndClosesChannel(t *testing.T) {
+	const provisioned = "m"
+	authz := &localAuthorizerStub{allowQueue: provisioned}
+	conn, buf := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
+	bindLocalIdentityAs(conn, LocalRoleService)
+	qm := &mockChannelQueueManager{
+		getQueueErr:    qstorage.ErrQueueNotFound,
+		existingSubErr: qstorage.ErrQueueNotFound,
+	}
+	conn.broker.queueManager = qm
+
+	ch := newChannel(conn, 1)
+	if err := ch.handleMethod(&codec.BasicConsume{Queue: testServiceQueue, ConsumerTag: testConsumerTag}); err != nil {
+		t.Fatalf("consume missing queue: %v", err)
+	}
+	if err := conn.writer.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	ch.consumersMu.RLock()
+	consumerCount := len(ch.consumers)
+	ch.consumersMu.RUnlock()
+	if consumerCount != 0 {
+		t.Fatalf("consumer registrations = %d, want 0 after failed subscribe", consumerCount)
+	}
+	if got := conn.broker.stats.GetConsumers(); got != 0 {
+		t.Fatalf("consumer stat = %d, want 0 after failed subscribe", got)
+	}
+	closeMethod := decodeSingleChannelClose(t, buf)
+	if closeMethod.ReplyCode != codec.NotFound {
+		t.Fatalf("reply code = %d, want %d", closeMethod.ReplyCode, codec.NotFound)
+	}
+	if closeMethod.ClassID != codec.ClassBasic || closeMethod.MethodID != codec.MethodBasicConsume {
+		t.Fatalf("close method = %d/%d, want basic.consume", closeMethod.ClassID, closeMethod.MethodID)
+	}
+}
+
+func TestLocalStreamConsumeCannotChangeClassicQueueType(t *testing.T) {
+	const provisioned = "m"
+	authz := &localAuthorizerStub{allowQueue: provisioned}
+	conn, buf := newPolicyTestConnection(t, NewLocalConnectionPolicy(nil, authz, authz, 0))
+	bindLocalIdentityAs(conn, LocalRoleService)
+	qm := &mockChannelQueueManager{
+		queueCfg:       &qtypes.QueueConfig{Name: provisioned, Type: qtypes.QueueTypeClassic},
+		existingSubErr: queue.ErrQueueNotStream,
+	}
+	conn.broker.queueManager = qm
+
+	ch := newChannel(conn, 1)
+	if err := ch.handleMethod(&codec.BasicConsume{
+		Queue:       testServiceQueue,
+		ConsumerTag: testConsumerTag,
+		Arguments:   map[string]any{"x-stream-offset": "first"},
+	}); err != nil {
+		t.Fatalf("consume classic queue with stream cursor: %v", err)
+	}
+	if err := conn.writer.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	closeMethod := decodeSingleChannelClose(t, buf)
+	if closeMethod.ReplyCode != codec.PreconditionFailed {
+		t.Fatalf("reply code = %d, want %d", closeMethod.ReplyCode, codec.PreconditionFailed)
+	}
+	if qm.existingCursorSubs != 1 || qm.cursorSubscribeCalls != 0 {
+		t.Fatalf("cursor subscription calls = existing:%d mutating:%d, want 1/0", qm.existingCursorSubs, qm.cursorSubscribeCalls)
 	}
 }
 

--- a/amqp/broker/policy_test.go
+++ b/amqp/broker/policy_test.go
@@ -61,15 +61,23 @@ func (s *localAuthenticatorStub) AuthenticateLocal(_ context.Context, clientID, 
 type localAuthorizerStub struct {
 	allowExchange   string
 	allowRoutingKey string
+	allowQueue      string
 	retired         bool
 	lastIdentity    LocalSessionIdentity
 	calls           int
+	subscribeCalls  int
 }
 
 func (s *localAuthorizerStub) CanPublishLocal(identity LocalSessionIdentity, exchange, routingKey string) bool {
 	s.calls++
 	s.lastIdentity = identity
 	return !s.retired && exchange == s.allowExchange && routingKey == s.allowRoutingKey
+}
+
+func (s *localAuthorizerStub) CanSubscribeLocal(identity LocalSessionIdentity, queue string) bool {
+	s.subscribeCalls++
+	s.lastIdentity = identity
+	return !s.retired && queue != "" && queue == s.allowQueue
 }
 
 func (s *localAuthorizerStub) IsSessionActive(identity LocalSessionIdentity) bool {
@@ -317,7 +325,7 @@ func TestLocalPublishRequiresExactExchangeAndRoutingKey(t *testing.T) {
 		// amq.default names the same default exchange the router resolves "" to,
 		// so the ACL must reach the same decision for both spellings.
 		{"explicit default alias", "amq.default", testAuditQueue, true},
-		{"wrong routing key", "", "other", false},
+		{"wrong routing key", "", testOtherTarget, false},
 		{"wrong exchange", "events", testAuditQueue, false},
 	}
 	for _, tc := range tests {

--- a/amqp/broker/stats.go
+++ b/amqp/broker/stats.go
@@ -30,6 +30,7 @@ type Stats struct {
 	localAuthSuccess       atomic.Uint64
 	localAuthFailures      atomic.Uint64
 	localPublishDenials    atomic.Uint64
+	localSubscribeDenials  atomic.Uint64
 	localOperationDenials  atomic.Uint64
 	localConnections       atomic.Uint64
 	localReloadSuccess     atomic.Uint64
@@ -71,6 +72,10 @@ func (s *Stats) IncrementLocalPublishDenials() {
 	s.localPublishDenials.Add(1)
 }
 
+func (s *Stats) IncrementLocalSubscribeDenials() {
+	s.localSubscribeDenials.Add(1)
+}
+
 func (s *Stats) IncrementLocalOperationDenials() {
 	s.localOperationDenials.Add(1)
 }
@@ -110,6 +115,10 @@ func (s *Stats) GetLocalAuthSuccess() uint64   { return s.localAuthSuccess.Load(
 func (s *Stats) GetLocalAuthFailures() uint64  { return s.localAuthFailures.Load() }
 func (s *Stats) GetLocalPublishDenials() uint64 {
 	return s.localPublishDenials.Load()
+}
+
+func (s *Stats) GetLocalSubscribeDenials() uint64 {
+	return s.localSubscribeDenials.Load()
 }
 
 func (s *Stats) GetLocalOperationDenials() uint64 {

--- a/amqp1/broker/broker.go
+++ b/amqp1/broker/broker.go
@@ -212,6 +212,10 @@ func (b *Broker) DeliverToClient(ctx context.Context, clientID string, msg any) 
 		if props != nil {
 			amqpMsg.ApplicationProperties = make(map[string]any, len(props))
 			for k, v := range props {
+				// Broker-internal state is never revealed to a remote receiver.
+				if corebroker.IsReservedProperty(k) {
+					continue
+				}
 				amqpMsg.ApplicationProperties[k] = v
 			}
 		}

--- a/amqp1/broker/broker_test.go
+++ b/amqp1/broker/broker_test.go
@@ -382,7 +382,7 @@ func TestTransferFromClientClientIDProperty(t *testing.T) {
 		Name:                 testSendLink,
 		Handle:               0,
 		Role:                 performatives.RoleSender,
-		Target:               &performatives.Target{Address: "test.ingest"},
+		Target:               &performatives.Target{Address: testIngestAddress},
 		InitialDeliveryCount: 0,
 	}
 	body, err := attach.Encode()
@@ -398,8 +398,8 @@ func TestTransferFromClientClientIDProperty(t *testing.T) {
 	assert.Equal(t, performatives.DescriptorFlow, desc)
 
 	msg := &message.Message{
-		Properties:            &message.Properties{To: "test.ingest"},
-		ApplicationProperties: map[string]any{"trace": "abc"},
+		Properties:            &message.Properties{To: testIngestAddress},
+		ApplicationProperties: map[string]any{testTraceKey: testTraceValue},
 		Data:                  [][]byte{[]byte("payload")},
 	}
 	msgBytes, err := msg.Encode()
@@ -418,11 +418,277 @@ func TestTransferFromClientClientIDProperty(t *testing.T) {
 
 	select {
 	case gotProps := <-propsCh:
-		require.Equal(t, "abc", gotProps["trace"])
+		require.Equal(t, testTraceValue, gotProps[testTraceKey])
 		require.Equal(t, PrefixedClientID("sender-client"), gotProps[corebroker.ClientIDProperty])
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for cross-deliver callback")
 	}
+}
+
+// AMQP 1.0 has no trusted listener, so every connection is a remote client:
+// reserved properties are dropped on ingress and cannot be forged.
+func TestTransferFromClientDropsReservedProperties(t *testing.T) {
+	b, c := setupBrokerAndPipe(t)
+	defer b.Close()
+	defer c.Close()
+
+	reserved := corebroker.ReservedPropertyPrefix + "re.trace"
+
+	require.NoError(t, b.router.Subscribe("mqtt-client", "test/ingest", 1, storage.SubscribeOptions{}))
+
+	propsCh := make(chan map[string]string, 1)
+	b.SetCrossDeliver(func(_ context.Context, _ string, _ string, _ []byte, _ byte, props map[string]string) {
+		propsCh <- cloneStringMap(props)
+	})
+
+	doAMQPHandshake(t, c, "sender-client")
+	doBeginSession(t, c, 0)
+
+	attach := &performatives.Attach{
+		Name:                 testSendLink,
+		Handle:               0,
+		Role:                 performatives.RoleSender,
+		Target:               &performatives.Target{Address: testIngestAddress},
+		InitialDeliveryCount: 0,
+	}
+	body, err := attach.Encode()
+	require.NoError(t, err)
+	require.NoError(t, c.WritePerformative(0, body))
+
+	desc, err := readDescriptor(t, c)
+	require.NoError(t, err)
+	assert.Equal(t, performatives.DescriptorAttach, desc)
+
+	desc, err = readDescriptor(t, c)
+	require.NoError(t, err)
+	assert.Equal(t, performatives.DescriptorFlow, desc)
+
+	msg := &message.Message{
+		Properties:            &message.Properties{To: testIngestAddress},
+		ApplicationProperties: map[string]any{reserved: testRuleTrace, testTraceKey: testTraceValue},
+		Data:                  [][]byte{[]byte("payload")},
+	}
+	msgBytes, err := msg.Encode()
+	require.NoError(t, err)
+
+	did := uint32(0)
+	mf := uint32(0)
+	transfer := &performatives.Transfer{
+		Handle:        0,
+		DeliveryID:    &did,
+		DeliveryTag:   []byte{0x01},
+		MessageFormat: &mf,
+		Settled:       true,
+	}
+	require.NoError(t, c.WriteTransfer(0, transfer, msgBytes))
+
+	select {
+	case gotProps := <-propsCh:
+		assert.NotContains(t, gotProps, reserved, "reserved property must not be forgeable by a remote sender")
+		assert.Equal(t, testTraceValue, gotProps[testTraceKey])
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for cross-deliver callback")
+	}
+}
+
+// Identity and origin protocol come from the authenticated connection. AMQP 1.0
+// has no trusted listener, so a sender may not attribute its publication to
+// another principal or claim it arrived over another protocol.
+func TestTransferFromClientRejectsForgedIdentity(t *testing.T) {
+	b, c := setupBrokerAndPipe(t)
+	defer b.Close()
+	defer c.Close()
+
+	require.NoError(t, b.router.Subscribe("mqtt-client", "test/ingest", 1, storage.SubscribeOptions{}))
+
+	propsCh := make(chan map[string]string, 1)
+	b.SetCrossDeliver(func(_ context.Context, _ string, _ string, _ []byte, _ byte, props map[string]string) {
+		propsCh <- cloneStringMap(props)
+	})
+
+	doAMQPHandshake(t, c, "sender-client")
+	doBeginSession(t, c, 0)
+
+	attach := &performatives.Attach{
+		Name:                 testSendLink,
+		Handle:               0,
+		Role:                 performatives.RoleSender,
+		Target:               &performatives.Target{Address: testIngestAddress},
+		InitialDeliveryCount: 0,
+	}
+	body, err := attach.Encode()
+	require.NoError(t, err)
+	require.NoError(t, c.WritePerformative(0, body))
+
+	desc, err := readDescriptor(t, c)
+	require.NoError(t, err)
+	assert.Equal(t, performatives.DescriptorAttach, desc)
+
+	desc, err = readDescriptor(t, c)
+	require.NoError(t, err)
+	assert.Equal(t, performatives.DescriptorFlow, desc)
+
+	msg := &message.Message{
+		Properties: &message.Properties{To: testIngestAddress},
+		ApplicationProperties: map[string]any{
+			corebroker.ExternalIDProperty: "victim-tenant",
+			corebroker.ProtocolProperty:   corebroker.ProtocolHTTP,
+			corebroker.ClientIDProperty:   "someone-else",
+		},
+		Data: [][]byte{[]byte("payload")},
+	}
+	msgBytes, err := msg.Encode()
+	require.NoError(t, err)
+
+	did := uint32(0)
+	mf := uint32(0)
+	transfer := &performatives.Transfer{
+		Handle:        0,
+		DeliveryID:    &did,
+		DeliveryTag:   []byte{0x01},
+		MessageFormat: &mf,
+		Settled:       true,
+	}
+	require.NoError(t, c.WriteTransfer(0, transfer, msgBytes))
+
+	select {
+	case gotProps := <-propsCh:
+		// No auth engine is configured, so no external identity resolves and the
+		// forged one must be discarded rather than left in place.
+		assert.NotContains(t, gotProps, corebroker.ExternalIDProperty)
+		assert.Equal(t, corebroker.ProtocolAMQP1, gotProps[corebroker.ProtocolProperty])
+		assert.Equal(t, PrefixedClientID("sender-client"), gotProps[corebroker.ClientIDProperty])
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for cross-deliver callback")
+	}
+}
+
+// Pub/sub egress mirrors ingress: a remote receiver never observes
+// broker-internal state, while ordinary properties are delivered.
+func TestPublishOmitsReservedPropertiesFromDelivery(t *testing.T) {
+	b, c := setupBrokerAndPipe(t)
+	defer b.Close()
+	defer c.Close()
+
+	reserved := corebroker.ReservedPropertyPrefix + "re.trace"
+
+	doAMQPHandshake(t, c, "pubsub-client")
+	doBeginSession(t, c, 0)
+
+	attachReceiver(t, b, c, "pubsub-client", "test/pubsub")
+
+	props := map[string]string{reserved: testRuleTrace, testTraceKey: testTraceValue}
+	go b.Publish(context.Background(), "test/pubsub", []byte("hello amqp"), props)
+
+	msg := readDeliveredMessage(t, c)
+	assert.NotContains(t, msg.ApplicationProperties, reserved)
+	assert.Equal(t, testTraceValue, msg.ApplicationProperties[testTraceKey])
+}
+
+// Queue delivery is a second egress path and must apply the same boundary.
+func TestDeliverToClientOmitsReservedProperties(t *testing.T) {
+	b, c := setupBrokerAndPipe(t)
+	defer b.Close()
+	defer c.Close()
+
+	reserved := corebroker.ReservedPropertyPrefix + "re.trace"
+
+	doAMQPHandshake(t, c, "queue-client")
+	doBeginSession(t, c, 0)
+
+	attachReceiver(t, b, c, "queue-client", "test/pubsub")
+
+	stored := &storage.Message{
+		Topic:      "test/pubsub",
+		Payload:    []byte("hello queue"),
+		Properties: map[string]string{reserved: testRuleTrace, testTraceKey: testTraceValue},
+	}
+	go b.DeliverToClient(context.Background(), corebroker.AMQP1ClientPrefix+"queue-client", stored) //nolint:errcheck // delivery error surfaces as a read timeout below
+
+	msg := readDeliveredMessage(t, c)
+	assert.NotContains(t, msg.ApplicationProperties, reserved)
+	assert.Equal(t, testTraceValue, msg.ApplicationProperties[testTraceKey])
+}
+
+// attachReceiver attaches a receiver link on handle 0 for address and grants it
+// credit, returning once the broker has applied the credit so the caller can
+// publish without racing the Flow.
+func attachReceiver(t *testing.T, b *Broker, c *amqpconn.Connection, containerID, address string) {
+	t.Helper()
+
+	attach := &performatives.Attach{
+		Name:   testRecvLink,
+		Handle: 0,
+		Role:   performatives.RoleReceiver,
+		Source: &performatives.Source{Address: address},
+	}
+	body, err := attach.Encode()
+	require.NoError(t, err)
+	require.NoError(t, c.WritePerformative(0, body))
+
+	desc, err := readDescriptor(t, c)
+	require.NoError(t, err)
+	require.Equal(t, performatives.DescriptorAttach, desc)
+
+	h := uint32(0)
+	dc := uint32(0)
+	lc := uint32(10)
+	flow := &performatives.Flow{
+		IncomingWindow: 65535,
+		NextOutgoingID: 0,
+		OutgoingWindow: 65535,
+		Handle:         &h,
+		DeliveryCount:  &dc,
+		LinkCredit:     &lc,
+	}
+	body, err = flow.Encode()
+	require.NoError(t, err)
+	require.NoError(t, c.WritePerformative(0, body))
+
+	require.Eventually(t, func() bool {
+		return senderLinkCredit(b, containerID, 0, 0) > 0
+	}, 2*time.Second, time.Millisecond, "broker did not apply link credit")
+}
+
+// senderLinkCredit reads the broker-side credit of a sender link, so tests can
+// wait for a Flow to be applied instead of sleeping.
+func senderLinkCredit(b *Broker, containerID string, channel uint16, handle uint32) uint32 {
+	val, ok := b.connections.Load(containerID)
+	if !ok {
+		return 0
+	}
+	conn := val.(*Connection)
+
+	conn.sessionsMu.RLock()
+	sess, ok := conn.sessions[channel]
+	conn.sessionsMu.RUnlock()
+	if !ok {
+		return 0
+	}
+
+	sess.linksMu.RLock()
+	link, ok := sess.links[handle]
+	sess.linksMu.RUnlock()
+	if !ok {
+		return 0
+	}
+
+	link.mu.Lock()
+	defer link.mu.Unlock()
+	return link.credit
+}
+
+// readDeliveredMessage reads one Transfer and decodes its message body.
+func readDeliveredMessage(t *testing.T, c *amqpconn.Connection) *message.Message {
+	t.Helper()
+
+	_, desc, _, payload, err := c.ReadPerformative()
+	require.NoError(t, err)
+	require.Equal(t, performatives.DescriptorTransfer, desc)
+
+	msg, err := message.Decode(payload)
+	require.NoError(t, err)
+	return msg
 }
 
 func TestQueueTransferCarriesClientID(t *testing.T) {
@@ -461,7 +727,7 @@ func TestQueueTransferCarriesClientID(t *testing.T) {
 
 	msg := &message.Message{
 		Properties:            &message.Properties{To: "$queue/orders/process"},
-		ApplicationProperties: map[string]any{"trace": "abc"},
+		ApplicationProperties: map[string]any{testTraceKey: testTraceValue},
 		Data:                  [][]byte{[]byte("payload")},
 	}
 	msgBytes, err := msg.Encode()
@@ -481,7 +747,7 @@ func TestQueueTransferCarriesClientID(t *testing.T) {
 	select {
 	case publish := <-mockQM.publishCh:
 		require.Equal(t, PrefixedClientID("sender-client"), publish.ClientID)
-		require.Equal(t, "abc", publish.Properties["trace"])
+		require.Equal(t, testTraceValue, publish.Properties[testTraceKey])
 		require.Equal(t, PrefixedClientID("sender-client"), publish.Properties[corebroker.ClientIDProperty])
 	case <-time.After(2 * time.Second):
 		t.Fatal("timed out waiting for queue publish")

--- a/amqp1/broker/consts_test.go
+++ b/amqp1/broker/consts_test.go
@@ -4,6 +4,10 @@
 package broker
 
 const (
-	testKeyOperation = "operation"
-	testKeyType      = "type"
+	testKeyOperation  = "operation"
+	testKeyType       = "type"
+	testIngestAddress = "test.ingest"
+	testTraceValue    = "abc"
+	testTraceKey      = "trace"
+	testRuleTrace     = `["rule-a"]`
 )

--- a/amqp1/broker/link.go
+++ b/amqp1/broker/link.go
@@ -280,22 +280,26 @@ func (l *Link) receiveTransfer(transfer *performatives.Transfer, payload []byte)
 	if auth != nil {
 		externalID = auth.ExternalID(clientID)
 	}
+	// AMQP 1.0 has no trusted listener: every connection authenticates as a
+	// remote client, so broker-internal properties are dropped on ingress and
+	// cannot be forged by a publisher.
 	props := make(map[string]string, len(msg.ApplicationProperties)+1)
 	for k, v := range msg.ApplicationProperties {
+		if corebroker.IsReservedProperty(k) {
+			continue
+		}
 		if s, ok := v.(string); ok {
 			props[k] = s
 		}
 	}
+	// Identity and origin are stamped from the authenticated connection, never
+	// read from the message: a sender may not attribute its publication to
+	// another principal or to another protocol.
 	props = corebroker.AddClientIDProperty(props, clientID)
-	if _, set := props[corebroker.ProtocolProperty]; !set {
-		props[corebroker.ProtocolProperty] = corebroker.ProtocolAMQP1
-	}
-	if _, set := props[corebroker.ExternalIDProperty]; !set {
-		if auth != nil {
-			if externalID := auth.ExternalID(clientID); externalID != "" {
-				props[corebroker.ExternalIDProperty] = externalID
-			}
-		}
+	props[corebroker.ProtocolProperty] = corebroker.ProtocolAMQP1
+	delete(props, corebroker.ExternalIDProperty)
+	if externalID != "" {
+		props[corebroker.ExternalIDProperty] = externalID
 	}
 	hookReq, ok := l.session.conn.broker.ApplyPublishHooks(l.session.conn.ctx, clientID, externalID, topic, data, props)
 	if !ok {
@@ -384,6 +388,10 @@ func (l *Link) sendMessage(topic string, payload []byte, props map[string]string
 	if len(props) > 0 {
 		msg.ApplicationProperties = make(map[string]any, len(props))
 		for k, v := range props {
+			// Broker-internal state is never revealed to a remote receiver.
+			if corebroker.IsReservedProperty(k) {
+				continue
+			}
 			msg.ApplicationProperties[k] = v
 		}
 	}

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -630,11 +630,15 @@ components:
         publish_denied:
           type: integer
           format: uint64
-          description: Local-principal publications denied by the exact-match ACL
+          description: Local-principal publications denied by the publish ACL
+        subscribe_denied:
+          type: integer
+          format: uint64
+          description: Local-principal consumer operations denied by the subscribe ACL
         operation_denied:
           type: integer
           format: uint64
-          description: Non-publish AMQP operations denied on the internal listener
+          description: AMQP operations denied because the principal's role does not permit them
 
     AMQPLocalReloadStats:
       type: object

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -32,6 +32,15 @@ type QueueSubscriber interface {
 	Unsubscribe(ctx context.Context, queueName, pattern, clientID, groupID string) error
 }
 
+// ExistingQueueSubscriber manages subscriptions without creating queues or
+// changing their configured type. Protocol authorization paths that grant read
+// access only use this interface so consuming cannot become an administrative
+// queue mutation.
+type ExistingQueueSubscriber interface {
+	SubscribeExisting(ctx context.Context, queueName, pattern, clientID, groupID, proxyNodeID string) error
+	SubscribeExistingWithCursor(ctx context.Context, queueName, pattern, clientID, groupID, proxyNodeID string, cursor *types.CursorOption) error
+}
+
 // QueueAcknowledger handles queue delivery acknowledgments.
 type QueueAcknowledger interface {
 	// Ack acknowledges successful processing of a message by a consumer group.

--- a/broker/localauth/store.go
+++ b/broker/localauth/store.go
@@ -34,16 +34,17 @@ func (f CredentialFingerprint) String() string {
 	return hex.EncodeToString(f[:8])
 }
 
-// PermissionsFingerprint identifies the exact publish ACL bound to a session.
-// It is comparable and contains no credential material.
+// PermissionsFingerprint identifies the exact publish and subscribe ACLs bound
+// to a session. It is comparable and contains no credential material. Both ACLs
+// share one fingerprint so that narrowing either revokes the session.
 type PermissionsFingerprint [sha256.Size]byte
 
 // Authentication describes a successfully authenticated local principal.
 type Authentication struct {
-	Principal                     string
-	CertificateURISAN             string
-	CredentialFingerprint         CredentialFingerprint
-	PublishPermissionsFingerprint PermissionsFingerprint
+	Principal              string
+	CertificateURISAN      string
+	CredentialFingerprint  CredentialFingerprint
+	PermissionsFingerprint PermissionsFingerprint
 }
 
 // PublishTarget is an exact AMQP exchange and routing-key pair.
@@ -64,11 +65,12 @@ type snapshot struct {
 }
 
 type principal struct {
-	certificateURISAN  string
-	current            CredentialFingerprint
-	previous           *CredentialFingerprint
-	publish            map[PublishTarget]struct{}
-	publishPermissions PermissionsFingerprint
+	certificateURISAN string
+	current           CredentialFingerprint
+	previous          *CredentialFingerprint
+	publish           map[PublishTarget]struct{}
+	subscribe         map[string]struct{}
+	permissions       PermissionsFingerprint
 }
 
 // New loads and validates a local-principal snapshot.
@@ -137,16 +139,16 @@ func (s *Store) Authenticate(username, secret, certificateURISAN string) (Authen
 	}
 
 	return Authentication{
-		Principal:                     username,
-		CertificateURISAN:             certificateURISAN,
-		CredentialFingerprint:         candidate,
-		PublishPermissionsFingerprint: principal.publishPermissions,
+		Principal:              username,
+		CertificateURISAN:      certificateURISAN,
+		CredentialFingerprint:  candidate,
+		PermissionsFingerprint: principal.permissions,
 	}, true
 }
 
 // IsActive reports whether an authenticated session is still valid in the
-// latest snapshot. It detects removed principals, SAN or publish-permission
-// changes, and retired credentials.
+// latest snapshot. It detects removed principals, SAN or permission changes,
+// and retired credentials.
 func (s *Store) IsActive(authentication Authentication) bool {
 	current := s.current.Load()
 	return authenticationActive(current, authentication)
@@ -165,6 +167,20 @@ func (s *Store) CanPublishAuthenticated(authentication Authentication, exchange,
 	return allowed
 }
 
+// CanSubscribeAuthenticated checks the session credential and exact subscribe
+// ACL against one immutable snapshot, for the same reason CanPublishAuthenticated
+// does: loading both independently would leave a revocation race when a reload
+// lands between the two checks.
+func (s *Store) CanSubscribeAuthenticated(authentication Authentication, queue string) bool {
+	current := s.current.Load()
+	if !authenticationActive(current, authentication) {
+		return false
+	}
+	principal := current.principals[authentication.Principal]
+	_, allowed := principal.subscribe[queue]
+	return allowed
+}
+
 func authenticationActive(current *snapshot, authentication Authentication) bool {
 	if current == nil {
 		return false
@@ -173,7 +189,7 @@ func authenticationActive(current *snapshot, authentication Authentication) bool
 	if !ok || principal.certificateURISAN != authentication.CertificateURISAN {
 		return false
 	}
-	if subtle.ConstantTimeCompare(authentication.PublishPermissionsFingerprint[:], principal.publishPermissions[:]) != 1 {
+	if subtle.ConstantTimeCompare(authentication.PermissionsFingerprint[:], principal.permissions[:]) != 1 {
 		return false
 	}
 	if subtle.ConstantTimeCompare(authentication.CredentialFingerprint[:], principal.current[:]) == 1 {
@@ -214,12 +230,18 @@ func buildSnapshot(configs []config.LocalPrincipalConfig, generation uint64) (*s
 			publish[PublishTarget{Exchange: permission.Exchange, RoutingKey: permission.RoutingKey}] = struct{}{}
 		}
 
+		subscribe := make(map[string]struct{}, len(principalConfig.Permissions.Subscribe))
+		for _, queue := range principalConfig.Permissions.Subscribe {
+			subscribe[queue] = struct{}{}
+		}
+
 		principals[principalConfig.Name] = &principal{
-			certificateURISAN:  principalConfig.CertificateURISAN,
-			current:            current,
-			previous:           previous,
-			publish:            publish,
-			publishPermissions: fingerprintPublishPermissions(publish),
+			certificateURISAN: principalConfig.CertificateURISAN,
+			current:           current,
+			previous:          previous,
+			publish:           publish,
+			subscribe:         subscribe,
+			permissions:       fingerprintPermissions(publish, subscribe),
 		}
 	}
 
@@ -254,6 +276,14 @@ func principalsEqual(left, right *principal) bool {
 	}
 	for target := range left.publish {
 		if _, ok := right.publish[target]; !ok {
+			return false
+		}
+	}
+	if len(left.subscribe) != len(right.subscribe) {
+		return false
+	}
+	for queue := range left.subscribe {
+		if _, ok := right.subscribe[queue]; !ok {
 			return false
 		}
 	}
@@ -307,7 +337,7 @@ func loadFingerprint(field, filename string, required bool) (CredentialFingerpri
 	return fingerprint, nil
 }
 
-func fingerprintPublishPermissions(publish map[PublishTarget]struct{}) PermissionsFingerprint {
+func fingerprintPermissions(publish map[PublishTarget]struct{}, subscribe map[string]struct{}) PermissionsFingerprint {
 	targets := make([]PublishTarget, 0, len(publish))
 	for target := range publish {
 		targets = append(targets, target)
@@ -319,10 +349,22 @@ func fingerprintPublishPermissions(publish map[PublishTarget]struct{}) Permissio
 		return targets[i].Exchange < targets[j].Exchange
 	})
 
-	serialized := make([]byte, 0)
+	queues := make([]string, 0, len(subscribe))
+	for queue := range subscribe {
+		queues = append(queues, queue)
+	}
+	sort.Strings(queues)
+
+	// The two ACLs are length-prefixed and separated by their own counts, so no
+	// rearrangement of entries between them can produce a colliding digest.
+	serialized := binary.BigEndian.AppendUint64(nil, uint64(len(targets)))
 	for _, target := range targets {
 		serialized = appendLengthPrefixed(serialized, target.Exchange)
 		serialized = appendLengthPrefixed(serialized, target.RoutingKey)
+	}
+	serialized = binary.BigEndian.AppendUint64(serialized, uint64(len(queues)))
+	for _, queue := range queues {
+		serialized = appendLengthPrefixed(serialized, queue)
 	}
 	return PermissionsFingerprint(sha256.Sum256(serialized))
 }

--- a/broker/localauth/store.go
+++ b/broker/localauth/store.go
@@ -14,6 +14,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -69,8 +70,12 @@ type principal struct {
 	current           CredentialFingerprint
 	previous          *CredentialFingerprint
 	publish           map[PublishTarget]struct{}
-	subscribe         map[string]struct{}
-	permissions       PermissionsFingerprint
+	// publishPrefixes is sorted, so the fingerprint is stable and matching is
+	// deterministic. It holds a handful of entries at most, which is why a
+	// linear scan is preferred to another map.
+	publishPrefixes []string
+	subscribe       map[string]struct{}
+	permissions     PermissionsFingerprint
 }
 
 // New loads and validates a local-principal snapshot.
@@ -163,8 +168,20 @@ func (s *Store) CanPublishAuthenticated(authentication Authentication, exchange,
 		return false
 	}
 	principal := current.principals[authentication.Principal]
-	_, allowed := principal.publish[PublishTarget{Exchange: exchange, RoutingKey: routingKey}]
-	return allowed
+	if _, allowed := principal.publish[PublishTarget{Exchange: exchange, RoutingKey: routingKey}]; allowed {
+		return true
+	}
+	// A prefix permission grants the default exchange only, matching the
+	// exchange restriction config already enforces on every publish permission.
+	if exchange != "" {
+		return false
+	}
+	for _, publishPrefix := range principal.publishPrefixes {
+		if strings.HasPrefix(routingKey, publishPrefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // CanSubscribeAuthenticated checks the session credential and exact subscribe
@@ -226,9 +243,15 @@ func buildSnapshot(configs []config.LocalPrincipalConfig, generation uint64) (*s
 		}
 
 		publish := make(map[PublishTarget]struct{}, len(principalConfig.Permissions.Publish))
+		var publishPrefixes []string
 		for _, permission := range principalConfig.Permissions.Publish {
+			if permission.IsPrefix() {
+				publishPrefixes = append(publishPrefixes, permission.RoutingKeyPrefix)
+				continue
+			}
 			publish[PublishTarget{Exchange: permission.Exchange, RoutingKey: permission.RoutingKey}] = struct{}{}
 		}
+		sort.Strings(publishPrefixes)
 
 		subscribe := make(map[string]struct{}, len(principalConfig.Permissions.Subscribe))
 		for _, queue := range principalConfig.Permissions.Subscribe {
@@ -240,8 +263,9 @@ func buildSnapshot(configs []config.LocalPrincipalConfig, generation uint64) (*s
 			current:           current,
 			previous:          previous,
 			publish:           publish,
+			publishPrefixes:   publishPrefixes,
 			subscribe:         subscribe,
-			permissions:       fingerprintPermissions(publish, subscribe),
+			permissions:       fingerprintPermissions(publish, publishPrefixes, subscribe),
 		}
 	}
 
@@ -278,6 +302,9 @@ func principalsEqual(left, right *principal) bool {
 		if _, ok := right.publish[target]; !ok {
 			return false
 		}
+	}
+	if !slices.Equal(left.publishPrefixes, right.publishPrefixes) {
+		return false
 	}
 	if len(left.subscribe) != len(right.subscribe) {
 		return false
@@ -337,7 +364,7 @@ func loadFingerprint(field, filename string, required bool) (CredentialFingerpri
 	return fingerprint, nil
 }
 
-func fingerprintPermissions(publish map[PublishTarget]struct{}, subscribe map[string]struct{}) PermissionsFingerprint {
+func fingerprintPermissions(publish map[PublishTarget]struct{}, publishPrefixes []string, subscribe map[string]struct{}) PermissionsFingerprint {
 	targets := make([]PublishTarget, 0, len(publish))
 	for target := range publish {
 		targets = append(targets, target)
@@ -355,12 +382,16 @@ func fingerprintPermissions(publish map[PublishTarget]struct{}, subscribe map[st
 	}
 	sort.Strings(queues)
 
-	// The two ACLs are length-prefixed and separated by their own counts, so no
+	// Each ACL is length-prefixed and preceded by its own count, so no
 	// rearrangement of entries between them can produce a colliding digest.
 	serialized := binary.BigEndian.AppendUint64(nil, uint64(len(targets)))
 	for _, target := range targets {
 		serialized = appendLengthPrefixed(serialized, target.Exchange)
 		serialized = appendLengthPrefixed(serialized, target.RoutingKey)
+	}
+	serialized = binary.BigEndian.AppendUint64(serialized, uint64(len(publishPrefixes)))
+	for _, publishPrefix := range publishPrefixes {
+		serialized = appendLengthPrefixed(serialized, publishPrefix)
 	}
 	serialized = binary.BigEndian.AppendUint64(serialized, uint64(len(queues)))
 	for _, queue := range queues {

--- a/broker/localauth/store.go
+++ b/broker/localauth/store.go
@@ -35,15 +35,17 @@ func (f CredentialFingerprint) String() string {
 	return hex.EncodeToString(f[:8])
 }
 
-// PermissionsFingerprint identifies the exact publish and subscribe ACLs bound
-// to a session. It is comparable and contains no credential material. Both ACLs
-// share one fingerprint so that narrowing either revokes the session.
+// PermissionsFingerprint identifies the role and the exact publish and
+// subscribe ACLs bound to a session. It is comparable and contains no
+// credential material. All three share one fingerprint so that narrowing any of
+// them revokes the session, exactly as a credential rotation does.
 type PermissionsFingerprint [sha256.Size]byte
 
 // Authentication describes a successfully authenticated local principal.
 type Authentication struct {
 	Principal              string
 	CertificateURISAN      string
+	Role                   string
 	CredentialFingerprint  CredentialFingerprint
 	PermissionsFingerprint PermissionsFingerprint
 }
@@ -67,6 +69,7 @@ type snapshot struct {
 
 type principal struct {
 	certificateURISAN string
+	role              string
 	current           CredentialFingerprint
 	previous          *CredentialFingerprint
 	publish           map[PublishTarget]struct{}
@@ -146,6 +149,7 @@ func (s *Store) Authenticate(username, secret, certificateURISAN string) (Authen
 	return Authentication{
 		Principal:              username,
 		CertificateURISAN:      certificateURISAN,
+		Role:                   principal.role,
 		CredentialFingerprint:  candidate,
 		PermissionsFingerprint: principal.permissions,
 	}, true
@@ -281,14 +285,16 @@ func buildSnapshot(configs []config.LocalPrincipalConfig, generation uint64) (*s
 			subscribe[queue] = struct{}{}
 		}
 
+		role := principalConfig.EffectiveRole()
 		principals[principalConfig.Name] = &principal{
 			certificateURISAN: principalConfig.CertificateURISAN,
+			role:              role,
 			current:           current,
 			previous:          previous,
 			publish:           publish,
 			publishPrefixes:   publishPrefixes,
 			subscribe:         subscribe,
-			permissions:       fingerprintPermissions(publish, publishPrefixes, subscribe),
+			permissions:       fingerprintPermissions(role, publish, publishPrefixes, subscribe),
 		}
 	}
 
@@ -309,7 +315,7 @@ func snapshotsEqual(left, right *snapshot) bool {
 }
 
 func principalsEqual(left, right *principal) bool {
-	if left.certificateURISAN != right.certificateURISAN || left.current != right.current {
+	if left.certificateURISAN != right.certificateURISAN || left.role != right.role || left.current != right.current {
 		return false
 	}
 	if (left.previous == nil) != (right.previous == nil) {
@@ -387,7 +393,7 @@ func loadFingerprint(field, filename string, required bool) (CredentialFingerpri
 	return fingerprint, nil
 }
 
-func fingerprintPermissions(publish map[PublishTarget]struct{}, publishPrefixes []string, subscribe map[string]struct{}) PermissionsFingerprint {
+func fingerprintPermissions(role string, publish map[PublishTarget]struct{}, publishPrefixes []string, subscribe map[string]struct{}) PermissionsFingerprint {
 	targets := make([]PublishTarget, 0, len(publish))
 	for target := range publish {
 		targets = append(targets, target)
@@ -405,9 +411,12 @@ func fingerprintPermissions(publish map[PublishTarget]struct{}, publishPrefixes 
 	}
 	sort.Strings(queues)
 
-	// Each ACL is length-prefixed and preceded by its own count, so no
-	// rearrangement of entries between them can produce a colliding digest.
-	serialized := binary.BigEndian.AppendUint64(nil, uint64(len(targets)))
+	// The role leads, and each ACL is length-prefixed and preceded by its own
+	// count, so no rearrangement of entries between them can produce a colliding
+	// digest. Narrowing a role therefore revokes sessions the way an ACL change
+	// does, which is the property that keeps a capability from outliving it.
+	serialized := appendLengthPrefixed(nil, role)
+	serialized = binary.BigEndian.AppendUint64(serialized, uint64(len(targets)))
 	for _, target := range targets {
 		serialized = appendLengthPrefixed(serialized, target.Exchange)
 		serialized = appendLengthPrefixed(serialized, target.RoutingKey)

--- a/broker/localauth/store.go
+++ b/broker/localauth/store.go
@@ -159,33 +159,56 @@ func (s *Store) IsActive(authentication Authentication) bool {
 	return authenticationActive(current, authentication)
 }
 
-// CanPublishAuthenticated checks the session credential and exact publish ACL
-// against one immutable snapshot. Loading both independently would leave a
-// revocation race when a reload lands between the two checks.
-func (s *Store) CanPublishAuthenticated(authentication Authentication, exchange, routingKey string) bool {
+// PublishGrant reports which kind of publish permission matched. The caller
+// needs the kind and not merely a yes or no, because an exact target names a
+// durable stream while a prefix names no queue at all.
+type PublishGrant uint8
+
+const (
+	// PublishGrantNone means no permission matched.
+	PublishGrantNone PublishGrant = iota
+	// PublishGrantExactTarget matched an exact exchange and routing-key pair,
+	// which must also appear under queues as a protected durable stream.
+	PublishGrantExactTarget
+	// PublishGrantPrefix matched a routing-key prefix, which is checked against
+	// no queues entry.
+	PublishGrantPrefix
+)
+
+// Allowed reports whether the grant authorizes the publication.
+func (g PublishGrant) Allowed() bool {
+	return g != PublishGrantNone
+}
+
+// AuthorizePublish checks the session credential and publish ACL against one
+// immutable snapshot, returning the matching grant. Loading both independently
+// would leave a revocation race when a reload lands between the two checks, and
+// returning the grant rather than a bool spares the caller a second lookup that
+// would reopen the same race.
+func (s *Store) AuthorizePublish(authentication Authentication, exchange, routingKey string) PublishGrant {
 	current := s.current.Load()
 	if !authenticationActive(current, authentication) {
-		return false
+		return PublishGrantNone
 	}
 	principal := current.principals[authentication.Principal]
 	if _, allowed := principal.publish[PublishTarget{Exchange: exchange, RoutingKey: routingKey}]; allowed {
-		return true
+		return PublishGrantExactTarget
 	}
 	// A prefix permission grants the default exchange only, matching the
 	// exchange restriction config already enforces on every publish permission.
 	if exchange != "" {
-		return false
+		return PublishGrantNone
 	}
 	for _, publishPrefix := range principal.publishPrefixes {
 		if strings.HasPrefix(routingKey, publishPrefix) {
-			return true
+			return PublishGrantPrefix
 		}
 	}
-	return false
+	return PublishGrantNone
 }
 
 // CanSubscribeAuthenticated checks the session credential and exact subscribe
-// ACL against one immutable snapshot, for the same reason CanPublishAuthenticated
+// ACL against one immutable snapshot, for the same reason AuthorizePublish
 // does: loading both independently would leave a revocation race when a reload
 // lands between the two checks.
 func (s *Store) CanSubscribeAuthenticated(authentication Authentication, queue string) bool {

--- a/broker/localauth/store_test.go
+++ b/broker/localauth/store_test.go
@@ -22,7 +22,7 @@ const (
 	currentSecret  = "0123456789abcdef0123456789abcdef"
 	previousSecret = "abcdef0123456789abcdef0123456789"
 	nextSecret     = "fedcba9876543210fedcba9876543210"
-	auditQueue     = "atom-audit"
+	auditQueue     = "atom.events"
 )
 
 func TestAuthenticateAndAuthorize(t *testing.T) {
@@ -62,13 +62,13 @@ func TestAuthenticateAndAuthorize(t *testing.T) {
 		t.Fatal("wrong certificate URI SAN was accepted")
 	}
 
-	if !store.AuthorizePublish(authentication, "", "atom-audit").Allowed() {
+	if !store.AuthorizePublish(authentication, "", "atom.events").Allowed() {
 		t.Fatal("configured publish target was denied")
 	}
-	if store.AuthorizePublish(authentication, "events", "atom-audit").Allowed() {
+	if store.AuthorizePublish(authentication, "events", "atom.events").Allowed() {
 		t.Fatal("wrong exchange was allowed")
 	}
-	if store.AuthorizePublish(authentication, "", "atom-audit.other").Allowed() {
+	if store.AuthorizePublish(authentication, "", "atom.events.other").Allowed() {
 		t.Fatal("prefix routing key was allowed")
 	}
 }
@@ -137,7 +137,7 @@ func TestReloadIsAtomicAndRevokesRemovedCredentials(t *testing.T) {
 	if store.IsActive(oldAuthentication) {
 		t.Fatal("removed previous credential remains active")
 	}
-	if store.AuthorizePublish(oldAuthentication, "", "atom-audit").Allowed() {
+	if store.AuthorizePublish(oldAuthentication, "", "atom.events").Allowed() {
 		t.Fatal("session authenticated before reload can still publish with a retired credential")
 	}
 	if !store.IsActive(newAuthentication) {
@@ -165,7 +165,7 @@ func TestReloadRevokesChangedPublishPermissions(t *testing.T) {
 		t.Fatal("initial authentication failed")
 	}
 
-	principal.Permissions.Publish[0].RoutingKey = "atom-audit-v2"
+	principal.Permissions.Publish[0].RoutingKey = "atom.events.v2"
 	changed, err := store.Reload([]config.LocalPrincipalConfig{principal})
 	if err != nil {
 		t.Fatalf("Reload() error = %v", err)
@@ -176,7 +176,7 @@ func TestReloadRevokesChangedPublishPermissions(t *testing.T) {
 	if store.IsActive(authentication) {
 		t.Fatal("session authenticated against the replaced publish ACL remains active")
 	}
-	if store.AuthorizePublish(authentication, "", "atom-audit-v2").Allowed() {
+	if store.AuthorizePublish(authentication, "", "atom.events.v2").Allowed() {
 		t.Fatal("session authenticated against the old ACL used the replacement ACL")
 	}
 
@@ -184,7 +184,7 @@ func TestReloadRevokesChangedPublishPermissions(t *testing.T) {
 	if !ok {
 		t.Fatal("authentication against the replacement ACL failed")
 	}
-	if !store.IsActive(reauthenticated) || !store.AuthorizePublish(reauthenticated, "", "atom-audit-v2").Allowed() {
+	if !store.IsActive(reauthenticated) || !store.AuthorizePublish(reauthenticated, "", "atom.events.v2").Allowed() {
 		t.Fatal("session authenticated against the replacement ACL is not active")
 	}
 }
@@ -306,7 +306,7 @@ func TestConcurrentAuthenticationAndReload(t *testing.T) {
 			for range 500 {
 				authentication, ok := store.Authenticate(principalName, currentSecret, principalSAN)
 				if ok {
-					_ = store.AuthorizePublish(authentication, "", "atom-audit")
+					_ = store.AuthorizePublish(authentication, "", "atom.events")
 				}
 			}
 		}()
@@ -330,7 +330,7 @@ func principalConfig(current, previous string) config.LocalPrincipalConfig {
 		CurrentSecretFile:  current,
 		PreviousSecretFile: previous,
 		Permissions: config.LocalPermissionsConfig{
-			Publish: []config.LocalPublishPermission{{Exchange: "", RoutingKey: "atom-audit"}},
+			Publish: []config.LocalPublishPermission{{Exchange: "", RoutingKey: "atom.events"}},
 		},
 	}
 }

--- a/broker/localauth/store_test.go
+++ b/broker/localauth/store_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/absmach/fluxmq/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -20,6 +22,7 @@ const (
 	currentSecret  = "0123456789abcdef0123456789abcdef"
 	previousSecret = "abcdef0123456789abcdef0123456789"
 	nextSecret     = "fedcba9876543210fedcba9876543210"
+	auditQueue     = "atom-audit"
 )
 
 func TestAuthenticateAndAuthorize(t *testing.T) {
@@ -255,13 +258,22 @@ func TestStoreRejectsInvalidConfiguration(t *testing.T) {
 			wantError: "exchange must be empty; local principals may publish only through the AMQP default exchange",
 		},
 		{
-			name: "subscribe ACL is unsupported",
+			name: "subscribe ACL entry cannot be empty",
 			configs: func() []config.LocalPrincipalConfig {
 				principal := principalConfig(current, "")
-				principal.Permissions.Subscribe = []string{"atom-audit"}
+				principal.Permissions.Subscribe = []string{""}
 				return []config.LocalPrincipalConfig{principal}
 			},
-			wantError: "subscribe is unsupported; local principals are publish-only",
+			wantError: "permissions.subscribe[0] cannot be empty",
+		},
+		{
+			name: "subscribe ACL entry cannot be duplicated",
+			configs: func() []config.LocalPrincipalConfig {
+				principal := principalConfig(current, "")
+				principal.Permissions.Subscribe = []string{auditQueue, auditQueue}
+				return []config.LocalPrincipalConfig{principal}
+			},
+			wantError: "duplicates an earlier subscribe permission",
 		},
 	}
 
@@ -328,4 +340,76 @@ func writeSecret(t *testing.T, dir, name, contents string) string {
 		t.Fatalf("write secret: %v", err)
 	}
 	return filename
+}
+
+// A principal may consume only the queues its own ACL names, and narrowing that
+// ACL must revoke sessions that authenticated under the wider one.
+func TestSubscribeACL(t *testing.T) {
+	dir := t.TempDir()
+	current := writeSecret(t, dir, "current", currentSecret)
+
+	withSubscribe := func(queues ...string) []config.LocalPrincipalConfig {
+		principal := principalConfig(current, "")
+		principal.Permissions.Subscribe = queues
+		return []config.LocalPrincipalConfig{principal}
+	}
+
+	store, err := New(withSubscribe(auditQueue, "m"))
+	require.NoError(t, err)
+
+	authentication, ok := store.Authenticate(principalName, currentSecret, principalSAN)
+	require.True(t, ok, "current secret was rejected")
+
+	t.Run("named queue is allowed", func(t *testing.T) {
+		assert.True(t, store.CanSubscribeAuthenticated(authentication, "m"))
+	})
+	t.Run("unnamed queue is refused", func(t *testing.T) {
+		assert.False(t, store.CanSubscribeAuthenticated(authentication, "other"))
+	})
+	t.Run("empty queue is refused", func(t *testing.T) {
+		assert.False(t, store.CanSubscribeAuthenticated(authentication, ""))
+	})
+
+	t.Run("narrowing the ACL revokes the session", func(t *testing.T) {
+		changed, err := store.Reload(withSubscribe(auditQueue))
+		require.NoError(t, err)
+		require.True(t, changed, "dropping a subscribe target must be seen as a change")
+
+		assert.False(t, store.IsActive(authentication),
+			"a session bound to the wider ACL must not survive it")
+		assert.False(t, store.CanSubscribeAuthenticated(authentication, auditQueue),
+			"the retired session must not consume even a still-permitted queue")
+	})
+
+	t.Run("publish ACL is unaffected by subscribe permissions", func(t *testing.T) {
+		reauthenticated, ok := store.Authenticate(principalName, currentSecret, principalSAN)
+		require.True(t, ok)
+		assert.True(t, store.CanPublishAuthenticated(reauthenticated, "", auditQueue))
+		assert.False(t, store.CanSubscribeAuthenticated(reauthenticated, "m"))
+	})
+}
+
+// The two ACLs share one fingerprint, so swapping a target between them must
+// not produce the same digest.
+func TestPermissionsFingerprintSeparatesACLs(t *testing.T) {
+	dir := t.TempDir()
+	current := writeSecret(t, dir, "current", currentSecret)
+
+	fingerprintFor := func(t *testing.T, publish []config.LocalPublishPermission, subscribe []string) PermissionsFingerprint {
+		t.Helper()
+		principal := principalConfig(current, "")
+		principal.Permissions.Publish = publish
+		principal.Permissions.Subscribe = subscribe
+		store, err := New([]config.LocalPrincipalConfig{principal})
+		require.NoError(t, err)
+		authentication, ok := store.Authenticate(principalName, currentSecret, principalSAN)
+		require.True(t, ok)
+		return authentication.PermissionsFingerprint
+	}
+
+	publishOnly := fingerprintFor(t, []config.LocalPublishPermission{{RoutingKey: "shared"}}, nil)
+	subscribeOnly := fingerprintFor(t, []config.LocalPublishPermission{{RoutingKey: "other"}}, []string{"shared"})
+
+	assert.NotEqual(t, publishOnly, subscribeOnly,
+		"a target moved between the publish and subscribe ACLs must change the fingerprint")
 }

--- a/broker/localauth/store_test.go
+++ b/broker/localauth/store_test.go
@@ -62,13 +62,13 @@ func TestAuthenticateAndAuthorize(t *testing.T) {
 		t.Fatal("wrong certificate URI SAN was accepted")
 	}
 
-	if !store.CanPublishAuthenticated(authentication, "", "atom-audit") {
+	if !store.AuthorizePublish(authentication, "", "atom-audit").Allowed() {
 		t.Fatal("configured publish target was denied")
 	}
-	if store.CanPublishAuthenticated(authentication, "events", "atom-audit") {
+	if store.AuthorizePublish(authentication, "events", "atom-audit").Allowed() {
 		t.Fatal("wrong exchange was allowed")
 	}
-	if store.CanPublishAuthenticated(authentication, "", "atom-audit.other") {
+	if store.AuthorizePublish(authentication, "", "atom-audit.other").Allowed() {
 		t.Fatal("prefix routing key was allowed")
 	}
 }
@@ -137,7 +137,7 @@ func TestReloadIsAtomicAndRevokesRemovedCredentials(t *testing.T) {
 	if store.IsActive(oldAuthentication) {
 		t.Fatal("removed previous credential remains active")
 	}
-	if store.CanPublishAuthenticated(oldAuthentication, "", "atom-audit") {
+	if store.AuthorizePublish(oldAuthentication, "", "atom-audit").Allowed() {
 		t.Fatal("session authenticated before reload can still publish with a retired credential")
 	}
 	if !store.IsActive(newAuthentication) {
@@ -176,7 +176,7 @@ func TestReloadRevokesChangedPublishPermissions(t *testing.T) {
 	if store.IsActive(authentication) {
 		t.Fatal("session authenticated against the replaced publish ACL remains active")
 	}
-	if store.CanPublishAuthenticated(authentication, "", "atom-audit-v2") {
+	if store.AuthorizePublish(authentication, "", "atom-audit-v2").Allowed() {
 		t.Fatal("session authenticated against the old ACL used the replacement ACL")
 	}
 
@@ -184,7 +184,7 @@ func TestReloadRevokesChangedPublishPermissions(t *testing.T) {
 	if !ok {
 		t.Fatal("authentication against the replacement ACL failed")
 	}
-	if !store.IsActive(reauthenticated) || !store.CanPublishAuthenticated(reauthenticated, "", "atom-audit-v2") {
+	if !store.IsActive(reauthenticated) || !store.AuthorizePublish(reauthenticated, "", "atom-audit-v2").Allowed() {
 		t.Fatal("session authenticated against the replacement ACL is not active")
 	}
 }
@@ -304,7 +304,7 @@ func TestConcurrentAuthenticationAndReload(t *testing.T) {
 			for range 500 {
 				authentication, ok := store.Authenticate(principalName, currentSecret, principalSAN)
 				if ok {
-					_ = store.CanPublishAuthenticated(authentication, "", "atom-audit")
+					_ = store.AuthorizePublish(authentication, "", "atom-audit")
 				}
 			}
 		}()
@@ -384,7 +384,7 @@ func TestSubscribeACL(t *testing.T) {
 	t.Run("publish ACL is unaffected by subscribe permissions", func(t *testing.T) {
 		reauthenticated, ok := store.Authenticate(principalName, currentSecret, principalSAN)
 		require.True(t, ok)
-		assert.True(t, store.CanPublishAuthenticated(reauthenticated, "", auditQueue))
+		assert.True(t, store.AuthorizePublish(reauthenticated, "", auditQueue).Allowed())
 		assert.False(t, store.CanSubscribeAuthenticated(reauthenticated, "m"))
 	})
 }
@@ -432,24 +432,26 @@ func TestPublishPrefixACL(t *testing.T) {
 	authentication, ok := store.Authenticate(principalName, currentSecret, principalSAN)
 	require.True(t, ok)
 
+	// The grant kind matters as much as the yes or no: an exact target is
+	// appended to a durable stream, a prefix is published as an ordinary topic.
 	tests := []struct {
 		name       string
 		exchange   string
 		routingKey string
-		want       bool
+		want       PublishGrant
 	}{
-		{name: "exact permission still matches", routingKey: auditQueue, want: true},
-		{name: "key under the prefix", routingKey: "m.domain.c.channel.temp", want: true},
-		{name: "prefix itself", routingKey: "m.", want: true},
-		{name: "key outside the prefix", routingKey: "other.domain", want: false},
-		{name: "prefix must match at the start", routingKey: "x.m.domain", want: false},
-		{name: "partial prefix is not enough", routingKey: "m", want: false},
-		{name: "prefix does not reach another exchange", exchange: "events", routingKey: "m.domain", want: false},
+		{name: "exact permission still matches", routingKey: auditQueue, want: PublishGrantExactTarget},
+		{name: "key under the prefix", routingKey: "m.domain.c.channel.temp", want: PublishGrantPrefix},
+		{name: "prefix itself", routingKey: "m.", want: PublishGrantPrefix},
+		{name: "key outside the prefix", routingKey: "other.domain", want: PublishGrantNone},
+		{name: "prefix must match at the start", routingKey: "x.m.domain", want: PublishGrantNone},
+		{name: "partial prefix is not enough", routingKey: "m", want: PublishGrantNone},
+		{name: "prefix does not reach another exchange", exchange: "events", routingKey: "m.domain", want: PublishGrantNone},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, store.CanPublishAuthenticated(authentication, tc.exchange, tc.routingKey))
+			assert.Equal(t, tc.want, store.AuthorizePublish(authentication, tc.exchange, tc.routingKey))
 		})
 	}
 
@@ -461,7 +463,7 @@ func TestPublishPrefixACL(t *testing.T) {
 		require.True(t, changed, "dropping a prefix permission must be seen as a change")
 
 		assert.False(t, store.IsActive(authentication))
-		assert.False(t, store.CanPublishAuthenticated(authentication, "", "m.domain.c.channel.temp"))
+		assert.False(t, store.AuthorizePublish(authentication, "", "m.domain.c.channel.temp").Allowed())
 	})
 }
 

--- a/broker/localauth/store_test.go
+++ b/broker/localauth/store_test.go
@@ -261,6 +261,7 @@ func TestStoreRejectsInvalidConfiguration(t *testing.T) {
 			name: "subscribe ACL entry cannot be empty",
 			configs: func() []config.LocalPrincipalConfig {
 				principal := principalConfig(current, "")
+				principal.Role = config.LocalRoleService
 				principal.Permissions.Subscribe = []string{""}
 				return []config.LocalPrincipalConfig{principal}
 			},
@@ -270,6 +271,7 @@ func TestStoreRejectsInvalidConfiguration(t *testing.T) {
 			name: "subscribe ACL entry cannot be duplicated",
 			configs: func() []config.LocalPrincipalConfig {
 				principal := principalConfig(current, "")
+				principal.Role = config.LocalRoleService
 				principal.Permissions.Subscribe = []string{auditQueue, auditQueue}
 				return []config.LocalPrincipalConfig{principal}
 			},
@@ -350,6 +352,7 @@ func TestSubscribeACL(t *testing.T) {
 
 	withSubscribe := func(queues ...string) []config.LocalPrincipalConfig {
 		principal := principalConfig(current, "")
+		principal.Role = config.LocalRoleService
 		principal.Permissions.Subscribe = queues
 		return []config.LocalPrincipalConfig{principal}
 	}
@@ -391,6 +394,63 @@ func TestSubscribeACL(t *testing.T) {
 
 // The two ACLs share one fingerprint, so swapping a target between them must
 // not produce the same digest.
+// The role is a capability, so narrowing it must revoke sessions that
+// authenticated under the wider one, exactly as narrowing an ACL does.
+// Otherwise a demoted service would keep consuming until it reconnected.
+func TestReloadRevokesNarrowedRole(t *testing.T) {
+	dir := t.TempDir()
+	current := writeSecret(t, dir, "current", currentSecret)
+	principal := principalConfig(current, "")
+	principal.Role = config.LocalRoleService
+	principal.Permissions.Subscribe = []string{auditQueue}
+
+	store, err := New([]config.LocalPrincipalConfig{principal})
+	require.NoError(t, err)
+	authentication, ok := store.Authenticate(principalName, currentSecret, principalSAN)
+	require.True(t, ok)
+	require.Equal(t, config.LocalRoleService, authentication.Role)
+	require.True(t, store.CanSubscribeAuthenticated(authentication, auditQueue))
+
+	narrowed := principalConfig(current, "")
+	changed, err := store.Reload([]config.LocalPrincipalConfig{narrowed})
+	require.NoError(t, err)
+	require.True(t, changed, "demoting a service to a publisher must be seen as a change")
+
+	assert.False(t, store.IsActive(authentication))
+	assert.False(t, store.CanSubscribeAuthenticated(authentication, auditQueue))
+
+	reauthenticated, ok := store.Authenticate(principalName, currentSecret, principalSAN)
+	require.True(t, ok)
+	assert.Equal(t, config.LocalRolePublisher, reauthenticated.Role)
+}
+
+// A role and an ACL entry spelling the same string must not collide in the
+// digest, or a change from one to the other would leave sessions alive.
+func TestPermissionsFingerprintSeparatesRoleFromACLs(t *testing.T) {
+	dir := t.TempDir()
+	current := writeSecret(t, dir, "current", currentSecret)
+
+	fingerprintFor := func(t *testing.T, role string, subscribe []string) PermissionsFingerprint {
+		t.Helper()
+		principal := principalConfig(current, "")
+		principal.Role = role
+		principal.Permissions.Subscribe = subscribe
+		store, err := New([]config.LocalPrincipalConfig{principal})
+		require.NoError(t, err)
+		authentication, ok := store.Authenticate(principalName, currentSecret, principalSAN)
+		require.True(t, ok)
+		return authentication.PermissionsFingerprint
+	}
+
+	service := fingerprintFor(t, config.LocalRoleService, nil)
+	publisher := fingerprintFor(t, config.LocalRolePublisher, nil)
+	assert.NotEqual(t, service, publisher, "a role change must change the fingerprint")
+
+	roleNamedQueue := fingerprintFor(t, config.LocalRoleService, []string{config.LocalRoleService})
+	assert.NotEqual(t, service, roleNamedQueue,
+		"a queue spelled like the role must not collide with the role itself")
+}
+
 func TestPermissionsFingerprintSeparatesACLs(t *testing.T) {
 	dir := t.TempDir()
 	current := writeSecret(t, dir, "current", currentSecret)
@@ -399,6 +459,7 @@ func TestPermissionsFingerprintSeparatesACLs(t *testing.T) {
 		t.Helper()
 		principal := principalConfig(current, "")
 		principal.Permissions.Publish = publish
+		principal.Role = config.LocalRoleService
 		principal.Permissions.Subscribe = subscribe
 		store, err := New([]config.LocalPrincipalConfig{principal})
 		require.NoError(t, err)

--- a/broker/localauth/store_test.go
+++ b/broker/localauth/store_test.go
@@ -413,3 +413,78 @@ func TestPermissionsFingerprintSeparatesACLs(t *testing.T) {
 	assert.NotEqual(t, publishOnly, subscribeOnly,
 		"a target moved between the publish and subscribe ACLs must change the fingerprint")
 }
+
+// A service publishes to topics derived from its own runtime data, so its ACL
+// names a routing-key prefix rather than keys that cannot be enumerated in
+// configuration. The prefix must bound the grant, not dissolve it.
+func TestPublishPrefixACL(t *testing.T) {
+	dir := t.TempDir()
+	current := writeSecret(t, dir, "current", currentSecret)
+
+	principal := principalConfig(current, "")
+	principal.Permissions.Publish = []config.LocalPublishPermission{
+		{RoutingKey: auditQueue},
+		{RoutingKeyPrefix: "m."},
+	}
+	store, err := New([]config.LocalPrincipalConfig{principal})
+	require.NoError(t, err)
+
+	authentication, ok := store.Authenticate(principalName, currentSecret, principalSAN)
+	require.True(t, ok)
+
+	tests := []struct {
+		name       string
+		exchange   string
+		routingKey string
+		want       bool
+	}{
+		{name: "exact permission still matches", routingKey: auditQueue, want: true},
+		{name: "key under the prefix", routingKey: "m.domain.c.channel.temp", want: true},
+		{name: "prefix itself", routingKey: "m.", want: true},
+		{name: "key outside the prefix", routingKey: "other.domain", want: false},
+		{name: "prefix must match at the start", routingKey: "x.m.domain", want: false},
+		{name: "partial prefix is not enough", routingKey: "m", want: false},
+		{name: "prefix does not reach another exchange", exchange: "events", routingKey: "m.domain", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, store.CanPublishAuthenticated(authentication, tc.exchange, tc.routingKey))
+		})
+	}
+
+	t.Run("dropping the prefix revokes the session", func(t *testing.T) {
+		narrowed := principalConfig(current, "")
+		narrowed.Permissions.Publish = []config.LocalPublishPermission{{RoutingKey: auditQueue}}
+		changed, err := store.Reload([]config.LocalPrincipalConfig{narrowed})
+		require.NoError(t, err)
+		require.True(t, changed, "dropping a prefix permission must be seen as a change")
+
+		assert.False(t, store.IsActive(authentication))
+		assert.False(t, store.CanPublishAuthenticated(authentication, "", "m.domain.c.channel.temp"))
+	})
+}
+
+// A prefix and an exact key spelling the same grant must not share a digest,
+// or narrowing one into the other would leave sessions alive.
+func TestPermissionsFingerprintSeparatesPrefixFromExact(t *testing.T) {
+	dir := t.TempDir()
+	current := writeSecret(t, dir, "current", currentSecret)
+
+	fingerprintFor := func(t *testing.T, publish []config.LocalPublishPermission) PermissionsFingerprint {
+		t.Helper()
+		principal := principalConfig(current, "")
+		principal.Permissions.Publish = publish
+		store, err := New([]config.LocalPrincipalConfig{principal})
+		require.NoError(t, err)
+		authentication, ok := store.Authenticate(principalName, currentSecret, principalSAN)
+		require.True(t, ok)
+		return authentication.PermissionsFingerprint
+	}
+
+	exact := fingerprintFor(t, []config.LocalPublishPermission{{RoutingKey: "m."}})
+	prefixed := fingerprintFor(t, []config.LocalPublishPermission{{RoutingKeyPrefix: "m."}})
+
+	assert.NotEqual(t, exact, prefixed,
+		"the same string as an exact key and as a prefix are different grants")
+}

--- a/broker/pubsub.go
+++ b/broker/pubsub.go
@@ -26,10 +26,9 @@ const (
 // marks it trusted. Every other connection has them stripped on ingress, so it
 // cannot forge one, and on egress, so it cannot observe one another service
 // set. MQTT, HTTP, CoAP, and AMQP 1.0 have no trusted listener and are
-// therefore stripped in both directions; only the AMQP 0.9.1 internal
-// listener is trusted, and only for ingress, because local principals are
-// publish-only. A reserved property consequently reaches the broker from a
-// trusted service today but is never handed back out to any connection.
+// therefore stripped in both directions. The trusted listeners are the AMQP
+// 0.9.1 internal and service listeners; only the service listener permits
+// consumers, so it is the one that both receives and reveals them.
 const ReservedPropertyPrefix = "_flux."
 
 // IsReservedProperty reports whether key names a broker-internal property.

--- a/broker/pubsub.go
+++ b/broker/pubsub.go
@@ -26,9 +26,13 @@ const (
 // marks it trusted. Every other connection has them stripped on ingress, so it
 // cannot forge one, and on egress, so it cannot observe one another service
 // set. MQTT, HTTP, CoAP, and AMQP 1.0 have no trusted listener and are
-// therefore stripped in both directions. The trusted listeners are the AMQP
-// 0.9.1 internal and service listeners; only the service listener permits
-// consumers, so it is the one that both receives and reveals them.
+// therefore stripped in both directions. The AMQP 0.9.1 local listener is the
+// trusted one, under whichever configuration key names it.
+//
+// Trust decides only whether reserved properties cross the boundary at all.
+// What a session may then do with them — publish, consume, relay an origin —
+// comes from the authenticated principal's role, so a listener grants no
+// capability of its own.
 const ReservedPropertyPrefix = "_flux."
 
 // IsReservedProperty reports whether key names a broker-internal property.

--- a/broker/pubsub.go
+++ b/broker/pubsub.go
@@ -18,6 +18,25 @@ const (
 	ProtocolProperty    = "protocol"
 )
 
+// ReservedPropertyPrefix marks message properties that carry broker-internal
+// state between trusted services.
+//
+// Trust is a property of the connection's listener policy, never of its
+// protocol. A connection carries reserved properties only when its policy
+// marks it trusted. Every other connection has them stripped on ingress, so it
+// cannot forge one, and on egress, so it cannot observe one another service
+// set. MQTT, HTTP, CoAP, and AMQP 1.0 have no trusted listener and are
+// therefore stripped in both directions; only the AMQP 0.9.1 internal
+// listener is trusted, and only for ingress, because local principals are
+// publish-only. A reserved property consequently reaches the broker from a
+// trusted service today but is never handed back out to any connection.
+const ReservedPropertyPrefix = "_flux."
+
+// IsReservedProperty reports whether key names a broker-internal property.
+func IsReservedProperty(key string) bool {
+	return strings.HasPrefix(key, ReservedPropertyPrefix)
+}
+
 // Origin protocol identifiers written into ProtocolProperty by ingress
 // handlers so downstream consumers can tell where a message came from.
 const (

--- a/broker/pubsub_test.go
+++ b/broker/pubsub_test.go
@@ -106,3 +106,24 @@ func TestExternalIDFromProperties(t *testing.T) {
 		ExternalIDProperty: testDeviceID,
 	}))
 }
+
+func TestIsReservedProperty(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want bool
+	}{
+		{name: "reserved key", key: ReservedPropertyPrefix + "re.trace", want: true},
+		{name: "prefix alone", key: ReservedPropertyPrefix, want: true},
+		{name: "client property", key: "trace", want: false},
+		{name: "origin property", key: ExternalIDProperty, want: false},
+		{name: "prefix not at start", key: "x" + ReservedPropertyPrefix + "re.trace", want: false},
+		{name: "empty key", key: "", want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsReservedProperty(tc.key))
+		})
+	}
+}

--- a/broker/routing.go
+++ b/broker/routing.go
@@ -132,6 +132,21 @@ func ParseQueueFilter(filter string) (queueName, pattern string) {
 	return rest, ""
 }
 
+// EffectiveConsumerGroupID returns the group identifier a queue consumer is
+// actually registered under. A pattern-scoped consumer is a distinct group from
+// an unpatterned one on the same queue, so the pattern qualifies the ID.
+//
+// This is the identifier the queue manager reports back — in stale-consumer
+// cleanup, for instance — so a protocol handler matching its own consumers
+// against a manager-supplied group has to build the same string rather than
+// compare the raw group it was asked to subscribe with.
+func EffectiveConsumerGroupID(groupID, pattern string) string {
+	if pattern == "" {
+		return groupID
+	}
+	return groupID + "@" + pattern
+}
+
 func parseAckSuffix(topic string) (AckKind, string, bool) {
 	if base, ok := strings.CutSuffix(topic, "/$ack"); ok {
 		return AckAccept, base, true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,9 +58,10 @@ import (
 
 // Listener mode names.
 const (
-	listenerPlain = "plain"
-	listenerTLS   = "tls"
-	listenerMTLS  = "mtls"
+	listenerPlain   = "plain"
+	listenerTLS     = "tls"
+	listenerMTLS    = "mtls"
+	listenerService = "service"
 )
 
 func protocolVersionForMode(mode string) int {
@@ -116,7 +117,7 @@ func (p *localAMQPPolicy) AuthenticateLocal(_ context.Context, _ string, usernam
 		}
 		return authentication.Principal,
 			hex.EncodeToString(authentication.CredentialFingerprint[:]),
-			hex.EncodeToString(authentication.PublishPermissionsFingerprint[:]),
+			hex.EncodeToString(authentication.PermissionsFingerprint[:]),
 			authentication.CertificateURISAN,
 			true,
 			nil
@@ -127,6 +128,11 @@ func (p *localAMQPPolicy) AuthenticateLocal(_ context.Context, _ string, usernam
 func (p *localAMQPPolicy) CanPublishLocal(identity amqpbroker.LocalSessionIdentity, exchange, routingKey string) bool {
 	authentication, ok := localAuthentication(identity)
 	return ok && p != nil && p.store != nil && p.store.CanPublishAuthenticated(authentication, exchange, routingKey)
+}
+
+func (p *localAMQPPolicy) CanSubscribeLocal(identity amqpbroker.LocalSessionIdentity, queue string) bool {
+	authentication, ok := localAuthentication(identity)
+	return ok && p != nil && p.store != nil && p.store.CanSubscribeAuthenticated(authentication, queue)
 }
 
 func (p *localAMQPPolicy) IsSessionActive(identity amqpbroker.LocalSessionIdentity) bool {
@@ -151,10 +157,10 @@ func localAuthentication(identity amqpbroker.LocalSessionIdentity) (localauth.Au
 	var permissionsFingerprint localauth.PermissionsFingerprint
 	copy(permissionsFingerprint[:], rawPermissionsFingerprint)
 	return localauth.Authentication{
-		Principal:                     identity.PrincipalID,
-		CertificateURISAN:             identity.CertificateURI,
-		CredentialFingerprint:         credentialFingerprint,
-		PublishPermissionsFingerprint: permissionsFingerprint,
+		Principal:              identity.PrincipalID,
+		CertificateURISAN:      identity.CertificateURI,
+		CredentialFingerprint:  credentialFingerprint,
+		PermissionsFingerprint: permissionsFingerprint,
 	}, true
 }
 
@@ -1164,6 +1170,12 @@ func main() {
 		localPolicyAdapter,
 		maxAMQP091MessageSize,
 	)
+	serviceAMQP091Policy := amqpbroker.NewLocalServiceConnectionPolicy(
+		localPolicyAdapter,
+		localPolicyAdapter,
+		localPolicyAdapter,
+		maxAMQP091MessageSize,
+	)
 	amqp091Slots := []struct {
 		name   string
 		cfg    config.AMQP091ListenerConfig
@@ -1173,6 +1185,7 @@ func main() {
 		{name: listenerTLS, cfg: cfg.Server.AMQP091.TLS, policy: externalAMQP091Policy},
 		{name: listenerMTLS, cfg: cfg.Server.AMQP091.MTLS, policy: externalAMQP091Policy},
 		{name: "internal", cfg: cfg.Server.AMQP091.Internal, policy: internalAMQP091Policy},
+		{name: listenerService, cfg: cfg.Server.AMQP091.Service, policy: serviceAMQP091Policy},
 	}
 
 	var amqp091Ready []<-chan struct{}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -58,10 +58,9 @@ import (
 
 // Listener mode names.
 const (
-	listenerPlain   = "plain"
-	listenerTLS     = "tls"
-	listenerMTLS    = "mtls"
-	listenerService = "service"
+	listenerPlain = "plain"
+	listenerTLS   = "tls"
+	listenerMTLS  = "mtls"
 )
 
 func protocolVersionForMode(mode string) int {
@@ -106,23 +105,34 @@ type localAMQPPolicy struct {
 	store *localauth.Store
 }
 
-func (p *localAMQPPolicy) AuthenticateLocal(_ context.Context, _ string, username, secret string, peer amqpbroker.VerifiedPeerIdentity) (string, string, string, string, bool, error) {
+func (p *localAMQPPolicy) AuthenticateLocal(_ context.Context, _ string, username, secret string, peer amqpbroker.VerifiedPeerIdentity) (amqpbroker.LocalAuthentication, bool, error) {
 	if p == nil || p.store == nil {
-		return "", "", "", "", false, nil
+		return amqpbroker.LocalAuthentication{}, false, nil
 	}
 	for _, uriSAN := range peer.URISANs {
 		authentication, ok := p.store.Authenticate(username, secret, uriSAN)
 		if !ok {
 			continue
 		}
-		return authentication.Principal,
-			hex.EncodeToString(authentication.CredentialFingerprint[:]),
-			hex.EncodeToString(authentication.PermissionsFingerprint[:]),
-			authentication.CertificateURISAN,
-			true,
-			nil
+		return amqpbroker.LocalAuthentication{
+			PrincipalID:            authentication.Principal,
+			Role:                   localPrincipalRole(authentication.Role),
+			CredentialFingerprint:  hex.EncodeToString(authentication.CredentialFingerprint[:]),
+			PermissionsFingerprint: hex.EncodeToString(authentication.PermissionsFingerprint[:]),
+			CertificateURI:         authentication.CertificateURISAN,
+		}, true, nil
 	}
-	return "", "", "", "", false, nil
+	return amqpbroker.LocalAuthentication{}, false, nil
+}
+
+// localPrincipalRole maps a configured role name onto the broker capability.
+// An unrecognized name falls back to the least privileged role rather than
+// failing open; configuration validation rejects such names at load.
+func localPrincipalRole(role string) amqpbroker.LocalPrincipalRole {
+	if role == config.LocalRoleService {
+		return amqpbroker.LocalRoleService
+	}
+	return amqpbroker.LocalRolePublisher
 }
 
 func (p *localAMQPPolicy) CanPublishLocal(identity amqpbroker.LocalSessionIdentity, exchange, routingKey string) amqpbroker.LocalPublishGrant {
@@ -169,6 +179,7 @@ func localAuthentication(identity amqpbroker.LocalSessionIdentity) (localauth.Au
 	return localauth.Authentication{
 		Principal:              identity.PrincipalID,
 		CertificateURISAN:      identity.CertificateURI,
+		Role:                   identity.Role.String(),
 		CredentialFingerprint:  credentialFingerprint,
 		PermissionsFingerprint: permissionsFingerprint,
 	}, true
@@ -390,7 +401,9 @@ func main() {
 		"amqp091_plain_listener", cfg.Server.AMQP091.Plain.Addr,
 		"amqp091_tls_listener", cfg.Server.AMQP091.TLS.Addr,
 		"amqp091_mtls_listener", cfg.Server.AMQP091.MTLS.Addr,
+		"amqp091_local_listener", cfg.Server.AMQP091.Local.Addr,
 		"amqp091_internal_listener", cfg.Server.AMQP091.Internal.Addr,
+		"amqp091_service_listener", cfg.Server.AMQP091.Service.Addr,
 		"admin_api_addr", cfg.Server.AdminAPIAddr,
 		"health_enabled", cfg.Server.HealthEnabled,
 		"cluster_enabled", cfg.Cluster.Enabled,
@@ -1168,7 +1181,7 @@ func main() {
 	}
 
 	// AMQP 0.9.1 servers. The public listeners receive only the external
-	// callout policy; the internal listener receives only the local-principal
+	// callout policy; the local listeners receive only the local-principal
 	// policy. There is deliberately no fallback between these policies.
 	maxAMQP091MessageSize := uint64(0)
 	if cfg.Broker.MaxMessageSize > 0 {
@@ -1179,13 +1192,10 @@ func main() {
 		amqp091ExternalHooks,
 		maxAMQP091MessageSize,
 	)
-	internalAMQP091Policy := amqpbroker.NewLocalPublishOnlyConnectionPolicy(
-		localPolicyAdapter,
-		localPolicyAdapter,
-		localPolicyAdapter,
-		maxAMQP091MessageSize,
-	)
-	serviceAMQP091Policy := amqpbroker.NewLocalServiceConnectionPolicy(
+	// Both local listeners share one policy. They differ only in network
+	// placement: capability comes from the authenticated principal's role, so a
+	// principal cannot widen itself by choosing a port.
+	localAMQP091Policy := amqpbroker.NewLocalConnectionPolicy(
 		localPolicyAdapter,
 		localPolicyAdapter,
 		localPolicyAdapter,
@@ -1199,8 +1209,21 @@ func main() {
 		{name: listenerPlain, cfg: cfg.Server.AMQP091.Plain, policy: externalAMQP091Policy},
 		{name: listenerTLS, cfg: cfg.Server.AMQP091.TLS, policy: externalAMQP091Policy},
 		{name: listenerMTLS, cfg: cfg.Server.AMQP091.MTLS, policy: externalAMQP091Policy},
-		{name: "internal", cfg: cfg.Server.AMQP091.Internal, policy: internalAMQP091Policy},
-		{name: listenerService, cfg: cfg.Server.AMQP091.Service, policy: serviceAMQP091Policy},
+	}
+	// Every local-principal listener gets the same policy under whichever key
+	// named it. They differ only in network placement.
+	for _, listener := range cfg.Server.AMQP091.LocalListeners() {
+		amqp091Slots = append(amqp091Slots, struct {
+			name   string
+			cfg    config.AMQP091ListenerConfig
+			policy *amqpbroker.ConnectionPolicy
+		}{name: listener.Name, cfg: listener.Config, policy: localAMQP091Policy})
+	}
+	if deprecated := cfg.Server.AMQP091.DeprecatedLocalListenerNames(); len(deprecated) > 0 {
+		slog.Warn("Deprecated AMQP 0.9.1 listener key",
+			"keys", strings.Join(deprecated, ","),
+			"replacement", "server.amqp091.local",
+			"reason", "local listeners are equivalent; capability comes from the principal role")
 	}
 
 	var amqp091Ready []<-chan struct{}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -125,9 +125,19 @@ func (p *localAMQPPolicy) AuthenticateLocal(_ context.Context, _ string, usernam
 	return "", "", "", "", false, nil
 }
 
-func (p *localAMQPPolicy) CanPublishLocal(identity amqpbroker.LocalSessionIdentity, exchange, routingKey string) bool {
+func (p *localAMQPPolicy) CanPublishLocal(identity amqpbroker.LocalSessionIdentity, exchange, routingKey string) amqpbroker.LocalPublishGrant {
 	authentication, ok := localAuthentication(identity)
-	return ok && p != nil && p.store != nil && p.store.CanPublishAuthenticated(authentication, exchange, routingKey)
+	if !ok || p == nil || p.store == nil {
+		return amqpbroker.LocalPublishGrantNone
+	}
+	switch p.store.AuthorizePublish(authentication, exchange, routingKey) {
+	case localauth.PublishGrantExactTarget:
+		return amqpbroker.LocalPublishGrantExactTarget
+	case localauth.PublishGrantPrefix:
+		return amqpbroker.LocalPublishGrantPrefix
+	default:
+		return amqpbroker.LocalPublishGrantNone
+	}
 }
 
 func (p *localAMQPPolicy) CanSubscribeLocal(identity amqpbroker.LocalSessionIdentity, queue string) bool {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -267,6 +267,11 @@ func localPrincipalPublishTargetContracts(principals []config.LocalPrincipalConf
 	targets := make(map[string]struct{})
 	for _, principal := range principals {
 		for _, permission := range principal.Permissions.Publish {
+			// A prefix permission authorizes topic publishing, not an append to
+			// one durable stream, so there is no single queue to contract with.
+			if permission.IsPrefix() {
+				continue
+			}
 			targets[permission.RoutingKey] = struct{}{}
 		}
 	}

--- a/cmd/main_bench_test.go
+++ b/cmd/main_bench_test.go
@@ -35,7 +35,7 @@ func BenchmarkLocalAMQPPolicyCanPublish(b *testing.B) {
 		b.Fatal(err)
 	}
 	adapter := &localAMQPPolicy{store: store}
-	principalID, credentialFingerprint, permissionsFingerprint, certificateURI, ok, err := adapter.AuthenticateLocal(
+	authentication, ok, err := adapter.AuthenticateLocal(
 		context.Background(),
 		"amqp091:client",
 		testLocalPrincipal,
@@ -46,10 +46,10 @@ func BenchmarkLocalAMQPPolicyCanPublish(b *testing.B) {
 		b.Fatalf("AuthenticateLocal() authenticated=%v error=%v", ok, err)
 	}
 	identity := amqpbroker.LocalSessionIdentity{
-		PrincipalID:            principalID,
-		CredentialFingerprint:  credentialFingerprint,
-		PermissionsFingerprint: permissionsFingerprint,
-		CertificateURI:         certificateURI,
+		PrincipalID:            authentication.PrincipalID,
+		CredentialFingerprint:  authentication.CredentialFingerprint,
+		PermissionsFingerprint: authentication.PermissionsFingerprint,
+		CertificateURI:         authentication.CertificateURI,
 	}
 
 	b.ReportAllocs()

--- a/cmd/main_bench_test.go
+++ b/cmd/main_bench_test.go
@@ -54,7 +54,7 @@ func BenchmarkLocalAMQPPolicyCanPublish(b *testing.B) {
 
 	b.ReportAllocs()
 	for b.Loop() {
-		if !adapter.CanPublishLocal(identity, "", testAuditQueue) {
+		if !adapter.CanPublishLocal(identity, "", testAuditQueue).Allowed() {
 			b.Fatal("configured publish target was denied")
 		}
 	}

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -54,28 +54,28 @@ func TestLocalAMQPPolicyAdapter(t *testing.T) {
 		CertificateFingerprint: strings.Repeat("a", 64),
 	}
 
-	principalID, credentialFingerprint, permissionsFingerprint, certificateURI, authenticated, err := adapter.AuthenticateLocal(
+	authentication, authenticated, err := adapter.AuthenticateLocal(
 		context.Background(), "amqp091:client", testLocalPrincipal, testLocalSecret, peer,
 	)
 	if err != nil {
 		t.Fatalf("AuthenticateLocal() error = %v", err)
 	}
-	if !authenticated || principalID != testLocalPrincipal || certificateURI != testLocalSAN {
-		t.Fatalf("unexpected authentication result: principal=%q certificate_uri=%q authenticated=%v", principalID, certificateURI, authenticated)
+	if !authenticated || authentication.PrincipalID != testLocalPrincipal || authentication.CertificateURI != testLocalSAN {
+		t.Fatalf("unexpected authentication result: principal=%q certificate_uri=%q authenticated=%v", authentication.PrincipalID, authentication.CertificateURI, authenticated)
 	}
-	decodedCredentialFingerprint, err := hex.DecodeString(credentialFingerprint)
+	decodedCredentialFingerprint, err := hex.DecodeString(authentication.CredentialFingerprint)
 	if err != nil || len(decodedCredentialFingerprint) != len(localauth.CredentialFingerprint{}) {
-		t.Fatalf("invalid credential fingerprint %q: %v", credentialFingerprint, err)
+		t.Fatalf("invalid credential fingerprint %q: %v", authentication.CredentialFingerprint, err)
 	}
-	decodedPermissionsFingerprint, err := hex.DecodeString(permissionsFingerprint)
+	decodedPermissionsFingerprint, err := hex.DecodeString(authentication.PermissionsFingerprint)
 	if err != nil || len(decodedPermissionsFingerprint) != len(localauth.PermissionsFingerprint{}) {
-		t.Fatalf("invalid permissions fingerprint %q: %v", permissionsFingerprint, err)
+		t.Fatalf("invalid permissions fingerprint %q: %v", authentication.PermissionsFingerprint, err)
 	}
 	identity := amqpbroker.LocalSessionIdentity{
-		PrincipalID:            principalID,
-		CredentialFingerprint:  credentialFingerprint,
-		PermissionsFingerprint: permissionsFingerprint,
-		CertificateURI:         certificateURI,
+		PrincipalID:            authentication.PrincipalID,
+		CredentialFingerprint:  authentication.CredentialFingerprint,
+		PermissionsFingerprint: authentication.PermissionsFingerprint,
+		CertificateURI:         authentication.CertificateURI,
 	}
 	if !adapter.CanPublishLocal(identity, "", testAuditQueue).Allowed() {
 		t.Fatal("exact configured publish target was denied")
@@ -110,7 +110,7 @@ func TestLocalAMQPPolicyAdapter(t *testing.T) {
 
 func TestLocalAMQPPolicyAdapterFailsClosed(t *testing.T) {
 	adapter := &localAMQPPolicy{}
-	if _, _, _, _, authenticated, err := adapter.AuthenticateLocal(context.Background(), "client", "user", "secret", amqpbroker.VerifiedPeerIdentity{}); err != nil || authenticated {
+	if _, authenticated, err := adapter.AuthenticateLocal(context.Background(), "client", "user", "secret", amqpbroker.VerifiedPeerIdentity{}); err != nil || authenticated {
 		t.Fatalf("nil local store must fail closed: authenticated=%v err=%v", authenticated, err)
 	}
 	if adapter.CanPublishLocal(amqpbroker.LocalSessionIdentity{PrincipalID: "principal"}, "", testAuditQueue).Allowed() {
@@ -140,7 +140,7 @@ func TestLocalAMQPPolicyAdapterRevokesChangedPermissions(t *testing.T) {
 		t.Fatal(err)
 	}
 	adapter := &localAMQPPolicy{store: store}
-	principalID, credentialFingerprint, permissionsFingerprint, certificateURI, authenticated, err := adapter.AuthenticateLocal(
+	authentication, authenticated, err := adapter.AuthenticateLocal(
 		context.Background(),
 		"amqp091:client",
 		testLocalPrincipal,
@@ -151,10 +151,10 @@ func TestLocalAMQPPolicyAdapterRevokesChangedPermissions(t *testing.T) {
 		t.Fatalf("AuthenticateLocal() authenticated=%v error=%v", authenticated, err)
 	}
 	identity := amqpbroker.LocalSessionIdentity{
-		PrincipalID:            principalID,
-		CredentialFingerprint:  credentialFingerprint,
-		PermissionsFingerprint: permissionsFingerprint,
-		CertificateURI:         certificateURI,
+		PrincipalID:            authentication.PrincipalID,
+		CredentialFingerprint:  authentication.CredentialFingerprint,
+		PermissionsFingerprint: authentication.PermissionsFingerprint,
+		CertificateURI:         authentication.CertificateURI,
 	}
 	if !adapter.IsSessionActive(identity) {
 		t.Fatal("freshly authenticated session was not active")

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -77,10 +77,10 @@ func TestLocalAMQPPolicyAdapter(t *testing.T) {
 		PermissionsFingerprint: permissionsFingerprint,
 		CertificateURI:         certificateURI,
 	}
-	if !adapter.CanPublishLocal(identity, "", testAuditQueue) {
+	if !adapter.CanPublishLocal(identity, "", testAuditQueue).Allowed() {
 		t.Fatal("exact configured publish target was denied")
 	}
-	if adapter.CanPublishLocal(identity, "events", testAuditQueue) || adapter.CanPublishLocal(identity, "", "atom-audit.other") {
+	if adapter.CanPublishLocal(identity, "events", testAuditQueue).Allowed() || adapter.CanPublishLocal(identity, "", "atom-audit.other").Allowed() {
 		t.Fatal("non-exact publish target was allowed")
 	}
 
@@ -103,7 +103,7 @@ func TestLocalAMQPPolicyAdapter(t *testing.T) {
 	if adapter.IsSessionActive(identity) {
 		t.Fatal("session authenticated with the removed secret remains active")
 	}
-	if adapter.CanPublishLocal(identity, "", testAuditQueue) {
+	if adapter.CanPublishLocal(identity, "", testAuditQueue).Allowed() {
 		t.Fatal("session authenticated before reload can publish with the removed secret")
 	}
 }
@@ -113,7 +113,7 @@ func TestLocalAMQPPolicyAdapterFailsClosed(t *testing.T) {
 	if _, _, _, _, authenticated, err := adapter.AuthenticateLocal(context.Background(), "client", "user", "secret", amqpbroker.VerifiedPeerIdentity{}); err != nil || authenticated {
 		t.Fatalf("nil local store must fail closed: authenticated=%v err=%v", authenticated, err)
 	}
-	if adapter.CanPublishLocal(amqpbroker.LocalSessionIdentity{PrincipalID: "principal"}, "", testAuditQueue) {
+	if adapter.CanPublishLocal(amqpbroker.LocalSessionIdentity{PrincipalID: "principal"}, "", testAuditQueue).Allowed() {
 		t.Fatal("nil local store authorized a publication")
 	}
 	if adapter.IsSessionActive(amqpbroker.LocalSessionIdentity{}) {
@@ -171,7 +171,7 @@ func TestLocalAMQPPolicyAdapterRevokesChangedPermissions(t *testing.T) {
 	if adapter.IsSessionActive(identity) {
 		t.Fatal("session authenticated against the replaced publish ACL remains active")
 	}
-	if adapter.CanPublishLocal(identity, "", "atom-audit-v2") {
+	if adapter.CanPublishLocal(identity, "", "atom-audit-v2").Allowed() {
 		t.Fatal("session authenticated against the old ACL used the replacement ACL")
 	}
 }
@@ -420,7 +420,7 @@ func TestReloadLocalPrincipalsRejectsInvalidTargetBeforeSwap(t *testing.T) {
 	if localStore.Generation() != generation {
 		t.Fatalf("generation changed after rejected reload: got %d, want %d", localStore.Generation(), generation)
 	}
-	if !localStore.CanPublishAuthenticated(authentication, "", testAuditQueue) {
+	if !localStore.AuthorizePublish(authentication, "", testAuditQueue).Allowed() {
 		t.Fatal("rejected reload replaced the previous valid snapshot")
 	}
 }
@@ -484,7 +484,7 @@ func TestReloadLocalPrincipalsReplacesProtectedTargets(t *testing.T) {
 	if len(contracts) != 1 || contracts[0].Name != securityQueue.Name {
 		t.Fatalf("protected contracts = %+v, want only %q", contracts, securityQueue.Name)
 	}
-	if localStore.CanPublishAuthenticated(authentication, "", auditQueue.Name) {
+	if localStore.AuthorizePublish(authentication, "", auditQueue.Name).Allowed() {
 		t.Fatal("old publish target remained authorized")
 	}
 	if localStore.IsActive(authentication) {
@@ -494,7 +494,7 @@ func TestReloadLocalPrincipalsReplacesProtectedTargets(t *testing.T) {
 	if !ok {
 		t.Fatal("principal did not reauthenticate against the replacement publish ACL")
 	}
-	if !localStore.CanPublishAuthenticated(reauthenticated, "", securityQueue.Name) {
+	if !localStore.AuthorizePublish(reauthenticated, "", securityQueue.Name).Allowed() {
 		t.Fatal("new publish target was not authorized")
 	}
 	if err := queueManager.PublishToDurableStream(ctx, auditQueue.Name, queueTypes.PublishRequest{Payload: []byte("{}")}); !errors.Is(err, queuepkg.ErrQueueNotProtected) {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -27,7 +27,7 @@ const (
 	testLocalSAN       = "spiffe://absmach/atom/audit-publisher"
 	testLocalSecret    = "0123456789abcdef0123456789abcdef"
 	testNextSecret     = "abcdef0123456789abcdef0123456789"
-	testAuditQueue     = "atom-audit"
+	testAuditQueue     = "atom.events"
 )
 
 func TestLocalAMQPPolicyAdapter(t *testing.T) {
@@ -80,7 +80,7 @@ func TestLocalAMQPPolicyAdapter(t *testing.T) {
 	if !adapter.CanPublishLocal(identity, "", testAuditQueue).Allowed() {
 		t.Fatal("exact configured publish target was denied")
 	}
-	if adapter.CanPublishLocal(identity, "events", testAuditQueue).Allowed() || adapter.CanPublishLocal(identity, "", "atom-audit.other").Allowed() {
+	if adapter.CanPublishLocal(identity, "events", testAuditQueue).Allowed() || adapter.CanPublishLocal(identity, "", "atom.events.other").Allowed() {
 		t.Fatal("non-exact publish target was allowed")
 	}
 
@@ -160,7 +160,7 @@ func TestLocalAMQPPolicyAdapterRevokesChangedPermissions(t *testing.T) {
 		t.Fatal("freshly authenticated session was not active")
 	}
 
-	principalConfig.Permissions.Publish[0].RoutingKey = "atom-audit-v2"
+	principalConfig.Permissions.Publish[0].RoutingKey = "atom.events.v2"
 	changed, err := store.Reload([]config.LocalPrincipalConfig{principalConfig})
 	if err != nil {
 		t.Fatalf("Reload() error = %v", err)
@@ -171,7 +171,7 @@ func TestLocalAMQPPolicyAdapterRevokesChangedPermissions(t *testing.T) {
 	if adapter.IsSessionActive(identity) {
 		t.Fatal("session authenticated against the replaced publish ACL remains active")
 	}
-	if adapter.CanPublishLocal(identity, "", "atom-audit-v2").Allowed() {
+	if adapter.CanPublishLocal(identity, "", "atom.events.v2").Allowed() {
 		t.Fatal("session authenticated against the old ACL used the replacement ACL")
 	}
 }
@@ -200,7 +200,7 @@ func TestValidateLocalPrincipalPublishTargets(t *testing.T) {
 			Publish: []config.LocalPublishPermission{{RoutingKey: testAuditQueue}},
 		},
 	}
-	expected := queueTypes.DefaultQueueConfig(testAuditQueue, "$queue/atom-audit/#")
+	expected := queueTypes.DefaultQueueConfig(testAuditQueue, "$queue/atom.events/#")
 	expected.Reserved = true
 	expected.Type = queueTypes.QueueTypeStream
 	expected.Retention = queueTypes.RetentionPolicy{
@@ -391,7 +391,7 @@ func TestReloadLocalPrincipalsRejectsInvalidTargetBeforeSwap(t *testing.T) {
 		t.Fatal("initial principal did not authenticate")
 	}
 
-	auditQueue := queueTypes.DefaultQueueConfig(testAuditQueue, "$queue/atom-audit/#")
+	auditQueue := queueTypes.DefaultQueueConfig(testAuditQueue, "$queue/atom.events/#")
 	auditQueue.Reserved = true
 	auditQueue.Type = queueTypes.QueueTypeStream
 	queueStore := newDurableTestQueueStore()
@@ -448,7 +448,7 @@ func TestReloadLocalPrincipalsReplacesProtectedTargets(t *testing.T) {
 		t.Fatal("initial principal did not authenticate")
 	}
 
-	auditQueue := queueTypes.DefaultQueueConfig(testAuditQueue, "$queue/atom-audit/#")
+	auditQueue := queueTypes.DefaultQueueConfig(testAuditQueue, "$queue/atom.events/#")
 	auditQueue.Reserved = true
 	auditQueue.Type = queueTypes.QueueTypeStream
 	securityQueue := queueTypes.DefaultQueueConfig("atom-security", "$queue/atom-security/#")
@@ -525,7 +525,7 @@ func TestReloadLocalPrincipalsRestoresProtectionWhenSecretLoadFails(t *testing.T
 		t.Fatalf("localauth.New() error = %v", err)
 	}
 
-	auditQueue := queueTypes.DefaultQueueConfig(testAuditQueue, "$queue/atom-audit/#")
+	auditQueue := queueTypes.DefaultQueueConfig(testAuditQueue, "$queue/atom.events/#")
 	auditQueue.Reserved = true
 	auditQueue.Type = queueTypes.QueueTypeStream
 	securityQueue := queueTypes.DefaultQueueConfig("atom-security", "$queue/atom-security/#")

--- a/config/auth_test.go
+++ b/config/auth_test.go
@@ -239,6 +239,44 @@ func TestValidateLocalPrincipals(t *testing.T) {
 			wantError: "exchange must be empty; local principals may publish only through the AMQP default exchange",
 		},
 		{
+			name: "publish permission cannot set both an exact key and a prefix",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.Permissions.Publish = []LocalPublishPermission{
+					{RoutingKey: testAuditQueue, RoutingKeyPrefix: "m."},
+				}
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: "cannot set both routing_key and routing_key_prefix",
+		},
+		{
+			name: "publish permission must set one of them",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.Permissions.Publish = []LocalPublishPermission{{}}
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: "must set either routing_key or routing_key_prefix",
+		},
+		{
+			name: "publish prefix cannot contain wildcards",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.Permissions.Publish = []LocalPublishPermission{{RoutingKeyPrefix: "m.#"}}
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: "must not contain wildcards",
+		},
+		{
+			name: "publish prefix cannot have surrounding whitespace",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.Permissions.Publish = []LocalPublishPermission{{RoutingKeyPrefix: " m."}}
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: "cannot have leading or trailing whitespace",
+		},
+		{
 			name: "subscribe permission cannot be empty",
 			principals: func() []LocalPrincipalConfig {
 				principal := valid()

--- a/config/auth_test.go
+++ b/config/auth_test.go
@@ -724,9 +724,17 @@ func TestValidateAgainstRuntimeRefusesExactTargetWhileClustered(t *testing.T) {
 		assert.NoError(t, ValidateAgainstRuntime(withPermission(false, prefixOnly), withPermission(false, exact)))
 	})
 
-	t.Run("no local listener means no local publication to strand", func(t *testing.T) {
+	t.Run("removing the running listener does not make the reload safe", func(t *testing.T) {
 		next := withPermission(false, exact)
 		next.Server.AMQP091.Local = AMQP091ListenerConfig{}
-		assert.NoError(t, ValidateAgainstRuntime(withPermission(true, prefixOnly), next))
+		err := ValidateAgainstRuntime(withPermission(true, prefixOnly), next)
+		require.Error(t, err, "the running listener remains active until restart")
+		assert.Contains(t, err.Error(), "while the running node is clustered")
+	})
+
+	t.Run("no running local listener means no local publication to strand", func(t *testing.T) {
+		running := withPermission(true, prefixOnly)
+		running.Server.AMQP091.Local = AMQP091ListenerConfig{}
+		assert.NoError(t, ValidateAgainstRuntime(running, withPermission(false, exact)))
 	})
 }

--- a/config/auth_test.go
+++ b/config/auth_test.go
@@ -10,6 +10,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -17,6 +20,7 @@ const (
 	testPrincipalSAN  = "spiffe://absmach/atom/audit-publisher"
 	testAuditQueue    = "atom-audit"
 	testInternalAddr  = ":5683"
+	testServiceAddr   = ":5684"
 	testServerCert    = "server.crt"
 	testServerKey     = "server.key"
 	testClientCA      = "clients.crt"
@@ -451,6 +455,88 @@ func TestValidateInternalAMQP091Listener(t *testing.T) {
 	}
 }
 
+// The service listener authenticates against the same principal store and
+// publishes through the same single-node durable path as the internal one, so
+// it carries the same deployment requirements.
+func TestValidateServiceAMQP091Listener(t *testing.T) {
+	configureValid := func(listener *AMQP091ListenerConfig) {
+		listener.Addr = testServiceAddr
+		listener.MaxConnections = 32
+		listener.TLS.CertFile = testServerCert
+		listener.TLS.KeyFile = testServerKey
+		listener.TLS.ClientCAFile = testClientCA
+		listener.TLS.ClientAuth = clientAuthRequire
+	}
+
+	tests := []struct {
+		name           string
+		configure      func(*AMQP091ListenerConfig)
+		clusterEnabled bool
+		withPrincipal  bool
+		wantError      string
+	}{
+		{
+			name:      "disabled by default",
+			configure: func(*AMQP091ListenerConfig) {},
+		},
+		{
+			name: "requires exact client auth mode",
+			configure: func(listener *AMQP091ListenerConfig) {
+				configureValid(listener)
+				listener.TLS.ClientAuth = "verify-if-given"
+			},
+			wantError: "server.amqp091.service.client_auth must be \"require\"",
+		},
+		{
+			name:      "requires a positive connection limit",
+			configure: func(listener *AMQP091ListenerConfig) { configureValid(listener); listener.MaxConnections = 0 },
+			wantError: "server.amqp091.service.max_connections must be positive",
+		},
+		{
+			name:      "requires a local principal",
+			configure: configureValid,
+			wantError: "auth.local_principals must contain at least one principal when server.amqp091.service.addr is configured",
+		},
+		{
+			name:           "rejects clustering",
+			configure:      configureValid,
+			clusterEnabled: true,
+			withPrincipal:  true,
+			wantError:      "server.amqp091.service.addr cannot be combined with cluster.enabled",
+		},
+		{
+			name:          "valid mandatory mTLS",
+			configure:     configureValid,
+			withPrincipal: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Default()
+			cfg.Cluster.Enabled = tt.clusterEnabled
+			tt.configure(&cfg.Server.AMQP091.Service)
+			if tt.withPrincipal {
+				cfg.Auth.LocalPrincipals = []LocalPrincipalConfig{{
+					Name:              testPrincipalName,
+					CertificateURISAN: testPrincipalSAN,
+					CurrentSecretFile: writeSecret(t, t.TempDir(), "current", strings.Repeat("a", 32)),
+				}}
+			}
+			err := cfg.Validate()
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("Validate() error = %v, want it to contain %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
 func writeSecret(t *testing.T, dir, name, contents string) string {
 	t.Helper()
 	filename := filepath.Join(dir, name)
@@ -458,4 +544,45 @@ func writeSecret(t *testing.T, dir, name, contents string) string {
 		t.Fatalf("write secret: %v", err)
 	}
 	return filename
+}
+
+// The auth subtree is decoded strictly, so a permission field the allowlist
+// omits is rejected at parse time however valid the struct would be. Parsing
+// real YAML is the only thing that catches that; validating a struct built in
+// Go never reaches the decoder.
+func TestLoadAcceptsPublishPermissionFields(t *testing.T) {
+	tests := []struct {
+		name       string
+		permission string
+	}{
+		{name: "exact routing key", permission: "routing_key: \"atom-audit\""},
+		{name: "routing key prefix", permission: "routing_key_prefix: \"m.\""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			secret := filepath.Join(dir, "secret")
+			require.NoError(t, os.WriteFile(secret, []byte(strings.Repeat("a", 32)), 0o600))
+
+			filename := filepath.Join(dir, "config.yaml")
+			body := "auth:\n" +
+				"  local_principals:\n" +
+				"    - name: \"svc\"\n" +
+				"      certificate_uri_san: \"spiffe://absmach/svc\"\n" +
+				"      current_secret_file: \"" + secret + "\"\n" +
+				"      permissions:\n" +
+				"        publish:\n" +
+				"          - " + tc.permission + "\n" +
+				"        subscribe:\n" +
+				"          - \"m\"\n"
+			require.NoError(t, os.WriteFile(filename, []byte(body), 0o600))
+
+			cfg, err := Load(filename)
+			require.NoError(t, err)
+			require.Len(t, cfg.Auth.LocalPrincipals, 1)
+			require.Len(t, cfg.Auth.LocalPrincipals[0].Permissions.Publish, 1)
+			assert.Equal(t, []string{"m"}, cfg.Auth.LocalPrincipals[0].Permissions.Subscribe)
+		})
+	}
 }

--- a/config/auth_test.go
+++ b/config/auth_test.go
@@ -18,7 +18,7 @@ import (
 const (
 	testPrincipalName = "atom-audit-publisher"
 	testPrincipalSAN  = "spiffe://absmach/atom/audit-publisher"
-	testAuditQueue    = "atom-audit"
+	testAuditQueue    = "atom.events"
 	testInternalAddr  = ":5683"
 	testServiceAddr   = ":5684"
 	testServerCert    = "server.crt"
@@ -49,7 +49,7 @@ auth:
       permissions:
         publish:
           - exchange: ""
-            routing_key: atom-audit
+            routing_key: atom.events
         subscribe: []
 `, testPrincipalName, testPrincipalSAN, current, previous)
 	if err := os.WriteFile(filename, []byte(contents), 0o600); err != nil {
@@ -654,7 +654,7 @@ func TestLoadAcceptsPublishPermissionFields(t *testing.T) {
 		name       string
 		permission string
 	}{
-		{name: "exact routing key", permission: "routing_key: \"atom-audit\""},
+		{name: "exact routing key", permission: "routing_key: \"atom.events\""},
 		{name: "routing key prefix", permission: "routing_key_prefix: \"m.\""},
 	}
 

--- a/config/auth_test.go
+++ b/config/auth_test.go
@@ -284,6 +284,7 @@ func TestValidateLocalPrincipals(t *testing.T) {
 			name: "subscribe permission cannot be empty",
 			principals: func() []LocalPrincipalConfig {
 				principal := valid()
+				principal.Role = LocalRoleService
 				principal.Permissions.Subscribe = []string{""}
 				return []LocalPrincipalConfig{principal}
 			},
@@ -293,6 +294,7 @@ func TestValidateLocalPrincipals(t *testing.T) {
 			name: "subscribe permission cannot contain wildcards",
 			principals: func() []LocalPrincipalConfig {
 				principal := valid()
+				principal.Role = LocalRoleService
 				principal.Permissions.Subscribe = []string{testAuditQueue + ".*"}
 				return []LocalPrincipalConfig{principal}
 			},
@@ -302,15 +304,43 @@ func TestValidateLocalPrincipals(t *testing.T) {
 			name: "subscribe permission cannot have surrounding whitespace",
 			principals: func() []LocalPrincipalConfig {
 				principal := valid()
+				principal.Role = LocalRoleService
 				principal.Permissions.Subscribe = []string{" " + testAuditQueue}
 				return []LocalPrincipalConfig{principal}
 			},
 			wantError: "cannot have leading or trailing whitespace",
 		},
 		{
+			name: "subscribe permission requires the service role",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.Permissions.Subscribe = []string{testAuditQueue}
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: "permissions.subscribe requires role \"service\"",
+		},
+		{
+			name: "unknown role is rejected",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.Role = "administrator"
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: "role \"administrator\" is unknown",
+		},
+		{
+			name: "role defaults to the least privileged one",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.Role = ""
+				return []LocalPrincipalConfig{principal}
+			},
+		},
+		{
 			name: "subscribe permission cannot be duplicated",
 			principals: func() []LocalPrincipalConfig {
 				principal := valid()
+				principal.Role = LocalRoleService
 				principal.Permissions.Subscribe = []string{testAuditQueue, testAuditQueue}
 				return []LocalPrincipalConfig{principal}
 			},
@@ -458,7 +488,16 @@ func TestValidateInternalAMQP091Listener(t *testing.T) {
 // The service listener authenticates against the same principal store and
 // publishes through the same single-node durable path as the internal one, so
 // it carries the same deployment requirements.
-func TestValidateServiceAMQP091Listener(t *testing.T) {
+// local is the current key; internal and service are deprecated aliases that
+// must stay exactly equivalent, or an operator migrating between them would get
+// a different security posture from the same file.
+func TestValidateLocalAMQP091Listeners(t *testing.T) {
+	keys := map[string]func(*Config) *AMQP091ListenerConfig{
+		listenerNameLocal:    func(c *Config) *AMQP091ListenerConfig { return &c.Server.AMQP091.Local },
+		listenerNameInternal: func(c *Config) *AMQP091ListenerConfig { return &c.Server.AMQP091.Internal },
+		listenerNameService:  func(c *Config) *AMQP091ListenerConfig { return &c.Server.AMQP091.Service },
+	}
+
 	configureValid := func(listener *AMQP091ListenerConfig) {
 		listener.Addr = testServiceAddr
 		listener.MaxConnections = 32
@@ -485,24 +524,24 @@ func TestValidateServiceAMQP091Listener(t *testing.T) {
 				configureValid(listener)
 				listener.TLS.ClientAuth = "verify-if-given"
 			},
-			wantError: "server.amqp091.service.client_auth must be \"require\"",
+			wantError: "client_auth must be \"require\"",
 		},
 		{
 			name:      "requires a positive connection limit",
 			configure: func(listener *AMQP091ListenerConfig) { configureValid(listener); listener.MaxConnections = 0 },
-			wantError: "server.amqp091.service.max_connections must be positive",
+			wantError: "max_connections must be positive",
 		},
 		{
 			name:      "requires a local principal",
 			configure: configureValid,
-			wantError: "auth.local_principals must contain at least one principal when server.amqp091.service.addr is configured",
+			wantError: "auth.local_principals must contain at least one principal when server.amqp091.",
 		},
 		{
 			name:           "rejects clustering",
 			configure:      configureValid,
 			clusterEnabled: true,
 			withPrincipal:  true,
-			wantError:      "server.amqp091.service.addr cannot be combined with cluster.enabled",
+			wantError:      "cannot be combined with cluster.enabled",
 		},
 		{
 			name:          "valid mandatory mTLS",
@@ -511,29 +550,71 @@ func TestValidateServiceAMQP091Listener(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cfg := Default()
-			cfg.Cluster.Enabled = tt.clusterEnabled
-			tt.configure(&cfg.Server.AMQP091.Service)
-			if tt.withPrincipal {
-				cfg.Auth.LocalPrincipals = []LocalPrincipalConfig{{
-					Name:              testPrincipalName,
-					CertificateURISAN: testPrincipalSAN,
-					CurrentSecretFile: writeSecret(t, t.TempDir(), "current", strings.Repeat("a", 32)),
-				}}
-			}
-			err := cfg.Validate()
-			if tt.wantError == "" {
-				if err != nil {
-					t.Fatalf("Validate() error = %v", err)
-				}
-				return
-			}
-			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
-				t.Fatalf("Validate() error = %v, want it to contain %q", err, tt.wantError)
-			}
-		})
+	for key, selector := range keys {
+		for _, tt := range tests {
+			t.Run(key+"/"+tt.name, func(t *testing.T) {
+				runLocalListenerCase(t, selector, tt.configure, tt.clusterEnabled, tt.withPrincipal, tt.wantError)
+			})
+		}
+	}
+}
+
+// The keys name listeners, not capabilities, so configuring several is a
+// network-placement choice and every one of them must be served.
+func TestLocalListenersEnumeratesEveryKey(t *testing.T) {
+	cfg := Default()
+	cfg.Server.AMQP091.Local.Addr = ":5683"
+	cfg.Server.AMQP091.Internal.Addr = ":5684"
+	cfg.Server.AMQP091.Service.Addr = ":5685"
+
+	listeners := cfg.Server.AMQP091.LocalListeners()
+	names := make([]string, 0, len(listeners))
+	for _, listener := range listeners {
+		names = append(names, listener.Name)
+	}
+	assert.Equal(t, []string{listenerNameLocal, listenerNameInternal, listenerNameService}, names)
+
+	assert.Equal(t, []string{listenerNameInternal, listenerNameService}, cfg.Server.AMQP091.DeprecatedLocalListenerNames(),
+		"only the aliases are reported for the deprecation warning")
+}
+
+func TestLocalListenersOmitsUnconfiguredKeys(t *testing.T) {
+	cfg := Default()
+	cfg.Server.AMQP091.Local.Addr = ":5683"
+
+	listeners := cfg.Server.AMQP091.LocalListeners()
+	require.Len(t, listeners, 1)
+	assert.Equal(t, listenerNameLocal, listeners[0].Name)
+	assert.Empty(t, cfg.Server.AMQP091.DeprecatedLocalListenerNames())
+}
+
+func runLocalListenerCase(
+	t *testing.T,
+	selector func(*Config) *AMQP091ListenerConfig,
+	configure func(*AMQP091ListenerConfig),
+	clusterEnabled, withPrincipal bool,
+	wantError string,
+) {
+	t.Helper()
+	cfg := Default()
+	cfg.Cluster.Enabled = clusterEnabled
+	configure(selector(cfg))
+	if withPrincipal {
+		cfg.Auth.LocalPrincipals = []LocalPrincipalConfig{{
+			Name:              testPrincipalName,
+			CertificateURISAN: testPrincipalSAN,
+			CurrentSecretFile: writeSecret(t, t.TempDir(), "current", strings.Repeat("a", 32)),
+		}}
+	}
+	err := cfg.Validate()
+	if wantError == "" {
+		if err != nil {
+			t.Fatalf("Validate() error = %v", err)
+		}
+		return
+	}
+	if err == nil || !strings.Contains(err.Error(), wantError) {
+		t.Fatalf("Validate() error = %v, want it to contain %q", err, wantError)
 	}
 }
 
@@ -570,6 +651,7 @@ func TestLoadAcceptsPublishPermissionFields(t *testing.T) {
 				"  local_principals:\n" +
 				"    - name: \"svc\"\n" +
 				"      certificate_uri_san: \"spiffe://absmach/svc\"\n" +
+				"      role: \"service\"\n" +
 				"      current_secret_file: \"" + secret + "\"\n" +
 				"      permissions:\n" +
 				"        publish:\n" +

--- a/config/auth_test.go
+++ b/config/auth_test.go
@@ -469,6 +469,9 @@ func TestValidateInternalAMQP091Listener(t *testing.T) {
 					Name:              testPrincipalName,
 					CertificateURISAN: testPrincipalSAN,
 					CurrentSecretFile: writeSecret(t, t.TempDir(), "current", strings.Repeat("a", 32)),
+					Permissions: LocalPermissionsConfig{
+						Publish: []LocalPublishPermission{{RoutingKey: testAuditQueue}},
+					},
 				}}
 			}
 			err := cfg.Validate()
@@ -512,6 +515,7 @@ func TestValidateLocalAMQP091Listeners(t *testing.T) {
 		configure      func(*AMQP091ListenerConfig)
 		clusterEnabled bool
 		withPrincipal  bool
+		publish        []LocalPublishPermission
 		wantError      string
 	}{
 		{
@@ -537,11 +541,23 @@ func TestValidateLocalAMQP091Listeners(t *testing.T) {
 			wantError: "auth.local_principals must contain at least one principal when server.amqp091.",
 		},
 		{
-			name:           "rejects clustering",
+			// An exact target is appended on the receiving node only, so a
+			// cluster would hide those records from consumers elsewhere.
+			name:           "rejects clustering with an exact publish target",
 			configure:      configureValid,
 			clusterEnabled: true,
 			withPrincipal:  true,
+			publish:        []LocalPublishPermission{{RoutingKey: testAuditQueue}},
 			wantError:      "cannot be combined with cluster.enabled",
+		},
+		{
+			// A prefix names no queue and is an ordinary topic publish, which
+			// the cluster forwards like any other, so it may run clustered.
+			name:           "allows clustering with prefix permissions only",
+			configure:      configureValid,
+			clusterEnabled: true,
+			withPrincipal:  true,
+			publish:        []LocalPublishPermission{{RoutingKeyPrefix: "m."}},
 		},
 		{
 			name:          "valid mandatory mTLS",
@@ -553,7 +569,7 @@ func TestValidateLocalAMQP091Listeners(t *testing.T) {
 	for key, selector := range keys {
 		for _, tt := range tests {
 			t.Run(key+"/"+tt.name, func(t *testing.T) {
-				runLocalListenerCase(t, selector, tt.configure, tt.clusterEnabled, tt.withPrincipal, tt.wantError)
+				runLocalListenerCase(t, selector, tt.configure, tt.clusterEnabled, tt.withPrincipal, tt.publish, tt.wantError)
 			})
 		}
 	}
@@ -593,6 +609,7 @@ func runLocalListenerCase(
 	selector func(*Config) *AMQP091ListenerConfig,
 	configure func(*AMQP091ListenerConfig),
 	clusterEnabled, withPrincipal bool,
+	publish []LocalPublishPermission,
 	wantError string,
 ) {
 	t.Helper()
@@ -604,6 +621,7 @@ func runLocalListenerCase(
 			Name:              testPrincipalName,
 			CertificateURISAN: testPrincipalSAN,
 			CurrentSecretFile: writeSecret(t, t.TempDir(), "current", strings.Repeat("a", 32)),
+			Permissions:       LocalPermissionsConfig{Publish: publish},
 		}}
 	}
 	err := cfg.Validate()

--- a/config/auth_test.go
+++ b/config/auth_test.go
@@ -239,13 +239,40 @@ func TestValidateLocalPrincipals(t *testing.T) {
 			wantError: "exchange must be empty; local principals may publish only through the AMQP default exchange",
 		},
 		{
-			name: "subscribe permissions are unsupported",
+			name: "subscribe permission cannot be empty",
 			principals: func() []LocalPrincipalConfig {
 				principal := valid()
-				principal.Permissions.Subscribe = []string{testAuditQueue}
+				principal.Permissions.Subscribe = []string{""}
 				return []LocalPrincipalConfig{principal}
 			},
-			wantError: "subscribe is unsupported; local principals are publish-only",
+			wantError: "permissions.subscribe[0] cannot be empty",
+		},
+		{
+			name: "subscribe permission cannot contain wildcards",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.Permissions.Subscribe = []string{testAuditQueue + ".*"}
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: "must be an exact queue name without wildcards",
+		},
+		{
+			name: "subscribe permission cannot have surrounding whitespace",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.Permissions.Subscribe = []string{" " + testAuditQueue}
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: "cannot have leading or trailing whitespace",
+		},
+		{
+			name: "subscribe permission cannot be duplicated",
+			principals: func() []LocalPrincipalConfig {
+				principal := valid()
+				principal.Permissions.Subscribe = []string{testAuditQueue, testAuditQueue}
+				return []LocalPrincipalConfig{principal}
+			},
+			wantError: "duplicates an earlier subscribe permission",
 		},
 	}
 

--- a/config/auth_test.go
+++ b/config/auth_test.go
@@ -686,3 +686,47 @@ func TestLoadAcceptsPublishPermissionFields(t *testing.T) {
 		})
 	}
 }
+
+// Clustering is restart-required while local principals are runtime-safe, so a
+// reload that disables clustering and adds an exact publish target in one edit
+// would otherwise apply the target inside a still-clustered runtime.
+func TestValidateAgainstRuntimeRefusesExactTargetWhileClustered(t *testing.T) {
+	dir := t.TempDir()
+	secret := writeSecret(t, dir, "current", strings.Repeat("a", 32))
+
+	withPermission := func(clusterEnabled bool, permission LocalPublishPermission) *Config {
+		cfg := Default()
+		cfg.Cluster.Enabled = clusterEnabled
+		cfg.Server.AMQP091.Local.Addr = testInternalAddr
+		cfg.Auth.LocalPrincipals = []LocalPrincipalConfig{{
+			Name:              testPrincipalName,
+			CertificateURISAN: testPrincipalSAN,
+			CurrentSecretFile: secret,
+			Permissions:       LocalPermissionsConfig{Publish: []LocalPublishPermission{permission}},
+		}}
+		return cfg
+	}
+
+	prefixOnly := LocalPublishPermission{RoutingKeyPrefix: "m."}
+	exact := LocalPublishPermission{RoutingKey: testAuditQueue}
+
+	t.Run("adding an exact target under a clustered runtime is refused", func(t *testing.T) {
+		err := ValidateAgainstRuntime(withPermission(true, prefixOnly), withPermission(false, exact))
+		require.Error(t, err, "the desired config disables clustering, but the running node has not restarted")
+		assert.Contains(t, err.Error(), "while the running node is clustered")
+	})
+
+	t.Run("keeping only prefixes under a clustered runtime is allowed", func(t *testing.T) {
+		assert.NoError(t, ValidateAgainstRuntime(withPermission(true, prefixOnly), withPermission(true, prefixOnly)))
+	})
+
+	t.Run("an exact target on an unclustered runtime is allowed", func(t *testing.T) {
+		assert.NoError(t, ValidateAgainstRuntime(withPermission(false, prefixOnly), withPermission(false, exact)))
+	})
+
+	t.Run("no local listener means no local publication to strand", func(t *testing.T) {
+		next := withPermission(false, exact)
+		next.Server.AMQP091.Local = AMQP091ListenerConfig{}
+		assert.NoError(t, ValidateAgainstRuntime(withPermission(true, prefixOnly), next))
+	})
+}

--- a/config/config.go
+++ b/config/config.go
@@ -27,6 +27,7 @@ const (
 	listenerNameTLS      = "tls"
 	listenerNameMTLS     = "mtls"
 	listenerNameInternal = "internal"
+	listenerNameService  = "service"
 
 	protocolMQTT    = "mqtt"
 	protocolAMQP    = "amqp"
@@ -493,6 +494,9 @@ type AMQP091Config struct {
 	TLS      AMQP091ListenerConfig `yaml:"tls"`
 	MTLS     AMQP091ListenerConfig `yaml:"mtls"`
 	Internal AMQP091ListenerConfig `yaml:"internal"`
+	// Service admits first-party services under the same mTLS local-principal
+	// rules as Internal, and additionally permits the consumer lifecycle.
+	Service AMQP091ListenerConfig `yaml:"service"`
 }
 
 // DefaultMaxInflightMessages is the fallback for Session.MaxInflightMessages
@@ -858,6 +862,7 @@ func Default() *Config {
 					MaxConnections: 10000,
 				},
 				Internal: AMQP091ListenerConfig{},
+				Service:  AMQP091ListenerConfig{},
 			},
 			HealthAddr:      ":8081",
 			HealthEnabled:   true,
@@ -1289,6 +1294,7 @@ func (c *Config) Validate() error {
 		{name: listenerNameTLS, cfg: c.Server.AMQP091.TLS, requireClientAuth: false},
 		{name: listenerNameMTLS, cfg: c.Server.AMQP091.MTLS, requireClientAuth: true},
 		{name: listenerNameInternal, cfg: c.Server.AMQP091.Internal, requireClientAuth: true, requireExactClientAuth: true},
+		{name: listenerNameService, cfg: c.Server.AMQP091.Service, requireClientAuth: true, requireExactClientAuth: true},
 	}
 
 	for _, slot := range amqp091Slots {
@@ -1300,7 +1306,7 @@ func (c *Config) Validate() error {
 		}
 		hasMessagingListener = true
 
-		if slot.name == listenerNameInternal && slot.cfg.MaxConnections <= 0 {
+		if (slot.name == listenerNameInternal || slot.name == listenerNameService) && slot.cfg.MaxConnections <= 0 {
 			return fmt.Errorf("server.amqp091.%s.max_connections must be positive", slot.name)
 		}
 		if slot.cfg.MaxConnections < 0 {
@@ -1704,8 +1710,22 @@ func ValidateLocalPrincipals(principals []LocalPrincipalConfig) error {
 			publishTargets[permission] = struct{}{}
 		}
 
-		if len(principal.Permissions.Subscribe) != 0 {
-			return fmt.Errorf("%s.permissions.subscribe is unsupported; local principals are publish-only", prefix)
+		subscribeQueues := make(map[string]struct{}, len(principal.Permissions.Subscribe))
+		for j, queue := range principal.Permissions.Subscribe {
+			permissionPrefix := fmt.Sprintf("%s.permissions.subscribe[%d]", prefix, j)
+			if queue == "" {
+				return fmt.Errorf("%s cannot be empty", permissionPrefix)
+			}
+			if strings.TrimSpace(queue) != queue {
+				return fmt.Errorf("%s cannot have leading or trailing whitespace", permissionPrefix)
+			}
+			if containsWildcard(queue) {
+				return fmt.Errorf("%s must be an exact queue name without wildcards", permissionPrefix)
+			}
+			if _, exists := subscribeQueues[queue]; exists {
+				return fmt.Errorf("%s duplicates an earlier subscribe permission", permissionPrefix)
+			}
+			subscribeQueues[queue] = struct{}{}
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -187,8 +187,9 @@ func validateLocalPrincipalYAML(node *yaml.Node, path string) error {
 				"publish": func(publish *yaml.Node) error {
 					return validateYAMLSequence(publish, path+".permissions.publish", func(entry *yaml.Node, entryPath string) error {
 						return validateYAMLMapping(entry, entryPath, map[string]func(*yaml.Node) error{
-							"exchange":    nil,
-							"routing_key": nil,
+							"exchange":           nil,
+							"routing_key":        nil,
+							"routing_key_prefix": nil,
 						})
 					})
 				},
@@ -1357,9 +1358,21 @@ func (c *Config) Validate() error {
 	if err := ValidateLocalPrincipals(c.Auth.LocalPrincipals); err != nil {
 		return err
 	}
-	if hasAddr(c.Server.AMQP091.Internal.Addr) {
+	// Both local-principal listeners authenticate against the same store and
+	// publish through the same durable path, so the requirements that follow
+	// apply to either being configured.
+	for _, listener := range []struct {
+		name string
+		addr string
+	}{
+		{name: listenerNameInternal, addr: c.Server.AMQP091.Internal.Addr},
+		{name: listenerNameService, addr: c.Server.AMQP091.Service.Addr},
+	} {
+		if !hasAddr(listener.addr) {
+			continue
+		}
 		if len(c.Auth.LocalPrincipals) == 0 {
-			return fmt.Errorf("auth.local_principals must contain at least one principal when server.amqp091.internal.addr is configured")
+			return fmt.Errorf("auth.local_principals must contain at least one principal when server.amqp091.%s.addr is configured", listener.name)
 		}
 		// A local publication is appended and synced on the receiving node only,
 		// and is deliberately never forwarded to other nodes: forwarding would
@@ -1368,7 +1381,7 @@ func (c *Config) Validate() error {
 		// elsewhere, with nothing to signal it, so refuse the combination rather
 		// than serve a listener whose records only some readers can see.
 		if c.Cluster.Enabled {
-			return fmt.Errorf("server.amqp091.internal.addr cannot be combined with cluster.enabled: local-principal publications are durable on the receiving node only and are not forwarded to other nodes; run the internal listener on a single-node deployment")
+			return fmt.Errorf("server.amqp091.%s.addr cannot be combined with cluster.enabled: local-principal publications are durable on the receiving node only and are not forwarded to other nodes; run local-principal listeners on a single-node deployment", listener.name)
 		}
 	}
 	for proto := range c.Hooks.Protocols {

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ const (
 
 	listenerNameTLS      = "tls"
 	listenerNameMTLS     = "mtls"
+	listenerNameLocal    = "local"
 	listenerNameInternal = "internal"
 	listenerNameService  = "service"
 
@@ -46,6 +47,7 @@ const (
 	storageTypeBadger = "badger"
 
 	writePolicyForward = "forward"
+	writePolicyLocal   = "local"
 	queueModeSync      = "sync"
 
 	authURLField               = "url"
@@ -101,13 +103,43 @@ type ExternalAuthConfig struct {
 	IdentityCacheTTL time.Duration `yaml:"identity_cache_ttl"`
 }
 
+// Local principal roles. A role is the capability a principal carries on every
+// listener it authenticates to, so it cannot be widened by choosing a port.
+const (
+	// LocalRolePublisher may only publish. It runs no consumer and may not
+	// relay an origin identity, because its publications are its own records.
+	LocalRolePublisher = "publisher"
+	// LocalRoleService may additionally consume, subject to its subscribe ACL,
+	// and may relay the origin identity of messages it did not author.
+	LocalRoleService = "service"
+)
+
+var knownLocalRoles = map[string]struct{}{
+	LocalRolePublisher: {},
+	LocalRoleService:   {},
+}
+
 // LocalPrincipalConfig configures a principal authenticated by FluxMQ itself.
 type LocalPrincipalConfig struct {
-	Name               string                 `yaml:"name"`
-	CertificateURISAN  string                 `yaml:"certificate_uri_san"`
+	Name              string `yaml:"name"`
+	CertificateURISAN string `yaml:"certificate_uri_san"`
+	// Role is the principal's capability, defaulting to the least privileged
+	// one. It lives here rather than on a listener because nothing binds a
+	// principal to a listener: a capability granted by a port would be granted
+	// to every principal that can reach it.
+	Role               string                 `yaml:"role,omitempty"`
 	CurrentSecretFile  string                 `yaml:"current_secret_file"`
 	PreviousSecretFile string                 `yaml:"previous_secret_file,omitempty"`
 	Permissions        LocalPermissionsConfig `yaml:"permissions"`
+}
+
+// EffectiveRole returns the configured role, defaulting to the least
+// privileged one when unset.
+func (c LocalPrincipalConfig) EffectiveRole() string {
+	if c.Role == "" {
+		return LocalRolePublisher
+	}
+	return c.Role
 }
 
 // LocalPermissionsConfig contains the publish and subscribe ACLs of one local
@@ -180,6 +212,7 @@ func validateLocalPrincipalYAML(node *yaml.Node, path string) error {
 	return validateYAMLMapping(node, path, map[string]func(*yaml.Node) error{
 		"name":                 nil,
 		"certificate_uri_san":  nil,
+		"role":                 nil,
 		"current_secret_file":  nil,
 		"previous_secret_file": nil,
 		"permissions": func(permissions *yaml.Node) error {
@@ -512,13 +545,55 @@ type AMQP091ListenerConfig struct {
 
 // AMQP091Config groups AMQP 0.9.1 listeners by mode.
 type AMQP091Config struct {
-	Plain    AMQP091ListenerConfig `yaml:"plain"`
-	TLS      AMQP091ListenerConfig `yaml:"tls"`
-	MTLS     AMQP091ListenerConfig `yaml:"mtls"`
+	Plain AMQP091ListenerConfig `yaml:"plain"`
+	TLS   AMQP091ListenerConfig `yaml:"tls"`
+	MTLS  AMQP091ListenerConfig `yaml:"mtls"`
+	// Local admits principals declared in auth.local_principals over mTLS. It
+	// confers no capability of its own: what a principal may do comes from its
+	// role. Configure more than one only to place them on separate networks.
+	Local AMQP091ListenerConfig `yaml:"local"`
+	// Internal and Service are deprecated aliases for Local, kept so existing
+	// configurations keep working. They behave identically to it and to each
+	// other; new configurations should use Local.
 	Internal AMQP091ListenerConfig `yaml:"internal"`
-	// Service admits first-party services under the same mTLS local-principal
-	// rules as Internal, and additionally permits the consumer lifecycle.
-	Service AMQP091ListenerConfig `yaml:"service"`
+	Service  AMQP091ListenerConfig `yaml:"service"`
+}
+
+// LocalListeners returns every configured local-principal listener with the
+// configuration key that named it, so callers do not have to know which of the
+// deprecated aliases an operator used.
+func (c AMQP091Config) LocalListeners() []NamedAMQP091Listener {
+	candidates := []NamedAMQP091Listener{
+		{Name: listenerNameLocal, Config: c.Local},
+		{Name: listenerNameInternal, Config: c.Internal},
+		{Name: listenerNameService, Config: c.Service},
+	}
+	listeners := make([]NamedAMQP091Listener, 0, len(candidates))
+	for _, candidate := range candidates {
+		if hasAddr(candidate.Config.Addr) {
+			listeners = append(listeners, candidate)
+		}
+	}
+	return listeners
+}
+
+// DeprecatedLocalListenerNames returns the deprecated keys an operator used, so
+// startup can name them in a warning.
+func (c AMQP091Config) DeprecatedLocalListenerNames() []string {
+	var names []string
+	if hasAddr(c.Internal.Addr) {
+		names = append(names, listenerNameInternal)
+	}
+	if hasAddr(c.Service.Addr) {
+		names = append(names, listenerNameService)
+	}
+	return names
+}
+
+// NamedAMQP091Listener pairs a listener with the configuration key that named it.
+type NamedAMQP091Listener struct {
+	Name   string
+	Config AMQP091ListenerConfig
 }
 
 // DefaultMaxInflightMessages is the fallback for Session.MaxInflightMessages
@@ -883,6 +958,7 @@ func Default() *Config {
 				MTLS: AMQP091ListenerConfig{
 					MaxConnections: 10000,
 				},
+				Local:    AMQP091ListenerConfig{},
 				Internal: AMQP091ListenerConfig{},
 				Service:  AMQP091ListenerConfig{},
 			},
@@ -1315,6 +1391,7 @@ func (c *Config) Validate() error {
 		{name: listenerNamePlain, cfg: c.Server.AMQP091.Plain, requireClientAuth: false},
 		{name: listenerNameTLS, cfg: c.Server.AMQP091.TLS, requireClientAuth: false},
 		{name: listenerNameMTLS, cfg: c.Server.AMQP091.MTLS, requireClientAuth: true},
+		{name: listenerNameLocal, cfg: c.Server.AMQP091.Local, requireClientAuth: true, requireExactClientAuth: true},
 		{name: listenerNameInternal, cfg: c.Server.AMQP091.Internal, requireClientAuth: true, requireExactClientAuth: true},
 		{name: listenerNameService, cfg: c.Server.AMQP091.Service, requireClientAuth: true, requireExactClientAuth: true},
 	}
@@ -1328,7 +1405,7 @@ func (c *Config) Validate() error {
 		}
 		hasMessagingListener = true
 
-		if (slot.name == listenerNameInternal || slot.name == listenerNameService) && slot.cfg.MaxConnections <= 0 {
+		if slot.requireExactClientAuth && slot.cfg.MaxConnections <= 0 {
 			return fmt.Errorf("server.amqp091.%s.max_connections must be positive", slot.name)
 		}
 		if slot.cfg.MaxConnections < 0 {
@@ -1358,21 +1435,12 @@ func (c *Config) Validate() error {
 	if err := ValidateLocalPrincipals(c.Auth.LocalPrincipals); err != nil {
 		return err
 	}
-	// Both local-principal listeners authenticate against the same store and
-	// publish through the same durable path, so the requirements that follow
-	// apply to either being configured.
-	for _, listener := range []struct {
-		name string
-		addr string
-	}{
-		{name: listenerNameInternal, addr: c.Server.AMQP091.Internal.Addr},
-		{name: listenerNameService, addr: c.Server.AMQP091.Service.Addr},
-	} {
-		if !hasAddr(listener.addr) {
-			continue
-		}
+	// Every local-principal listener authenticates against the same store and
+	// publishes through the same durable path, so the requirements that follow
+	// apply to whichever key configured one.
+	for _, listener := range c.Server.AMQP091.LocalListeners() {
 		if len(c.Auth.LocalPrincipals) == 0 {
-			return fmt.Errorf("auth.local_principals must contain at least one principal when server.amqp091.%s.addr is configured", listener.name)
+			return fmt.Errorf("auth.local_principals must contain at least one principal when server.amqp091.%s.addr is configured", listener.Name)
 		}
 		// A local publication is appended and synced on the receiving node only,
 		// and is deliberately never forwarded to other nodes: forwarding would
@@ -1381,7 +1449,7 @@ func (c *Config) Validate() error {
 		// elsewhere, with nothing to signal it, so refuse the combination rather
 		// than serve a listener whose records only some readers can see.
 		if c.Cluster.Enabled {
-			return fmt.Errorf("server.amqp091.%s.addr cannot be combined with cluster.enabled: local-principal publications are durable on the receiving node only and are not forwarded to other nodes; run local-principal listeners on a single-node deployment", listener.name)
+			return fmt.Errorf("server.amqp091.%s.addr cannot be combined with cluster.enabled: local-principal publications are durable on the receiving node only and are not forwarded to other nodes; run local-principal listeners on a single-node deployment", listener.Name)
 		}
 	}
 	for proto := range c.Hooks.Protocols {
@@ -1499,7 +1567,7 @@ func (c *Config) Validate() error {
 
 		if c.Cluster.Raft.WritePolicy != "" {
 			switch strings.ToLower(c.Cluster.Raft.WritePolicy) {
-			case "local", "reject", writePolicyForward:
+			case writePolicyLocal, "reject", writePolicyForward:
 			default:
 				return fmt.Errorf("cluster.raft.write_policy must be one of: local, reject, forward")
 			}
@@ -1699,6 +1767,13 @@ func ValidateLocalPrincipals(principals []LocalPrincipalConfig) error {
 			return fmt.Errorf("%s.name %q is duplicated", prefix, name)
 		}
 		names[name] = struct{}{}
+
+		if _, known := knownLocalRoles[principal.EffectiveRole()]; !known {
+			return fmt.Errorf("%s.role %q is unknown (valid: %s, %s)", prefix, principal.Role, LocalRolePublisher, LocalRoleService)
+		}
+		if principal.EffectiveRole() == LocalRolePublisher && len(principal.Permissions.Subscribe) != 0 {
+			return fmt.Errorf("%s.permissions.subscribe requires role %q; a publisher runs no consumer", prefix, LocalRoleService)
+		}
 
 		uriSAN := strings.TrimSpace(principal.CertificateURISAN)
 		if uriSAN == "" {

--- a/config/config.go
+++ b/config/config.go
@@ -208,6 +208,31 @@ func validateAuthYAML(node *yaml.Node) error {
 	})
 }
 
+// ValidateAgainstRuntime checks the rules that depend on what the process is
+// actually running rather than on what the new file asks for.
+//
+// Validate sees one config and answers for a fresh start. A reload is different:
+// its runtime-safe fields take effect immediately while restart-required ones do
+// not, so the two halves of a cross-field rule can come from different
+// configurations. Clustering is restart-required and local principals are
+// runtime-safe, so a reload that disables clustering and adds an exact publish
+// target in the same edit would pass Validate and then apply the target inside a
+// still-clustered runtime, writing records no other node forwards. Ask the
+// cluster question of the running config.
+func ValidateAgainstRuntime(running, next *Config) error {
+	if running == nil || next == nil || !running.Cluster.Enabled {
+		return nil
+	}
+	if len(next.Server.AMQP091.LocalListeners()) == 0 {
+		return nil
+	}
+	name, target, found := firstExactPublishTarget(next.Auth.LocalPrincipals)
+	if !found {
+		return nil
+	}
+	return fmt.Errorf("auth.local_principals %q grants the exact publish target %q, which cannot be applied while the running node is clustered: clustering is restart-required, so disabling it in the same reload does not take effect until restart; restart the node to change both together", name, target)
+}
+
 // firstExactPublishTarget reports the first principal granting an exact publish
 // target, naming it so the operator can find the entry to change.
 func firstExactPublishTarget(principals []LocalPrincipalConfig) (principal, target string, found bool) {

--- a/config/config.go
+++ b/config/config.go
@@ -223,7 +223,10 @@ func ValidateAgainstRuntime(running, next *Config) error {
 	if running == nil || next == nil || !running.Cluster.Enabled {
 		return nil
 	}
-	if len(next.Server.AMQP091.LocalListeners()) == 0 {
+	// Listener changes are restart-required too. Ask whether the running
+	// process has a local listener; removing it from the desired file does not
+	// stop that listener before the runtime-safe principal snapshot is applied.
+	if len(running.Server.AMQP091.LocalListeners()) == 0 {
 		return nil
 	}
 	name, target, found := firstExactPublishTarget(next.Auth.LocalPrincipals)

--- a/config/config.go
+++ b/config/config.go
@@ -110,16 +110,37 @@ type LocalPrincipalConfig struct {
 	Permissions        LocalPermissionsConfig `yaml:"permissions"`
 }
 
-// LocalPermissionsConfig contains exact-match publish and subscribe ACLs.
+// LocalPermissionsConfig contains the publish and subscribe ACLs of one local
+// principal. Subscribe entries are exact queue names.
 type LocalPermissionsConfig struct {
 	Publish   []LocalPublishPermission `yaml:"publish"`
 	Subscribe []string                 `yaml:"subscribe"`
 }
 
-// LocalPublishPermission grants publish access to one exact AMQP target.
+// LocalPublishPermission grants publish access to an AMQP target, named either
+// exactly or by routing-key prefix. Exactly one of RoutingKey and
+// RoutingKeyPrefix must be set.
+//
+// An exact permission is what a durable-stream publisher needs: the routing key
+// names the queue it appends to, so it must also appear under queues.
+//
+// A prefix permission exists because a service publishes to topics derived from
+// its own runtime data — a tenant identifier, a channel identifier — which
+// cannot be enumerated in broker configuration. It grants every routing key
+// under the prefix and is checked against no queue, so it authorizes topic
+// publishing rather than a durable append. Keep the prefix as narrow as the
+// service's topic namespace allows: it is what separates one service's reach
+// from another's.
 type LocalPublishPermission struct {
-	Exchange   string `yaml:"exchange"`
-	RoutingKey string `yaml:"routing_key"`
+	Exchange         string `yaml:"exchange"`
+	RoutingKey       string `yaml:"routing_key,omitempty"`
+	RoutingKeyPrefix string `yaml:"routing_key_prefix,omitempty"`
+}
+
+// IsPrefix reports whether the permission grants a routing-key prefix rather
+// than one exact routing key.
+func (p LocalPublishPermission) IsPrefix() bool {
+	return p.RoutingKeyPrefix != ""
 }
 
 // UnmarshalYAML keeps the auth subtree strict without changing the historical
@@ -1695,14 +1716,28 @@ func ValidateLocalPrincipals(principals []LocalPrincipalConfig) error {
 			if permission.Exchange != "" {
 				return fmt.Errorf("%s.exchange must be empty; local principals may publish only through the AMQP default exchange", permissionPrefix)
 			}
-			if permission.RoutingKey == "" {
-				return fmt.Errorf("%s.routing_key cannot be empty", permissionPrefix)
-			}
 			if containsWildcard(permission.Exchange) {
 				return fmt.Errorf("%s.exchange must be an exact value without wildcards", permissionPrefix)
 			}
-			if containsWildcard(permission.RoutingKey) {
-				return fmt.Errorf("%s.routing_key must be an exact value without wildcards", permissionPrefix)
+			if permission.RoutingKey != "" && permission.RoutingKeyPrefix != "" {
+				return fmt.Errorf("%s cannot set both routing_key and routing_key_prefix", permissionPrefix)
+			}
+			// A prefix is a wildcard by construction, so it must never be written
+			// as one: accepting "m.#" would silently grant the literal "#" too.
+			if permission.IsPrefix() {
+				if containsWildcard(permission.RoutingKeyPrefix) {
+					return fmt.Errorf("%s.routing_key_prefix must not contain wildcards; it already matches every routing key beneath it", permissionPrefix)
+				}
+				if strings.TrimSpace(permission.RoutingKeyPrefix) != permission.RoutingKeyPrefix {
+					return fmt.Errorf("%s.routing_key_prefix cannot have leading or trailing whitespace", permissionPrefix)
+				}
+			} else {
+				if permission.RoutingKey == "" {
+					return fmt.Errorf("%s must set either routing_key or routing_key_prefix", permissionPrefix)
+				}
+				if containsWildcard(permission.RoutingKey) {
+					return fmt.Errorf("%s.routing_key must be an exact value without wildcards", permissionPrefix)
+				}
 			}
 			if _, exists := publishTargets[permission]; exists {
 				return fmt.Errorf("%s duplicates an earlier publish permission", permissionPrefix)

--- a/config/config.go
+++ b/config/config.go
@@ -208,6 +208,19 @@ func validateAuthYAML(node *yaml.Node) error {
 	})
 }
 
+// firstExactPublishTarget reports the first principal granting an exact publish
+// target, naming it so the operator can find the entry to change.
+func firstExactPublishTarget(principals []LocalPrincipalConfig) (principal, target string, found bool) {
+	for _, candidate := range principals {
+		for _, permission := range candidate.Permissions.Publish {
+			if !permission.IsPrefix() {
+				return candidate.Name, permission.RoutingKey, true
+			}
+		}
+	}
+	return "", "", false
+}
+
 func validateLocalPrincipalYAML(node *yaml.Node, path string) error {
 	return validateYAMLMapping(node, path, map[string]func(*yaml.Node) error{
 		"name":                 nil,
@@ -1435,21 +1448,28 @@ func (c *Config) Validate() error {
 	if err := ValidateLocalPrincipals(c.Auth.LocalPrincipals); err != nil {
 		return err
 	}
-	// Every local-principal listener authenticates against the same store and
-	// publishes through the same durable path, so the requirements that follow
-	// apply to whichever key configured one.
+	// Every local-principal listener authenticates against the same store, so a
+	// listener under any of the keys requires the store to be populated.
 	for _, listener := range c.Server.AMQP091.LocalListeners() {
 		if len(c.Auth.LocalPrincipals) == 0 {
 			return fmt.Errorf("auth.local_principals must contain at least one principal when server.amqp091.%s.addr is configured", listener.Name)
 		}
-		// A local publication is appended and synced on the receiving node only,
-		// and is deliberately never forwarded to other nodes: forwarding would
-		// acknowledge a publisher on a barrier no single node established. In a
-		// cluster that makes the records unreachable from consumers attached
-		// elsewhere, with nothing to signal it, so refuse the combination rather
-		// than serve a listener whose records only some readers can see.
+		// An exact publish target is appended and synced on the receiving node
+		// only, and is deliberately never forwarded to other nodes: forwarding
+		// would acknowledge a publisher on a barrier no single node established.
+		// In a cluster that makes those records unreachable from consumers
+		// attached elsewhere, with nothing to signal it, so refuse the
+		// combination rather than serve a principal whose records only some
+		// readers can see.
+		//
+		// The permission decides this, not the listener, exactly as it decides
+		// how a publication is routed. A prefix permission names no queue and is
+		// an ordinary topic publish, which the cluster forwards like any other,
+		// so a principal holding only prefix permissions may run clustered.
 		if c.Cluster.Enabled {
-			return fmt.Errorf("server.amqp091.%s.addr cannot be combined with cluster.enabled: local-principal publications are durable on the receiving node only and are not forwarded to other nodes; run local-principal listeners on a single-node deployment", listener.Name)
+			if name, target, found := firstExactPublishTarget(c.Auth.LocalPrincipals); found {
+				return fmt.Errorf("auth.local_principals %q grants the exact publish target %q, which cannot be combined with cluster.enabled: an exact target is durable on the receiving node only and is not forwarded to other nodes; grant permissions.publish[].routing_key_prefix instead, or run server.amqp091.%s on a single-node deployment", name, target, listener.Name)
+			}
 		}
 	}
 	for proto := range c.Hooks.Protocols {

--- a/config/config.go
+++ b/config/config.go
@@ -1795,9 +1795,9 @@ func validateListenerTLS(prefix string, cfg mqtttls.Config, requireCA bool) erro
 
 // ValidateLocalPrincipals checks the declarative rules for local principals:
 // unique non-blank names and absolute URI SANs, readable high-entropy secret
-// files, and exact publish-only permissions. It is the single definition of
-// those rules, shared with the runtime store that loads the same section, so
-// startup validation and a SIGHUP reload cannot drift apart.
+// files, roles, and exact-or-prefix publish permissions. It is the single
+// definition of those rules, shared with the runtime store that loads the same
+// section, so startup validation and a SIGHUP reload cannot drift apart.
 func ValidateLocalPrincipals(principals []LocalPrincipalConfig) error {
 	names := make(map[string]struct{}, len(principals))
 	uriSANs := make(map[string]struct{}, len(principals))

--- a/config/diff_test.go
+++ b/config/diff_test.go
@@ -238,12 +238,12 @@ func TestClassifyFieldDefault(t *testing.T) {
 	}
 }
 
-// Local-principal ACLs are runtime-safe while the listener that serves them is
-// not. That asymmetry is what keeps a reload from applying node-local durable
-// grants inside a still-clustered runtime: a local listener cannot be brought
-// up without a restart, and startup refuses to bring one up alongside
-// clustering at all. Making a listener field runtime-safe would open that
-// window, so pin both classifications.
+// Local-principal ACLs are runtime-safe while clustering and the listener that
+// serves them are not. That asymmetry is why a reload cannot be validated
+// against the file alone: an exact publish target would apply immediately while
+// a clustering change in the same edit waits for restart. ValidateAgainstRuntime
+// closes that window; these classifications are what make it necessary, so pin
+// them and fail loudly if any of them moves.
 func TestLocalListenerCannotStartWithoutRestart(t *testing.T) {
 	for _, field := range []string{
 		"Server",

--- a/config/diff_test.go
+++ b/config/diff_test.go
@@ -238,6 +238,29 @@ func TestClassifyFieldDefault(t *testing.T) {
 	}
 }
 
+// Local-principal ACLs are runtime-safe while the listener that serves them is
+// not. That asymmetry is what keeps a reload from applying node-local durable
+// grants inside a still-clustered runtime: a local listener cannot be brought
+// up without a restart, and startup refuses to bring one up alongside
+// clustering at all. Making a listener field runtime-safe would open that
+// window, so pin both classifications.
+func TestLocalListenerCannotStartWithoutRestart(t *testing.T) {
+	for _, field := range []string{
+		"Server",
+		"Server.AMQP091",
+		"Server.AMQP091.Local",
+		"Server.AMQP091.Local.Addr",
+		"Cluster.Enabled",
+	} {
+		if got := ClassifyField(field); got != RestartRequired {
+			t.Errorf("ClassifyField(%q) = %s, want %s", field, got, RestartRequired)
+		}
+	}
+	if got := ClassifyField("Auth.LocalPrincipals"); got != RuntimeSafe {
+		t.Errorf("ClassifyField(\"Auth.LocalPrincipals\") = %s, want %s", got, RuntimeSafe)
+	}
+}
+
 func TestReloadClassString(t *testing.T) {
 	if RuntimeSafe.String() != "runtime_safe" {
 		t.Errorf("RuntimeSafe.String() = %q", RuntimeSafe.String())

--- a/deployments/docker/README.md
+++ b/deployments/docker/README.md
@@ -51,11 +51,11 @@ FLUXMQ_NODE_URLS=http://my-broker:8082
 
 ## Dedicated local-principal AMQP listener
 
-`compose.local-principal.yaml` is a production-shaped overlay for an Atom audit
+`compose.local-principal.yaml` is a production-shaped overlay for an Atom event
 publisher. It keeps remote AMQP over TLS on port `5682`, enables an mTLS-only
-internal listener on container port `5683`, explicitly disables FluxMQ's
+local listener on container port `5683`, explicitly disables FluxMQ's
 otherwise-default MQTT, WebSocket, and AMQP 1.0 listeners, mounts local
-credentials as Docker secrets, and pre-provisions the `atom-audit` stream.
+credentials as Docker secrets, and pre-provisions the `atom.events` stream.
 
 The overlay requires Docker Compose 2.24.4 or newer because it uses
 `!override` to remove the base file's unused host port mappings.
@@ -112,16 +112,16 @@ Attach Atom to the Compose project's `atom-internal` network and connect to
 `fluxmq:5683`; the server certificate must be valid for the name the Atom AMQP
 client verifies. Do not attach public services to that network. If the subnet
 conflicts with your environment, change the Compose subnet, FluxMQ static
-address, and `server.amqp091.internal.addr` together.
+address, and `server.amqp091.local.addr` together.
 
-The internal listener requires all three credentials:
+The local listener requires all three credentials:
 
 - SASL username `atom-audit-publisher`;
 - the secret from `ATOM_AUDIT_SECRET_CURRENT_FILE`;
 - a client certificate signed by `ATOM_CLIENT_CA_FILE` with URI SAN
   `spiffe://absmach/atom/audit-publisher`.
 
-It may publish only to the default exchange with routing key `atom-audit`.
+It may publish only to the default exchange with routing key `atom.events`.
 Subscriptions and topology operations are denied. Confirmed delivery remains
 at least once: Atom must reuse a stable event ID on retries, and consumers must
 deduplicate it. See

--- a/deployments/docker/config-local-principal.yaml
+++ b/deployments/docker/config-local-principal.yaml
@@ -1,4 +1,4 @@
-# Production-shaped single-node configuration for the dedicated Atom audit
+# Production-shaped single-node configuration for the dedicated Atom event
 # publisher listener. Use with compose.local-principal.yaml.
 
 server:
@@ -38,7 +38,7 @@ server:
 
     # Bind only to FluxMQ's fixed address on the private atom-internal Docker
     # network. Do not replace this with :5683 in a multi-network container.
-    internal:
+    local:
       addr: "172.30.0.2:5683"
       max_connections: 32
       cert_file: "/run/secrets/fluxmq_server_cert"
@@ -80,18 +80,19 @@ auth:
   local_principals:
     - name: "atom-audit-publisher"
       certificate_uri_san: "spiffe://absmach/atom/audit-publisher"
+      role: "publisher"
       current_secret_file: "/run/secrets/atom_audit_secret_current"
       previous_secret_file: "/run/secrets/atom_audit_secret_previous"
       permissions:
         publish:
           - exchange: ""
-            routing_key: "atom-audit"
+            routing_key: "atom.events"
         subscribe: []
 
 queues:
-  - name: "atom-audit"
+  - name: "atom.events"
     topics:
-      - "$queue/atom-audit/#"
+      - "$queue/atom.events/#"
     reserved: true
     type: "stream"
     retention:

--- a/docs/content/docs/configuration/hot-reload.md
+++ b/docs/content/docs/configuration/hot-reload.md
@@ -113,7 +113,7 @@ All other fields require a full restart to take effect. These include:
 - **Session**: session defaults (affects existing connections)
 - **Webhook**: webhook worker pool configuration
 - **External auth**: `auth.external` callout and cache settings
-- **Local listener transport**: `server.amqp091.internal` address, limits, and TLS settings
+- **Local listener transport**: `server.amqp091.local` address, limits, and TLS settings
 - **Hooks**: blocking hook callout configuration
 - **AMQP / AMQP 0.9.1**: all protocol-level settings
 

--- a/docs/content/docs/configuration/security.md
+++ b/docs/content/docs/configuration/security.md
@@ -38,7 +38,7 @@ that mesh, never for cross-host traffic.
 By default, all protocols require auth when `auth.external.url` is set. The
 `protocols` map lets you selectively enable or disable the external callout per
 protocol. Internal AMQP services that need local authentication use
-`server.amqp091.internal`; they do not disable authentication on a remote
+`server.amqp091.local`; they do not disable authentication on a remote
 listener.
 
 ```yaml
@@ -74,13 +74,13 @@ declared in FluxMQ's own configuration — audit and event streams, internal
 telemetry, and similar broker-adjacent pipelines. Principals are static: adding
 one is a configuration and secret-provisioning change followed by `SIGHUP`,
 never a runtime registration. There is no dynamic, per-tenant, or per-user
-identity here, and each entry grants exactly one publish target. Remote
+identity here, and each entry grants exactly the targets it names. Remote
 clients, devices, and tenants authenticate through `auth.external`.
 
 ```yaml
 server:
   amqp091:
-    internal:
+    local:
       addr: ":5683"
       max_connections: 32
       cert_file: "/run/secrets/fluxmq_server_cert"
@@ -107,9 +107,9 @@ username, and local secret to match one configured principal. Permissions are
 exact-match allowlists. Port `5683` must remain on a private network and must
 not be published to the host or Internet.
 
-The listener is single-node only. Its publications are durable on the receiving
-node and are never forwarded to other nodes, so configuring it together with
-`cluster.enabled` is a startup error rather than a deployment whose records
+Local-principal listeners are single-node only. Their publications are durable
+on the receiving node and are never forwarded to other nodes, so configuring one
+together with `cluster.enabled` is a startup error rather than a deployment whose records
 some consumers cannot reach. `cluster.enabled` defaults to true, so it must be
 set to false explicitly.
 
@@ -130,9 +130,9 @@ abandoned appends waiting on one stream is capped; publications beyond that cap
 are refused before any storage work starts, and both outcomes close the channel
 so a stalled stream cannot accumulate retries.
 
-On this listener a principal is publish-only: every consume, `basic.get`, and
-`queue.declare` is denied whatever `permissions.subscribe` says. Consumers
-require the [service listener](#service-listener) below.
+What a principal may do here is decided by its [role](#principal-roles), not by
+this listener. A `publisher` is refused every consume, `basic.get`, and
+`queue.declare`; a `service` is admitted subject to its own subscribe ACL.
 
 Local-principal counters are exposed under
 `by_protocol.amqp.local_principals` in `GET /api/v1/stats`. They cover active
@@ -165,25 +165,37 @@ FluxMQ's own configuration. Every other connection — MQTT, HTTP, CoAP, AMQP
 Speaking AMQP does not by itself confer trust, and an externally authenticated
 AMQP client is never treated as a service.
 
-### Service Listener
+### Principal Roles
 
-`server.amqp091.internal` admits publish-only principals: it exists for audit
-records, so a principal there may publish to the targets its ACL names and
-nothing else, and may never relay an origin identity.
+A local principal carries a **role**, and the role is what decides its
+capability. Roles live on the principal rather than on a listener because
+nothing binds a principal to a listener: any principal with a valid certificate
+and secret can connect to any local listener, so a capability granted by a port
+would be granted to every principal able to reach that port.
 
-`server.amqp091.service` admits the same kind of mTLS local principal but also
-permits the consumer lifecycle, so a first-party service can subscribe and read
-the reserved properties another service set. It is what makes the namespace
-useful in both directions rather than write-only.
+| Role | May publish | May consume | May relay an origin identity |
+| --- | --- | --- | --- |
+| `publisher` (default) | yes, per its ACL | no | no |
+| `service` | yes, per its ACL | yes, per its ACL | yes |
 
-A service listener grants no blanket access. Every operation is still authorized
-against the principal's own ACL:
+`publisher` is the default when `role` is omitted, so an unspecified principal
+gets the least privilege. It is the audit-publisher shape: its publications are
+its own records, so it may never attribute one to another origin.
+
+`service` additionally runs consumers and may relay the true origin of messages
+it did not author. It is what makes the reserved-property namespace useful in
+both directions rather than write-only, because a service can read what another
+service set.
+
+A role grants no blanket access. Every operation is still authorized against the
+principal's own ACL:
 
 ```yaml
 auth:
   local_principals:
     - name: rules-engine
       certificate_uri_san: spiffe://absmach/magistrala/rules-engine
+      role: service
       current_secret_file: /run/secrets/re-current
       permissions:
         publish:
@@ -192,9 +204,34 @@ auth:
           - m
 ```
 
+Declaring `permissions.subscribe` on a `publisher` is rejected at load rather
+than silently ignored, so a principal's configuration cannot suggest a
+capability it does not have.
+
+The role joins the permissions fingerprint, so demoting a `service` to a
+`publisher` revokes its live sessions exactly as narrowing an ACL or rotating a
+credential does. A demoted principal does not keep consuming until it happens to
+reconnect.
+
+### Listeners
+
+`server.amqp091.local` admits mTLS peers whose verified certificate URI SAN
+matches a configured principal. It confers no capability of its own. Configure
+more than one local listener only when you want, say, the audit path and the
+service path on separate network segments; one is enough otherwise. Each
+requires a configured principal and each refuses to run alongside
+`cluster.enabled`, because local publications are durable on the receiving node
+only.
+
+`server.amqp091.internal` and `server.amqp091.service` are deprecated aliases
+for `local`. They behave identically to it and to each other, and FluxMQ logs a
+warning naming any that are still in use. They exist because capability used to
+be a property of the listener; it is now a property of the principal, so the
+distinction they drew no longer means anything.
+
 `subscribe` names exact queues; wildcards, duplicates, blank entries, and
 surrounding whitespace are rejected at load. A principal declaring no
-`subscribe` entry is refused a consumer even on the service listener, and one
+`subscribe` entry is refused a consumer even with the `service` role, and one
 declaring no `publish` entry cannot publish. Unlike exact publish targets,
 subscribe targets need no matching `queues` entry: the durability contract those
 carry exists because local publishes are acknowledged as crash-durable, which
@@ -242,13 +279,9 @@ while an empty or single-character prefix is not. The same string as an exact
 key and as a prefix are different grants and produce different permissions
 fingerprints, so narrowing one into the other revokes existing sessions.
 
-Publish and subscribe ACLs share one permissions fingerprint, so narrowing
-either revokes the sessions that authenticated under the wider one, exactly as a
+The role and both ACLs share one permissions fingerprint, so narrowing any of
+them revokes the sessions that authenticated under the wider one, exactly as a
 credential rotation does.
-
-A service relays messages it did not originate, so unlike a publish-only
-principal it may state a message's true `external_id` and `protocol` rather than
-having its own identity stamped on them.
 
 The admin API (`server.api`) is exempt because it is an operator plane, not a
 client plane: it is unauthenticated and already exposes session inspection and
@@ -263,18 +296,16 @@ properties describing who published it and over which transport. These are
 stamped from the authenticated connection, so a publisher cannot attribute its
 message to another principal or claim it arrived over another protocol.
 
-A trusted AMQP 0.9.1 service relaying a message on behalf of an original
-publisher may override `external_id` and `protocol` to preserve the true
-origin, by setting them as message headers. The same trust rule as reserved
-properties applies, with one addition: a **local principal may not** relay an
-origin either. Its identity is fixed by configuration and its publications are
-audit records, so relaying would make the record disagree with the peer that
-actually authenticated. Untrusted connections on every protocol — including
-AMQP 0.9.1 remote and AMQP 1.0 — have any supplied value discarded and
-replaced with their own authenticated identity.
+A local principal with the `service` role may relay a message it did not
+author, overriding `external_id` and `protocol` with the true origin by setting
+them as message headers. A `publisher` may not: its publications are its own
+records, and a relayed origin would make one disagree with the principal that
+authenticated. Because the rule follows the role rather than the listener, a
+publisher stays a publisher on whichever local listener it connects to.
 
-Ordinary user properties are unaffected and continue to flow in both
-directions on every protocol that supports them.
+Untrusted connections on every protocol — including AMQP 0.9.1 remote and AMQP
+1.0 — have any supplied value discarded and replaced with their own
+authenticated identity.
 
 ## Blocking Hooks
 

--- a/docs/content/docs/configuration/security.md
+++ b/docs/content/docs/configuration/security.md
@@ -119,11 +119,12 @@ prefix permissions runs clustered without restriction. The permission decides
 this, exactly as it decides how the publication is routed.
 
 The same rule is applied to reloads against the running node rather than the
-new file. `auth.local_principals` reloads at runtime while `cluster.enabled`
-requires a restart, so a single edit that disables clustering and adds an exact
-target would otherwise apply the target immediately while the node stayed
-clustered. Such a reload is refused; make the two changes in separate steps,
-restarting in between.
+new file. `auth.local_principals` reloads at runtime while `cluster.enabled` and
+local listener changes require a restart. A single edit that disables
+clustering or removes the local listener while adding an exact target would
+otherwise apply the target immediately while the node stayed clustered and its
+listener stayed active. Such a reload is refused; make the changes in separate
+steps, restarting in between.
 
 Publish permissions support only the default exchange (`exchange: ""`) and an
 exact, non-empty routing key. Other exchanges and wildcard routing keys are
@@ -257,10 +258,17 @@ exists, which is a configuration write: services consume queues that were
 provisioned for them, so they never need it. `basic.get`, `queue.bind`,
 `queue.unbind`, `queue.purge`, and `queue.delete` are refused.
 
+Consumption also uses a non-mutating queue-manager operation: it fails if the
+queue does not exist and a stream cursor is refused for a queue not already
+configured as a stream. A read grant therefore cannot create a queue or change
+its type indirectly through `basic.consume`.
+
 `subscribe` names queues, but a client addresses one through the queue prefix,
 so `subscribe: [m]` authorizes `basic.consume` on `$queue/m`. The wire value is
 resolved before it is matched, and an address that resolves to no queue —
 a bare `m`, or a pub/sub filter — is refused, because no entry grants one.
+`queue.declare` follows AMQP queue-name semantics instead: its passive assertion
+uses the bare name `m`, which is matched directly against the same ACL entry.
 
 #### Publish targets: exact keys and prefixes
 

--- a/docs/content/docs/configuration/security.md
+++ b/docs/content/docs/configuration/security.md
@@ -242,13 +242,18 @@ subscribe targets need no matching `queues` entry: the durability contract those
 carry exists because local publishes are acknowledged as crash-durable, which
 does not apply to reading.
 
-A subscribe permission grants reads and nothing else. `basic.consume` and
-`basic.get` are allowed for the queues it names, and `queue.declare` is allowed
-only in its passive form, to assert that a queue exists. A non-passive declare
-creates a queue and rewrites the type, retention, TTL and durability of one that
-already exists, which is a configuration write: services consume queues that
-were provisioned for them, so they never need it. `queue.bind`, `queue.unbind`,
-`queue.purge`, and `queue.delete` are refused on both listeners.
+A subscribe permission grants reads and nothing else. `basic.consume` is
+allowed for the queues it names, and `queue.declare` is allowed only in its
+passive form, to assert that a queue exists. A non-passive declare creates a
+queue and rewrites the type, retention, TTL and durability of one that already
+exists, which is a configuration write: services consume queues that were
+provisioned for them, so they never need it. `basic.get`, `queue.bind`,
+`queue.unbind`, `queue.purge`, and `queue.delete` are refused.
+
+`subscribe` names queues, but a client addresses one through the queue prefix,
+so `subscribe: [m]` authorizes `basic.consume` on `$queue/m`. The wire value is
+resolved before it is matched, and an address that resolves to no queue —
+a bare `m`, or a pub/sub filter — is refused, because no entry grants one.
 
 #### Publish targets: exact keys and prefixes
 
@@ -265,12 +270,15 @@ a tenant identifier, a channel identifier, a subtopic — which cannot be
 enumerated in broker configuration. The Rules Engine republishing a rule output
 to `m.<domain>.c.<channel>.<subtopic>` is the motivating case.
 
-The permission that matched decides how the publication is delivered, on either
-listener. An exact target is appended to its protected stream and synced before
-the publisher confirm; a prefix match is routed as an ordinary topic publish and
-carries no durability barrier. This is a property of the permission, not of the
-port the principal connected to, so one `permissions.publish` entry means the
-same thing everywhere.
+The permission that matched decides how the publication is delivered. An exact
+target is appended to its protected stream and synced before the publisher
+confirm; a prefix match is always routed as an ordinary topic publish and
+carries no durability barrier. A prefix grant can never reach a queue, whatever
+routing key it covers — not through a `$queue/`-shaped prefix, and not through a
+routing key that happens to name a configured stream — because it was authorized
+against no `queues` entry. This is a property of the permission, not of the port
+the principal connected to, so one `permissions.publish` entry means the same
+thing everywhere.
 
 A prefix is a wildcard by construction and must never be written as one:
 `m.#` is rejected, because accepting it would silently grant the literal `#`

--- a/docs/content/docs/configuration/security.md
+++ b/docs/content/docs/configuration/security.md
@@ -169,9 +169,8 @@ API, and no client may set or read one.
 
 The boundary is the listener's trust policy, not the protocol. Only the AMQP
 0.9.1 `local` listener and its deprecated `internal` and `service` aliases are
-trusted, because they admit solely
-mTLS peers whose verified certificate URI SAN matches a principal declared in
-FluxMQ's own configuration. Every other connection — MQTT, HTTP, CoAP, AMQP
+trusted, because they admit solely mTLS peers whose verified certificate URI
+SAN matches a principal declared in FluxMQ's own configuration. Every other connection — MQTT, HTTP, CoAP, AMQP
 1.0, and AMQP 0.9.1 on the remote listener — is treated as a tenant or device:
 
 - **Ingress**: reserved properties supplied by an untrusted publisher are

--- a/docs/content/docs/configuration/security.md
+++ b/docs/content/docs/configuration/security.md
@@ -118,6 +118,13 @@ which the cluster forwards like any other message, so a principal holding only
 prefix permissions runs clustered without restriction. The permission decides
 this, exactly as it decides how the publication is routed.
 
+The same rule is applied to reloads against the running node rather than the
+new file. `auth.local_principals` reloads at runtime while `cluster.enabled`
+requires a restart, so a single edit that disables clustering and adds an exact
+target would otherwise apply the target immediately while the node stayed
+clustered. Such a reload is refused; make the two changes in separate steps,
+restarting in between.
+
 Publish permissions support only the default exchange (`exchange: ""`) and an
 exact, non-empty routing key. Other exchanges and wildcard routing keys are
 rejected when the configuration is loaded. At publish time the ACL is applied

--- a/docs/content/docs/configuration/security.md
+++ b/docs/content/docs/configuration/security.md
@@ -186,7 +186,7 @@ auth:
       current_secret_file: /run/secrets/re-current
       permissions:
         publish:
-          - routing_key: m
+          - routing_key_prefix: "m."
         subscribe:
           - m
 ```
@@ -198,6 +198,33 @@ declaring no `publish` entry cannot publish. Unlike publish targets, subscribe
 targets need no matching `queues` entry: the durability contract that publish
 targets carry exists because local publishes are acknowledged as crash-durable,
 which does not apply to reading.
+
+#### Publish targets: exact keys and prefixes
+
+A publish permission sets exactly one of `routing_key` or `routing_key_prefix`.
+
+`routing_key` names one exact target. It is what a durable-stream publisher
+needs, because the routing key is the queue it appends to, so it must also
+appear under `queues`. The audit publisher uses this form.
+
+`routing_key_prefix` grants every routing key beneath it and is checked against
+no queue, so it authorizes topic publishing rather than a durable append. It
+exists because a service publishes to topics built from its own runtime data —
+a tenant identifier, a channel identifier, a subtopic — which cannot be
+enumerated in broker configuration. The Rules Engine republishing a rule output
+to `m.<domain>.c.<channel>.<subtopic>` is the motivating case.
+
+A prefix is a wildcard by construction and must never be written as one:
+`m.#` is rejected, because accepting it would silently grant the literal `#`
+as well. Prefix matching is a plain string prefix over the routing key and
+applies only to the default exchange, the same restriction every publish
+permission carries.
+
+Keep the prefix as narrow as the service's topic namespace allows. It is what
+separates one service's reach from another's, so `m.` is a meaningful boundary
+while an empty or single-character prefix is not. The same string as an exact
+key and as a prefix are different grants and produce different permissions
+fingerprints, so narrowing one into the other revokes existing sessions.
 
 Publish and subscribe ACLs share one permissions fingerprint, so narrowing
 either revokes the sessions that authenticated under the wider one, exactly as a

--- a/docs/content/docs/configuration/security.md
+++ b/docs/content/docs/configuration/security.md
@@ -107,11 +107,16 @@ username, and local secret to match one configured principal. Permissions are
 exact-match allowlists. Port `5683` must remain on a private network and must
 not be published to the host or Internet.
 
-Local-principal listeners are single-node only. Their publications are durable
-on the receiving node and are never forwarded to other nodes, so configuring one
-together with `cluster.enabled` is a startup error rather than a deployment whose records
-some consumers cannot reach. `cluster.enabled` defaults to true, so it must be
-set to false explicitly.
+An **exact** publish target is single-node only. It is appended and synced on
+the receiving node and never forwarded, so granting one together with
+`cluster.enabled` is a startup error rather than a deployment whose records some
+consumers cannot reach. `cluster.enabled` defaults to true, so a principal
+holding an exact target needs it set to false explicitly.
+
+A **prefix** publish target names no queue and is an ordinary topic publish,
+which the cluster forwards like any other message, so a principal holding only
+prefix permissions runs clustered without restriction. The permission decides
+this, exactly as it decides how the publication is routed.
 
 Publish permissions support only the default exchange (`exchange: ""`) and an
 exact, non-empty routing key. Other exchanges and wildcard routing keys are
@@ -219,9 +224,9 @@ reconnect.
 matches a configured principal. It confers no capability of its own. Configure
 more than one local listener only when you want, say, the audit path and the
 service path on separate network segments; one is enough otherwise. Each
-requires a configured principal and each refuses to run alongside
-`cluster.enabled`, because local publications are durable on the receiving node
-only.
+requires a configured principal. Whether a deployment may run clustered is a
+question about the permissions its principals hold, not about the listener: see
+the exact-versus-prefix distinction above.
 
 `server.amqp091.internal` and `server.amqp091.service` are deprecated aliases
 for `local`. They behave identically to it and to each other, and FluxMQ logs a

--- a/docs/content/docs/configuration/security.md
+++ b/docs/content/docs/configuration/security.md
@@ -5,7 +5,7 @@ description: External auth, local principals, TLS/mTLS listeners, and rate limit
 
 # Security Configuration
 
-**Last Updated:** 2026-07-29
+**Last Updated:** 2026-08-01
 
 ## External Auth Callout
 
@@ -60,7 +60,7 @@ Valid protocol keys: `mqtt`, `amqp`, `amqp091`, `http`, `coap`.
 When the `protocols` map is omitted or empty, all protocols require external
 auth. When the map is present, only protocols set to `true` get external auth;
 all others allow connections without external authentication. Do not disable
-external auth merely to carry internal traffic. Use an internal listener with
+external auth merely to carry internal traffic. Use a local listener with
 a local principal instead.
 
 ## Internal AMQP Local Principals
@@ -93,18 +93,20 @@ auth:
   local_principals:
     - name: "atom-audit-publisher"
       certificate_uri_san: "spiffe://absmach/atom/audit-publisher"
+      role: "publisher"
       current_secret_file: "/run/secrets/atom_audit_secret_current"
       previous_secret_file: "/run/secrets/atom_audit_secret_previous"
       permissions:
         publish:
           - exchange: ""
-            routing_key: "atom-audit"
+            routing_key: "atom.events"
         subscribe: []
 ```
 
-The internal listener requires a CA-verified certificate URI SAN, SASL
+The local listener requires a CA-verified certificate URI SAN, SASL
 username, and local secret to match one configured principal. Permissions are
-exact-match allowlists. Port `5683` must remain on a private network and must
+explicit allowlists of exact routing keys, routing-key prefixes, and exact
+subscription queues. Port `5683` must remain on a private network and must
 not be published to the host or Internet.
 
 An **exact** publish target is single-node only. It is appended and synced on
@@ -126,14 +128,15 @@ otherwise apply the target immediately while the node stayed clustered and its
 listener stayed active. Such a reload is refused; make the changes in separate
 steps, restarting in between.
 
-Publish permissions support only the default exchange (`exchange: ""`) and an
-exact, non-empty routing key. Other exchanges and wildcard routing keys are
-rejected when the configuration is loaded. At publish time the ACL is applied
-to the resolved exchange, so a client may address the default exchange as `""`
-or as `amq.default`.
+Publish permissions support only the default exchange (`exchange: ""`) and
+set exactly one of an exact, non-empty `routing_key` or a non-empty plain
+`routing_key_prefix`. Other exchanges and AMQP wildcard syntax are rejected
+when the configuration is loaded. At publish time the ACL is applied to the
+resolved exchange, so a client may address the default exchange as `""` or as
+`amq.default`.
 
-A publish target must be a pre-provisioned protected stream on a queue store
-that provides real crash durability; the in-memory queue store cannot back one.
+An exact publish target must be a pre-provisioned protected stream on a queue
+store that provides real crash durability; the in-memory queue store cannot back one.
 Publisher confirms are sent only after the append and its durability barrier
 complete. The wait for that barrier is bounded: an fsync cannot be cancelled
 once started, so FluxMQ stops waiting after the internal publish timeout and
@@ -165,7 +168,8 @@ state passed between first-party services. They are not part of the client
 API, and no client may set or read one.
 
 The boundary is the listener's trust policy, not the protocol. Only the AMQP
-0.9.1 `internal` and `service` listeners are trusted, because they admit solely
+0.9.1 `local` listener and its deprecated `internal` and `service` aliases are
+trusted, because they admit solely
 mTLS peers whose verified certificate URI SAN matches a principal declared in
 FluxMQ's own configuration. Every other connection — MQTT, HTTP, CoAP, AMQP
 1.0, and AMQP 0.9.1 on the remote listener — is treated as a tenant or device:

--- a/docs/content/docs/configuration/security.md
+++ b/docs/content/docs/configuration/security.md
@@ -151,7 +151,7 @@ state passed between first-party services. They are not part of the client
 API, and no client may set or read one.
 
 The boundary is the listener's trust policy, not the protocol. Only the AMQP
-0.9.1 internal listener described above is trusted, because it admits solely
+0.9.1 `internal` and `service` listeners are trusted, because they admit solely
 mTLS peers whose verified certificate URI SAN matches a principal declared in
 FluxMQ's own configuration. Every other connection — MQTT, HTTP, CoAP, AMQP
 1.0, and AMQP 0.9.1 on the remote listener — is treated as a tenant or device:
@@ -161,10 +161,51 @@ FluxMQ's own configuration. Every other connection — MQTT, HTTP, CoAP, AMQP
 - **Egress**: reserved properties are omitted from deliveries to untrusted
   consumers, so a client cannot observe state another service set.
 
-Local principals are publish-only, so no connection currently consumes
-reserved properties; today they travel from a trusted service into the broker
-only. Speaking AMQP does not by itself confer trust, and an externally
-authenticated AMQP client is never treated as a service.
+Speaking AMQP does not by itself confer trust, and an externally authenticated
+AMQP client is never treated as a service.
+
+### Service Listener
+
+`server.amqp091.internal` admits publish-only principals: it exists for audit
+records, so a principal there may publish to the targets its ACL names and
+nothing else, and may never relay an origin identity.
+
+`server.amqp091.service` admits the same kind of mTLS local principal but also
+permits the consumer lifecycle, so a first-party service can subscribe and read
+the reserved properties another service set. It is what makes the namespace
+useful in both directions rather than write-only.
+
+A service listener grants no blanket access. Every operation is still authorized
+against the principal's own ACL:
+
+```yaml
+auth:
+  local_principals:
+    - name: rules-engine
+      certificate_uri_san: spiffe://absmach/magistrala/rules-engine
+      current_secret_file: /run/secrets/re-current
+      permissions:
+        publish:
+          - routing_key: m
+        subscribe:
+          - m
+```
+
+`subscribe` names exact queues; wildcards, duplicates, blank entries, and
+surrounding whitespace are rejected at load. A principal declaring no
+`subscribe` entry is refused a consumer even on the service listener, and one
+declaring no `publish` entry cannot publish. Unlike publish targets, subscribe
+targets need no matching `queues` entry: the durability contract that publish
+targets carry exists because local publishes are acknowledged as crash-durable,
+which does not apply to reading.
+
+Publish and subscribe ACLs share one permissions fingerprint, so narrowing
+either revokes the sessions that authenticated under the wider one, exactly as a
+credential rotation does.
+
+A service relays messages it did not originate, so unlike a publish-only
+principal it may state a message's true `external_id` and `protocol` rather than
+having its own identity stamped on them.
 
 The admin API (`server.api`) is exempt because it is an operator plane, not a
 client plane: it is unauthenticated and already exposes session inspection and

--- a/docs/content/docs/configuration/security.md
+++ b/docs/content/docs/configuration/security.md
@@ -144,6 +144,54 @@ See [Internal AMQP Local Principals](/deployment/internal-amqp-local-principals)
 for the complete production configuration, rotation process, tests, and
 rollout contract.
 
+## Reserved Message Properties
+
+Message property names beginning with `_flux.` are reserved for broker-internal
+state passed between first-party services. They are not part of the client
+API, and no client may set or read one.
+
+The boundary is the listener's trust policy, not the protocol. Only the AMQP
+0.9.1 internal listener described above is trusted, because it admits solely
+mTLS peers whose verified certificate URI SAN matches a principal declared in
+FluxMQ's own configuration. Every other connection — MQTT, HTTP, CoAP, AMQP
+1.0, and AMQP 0.9.1 on the remote listener — is treated as a tenant or device:
+
+- **Ingress**: reserved properties supplied by an untrusted publisher are
+  dropped before routing, so a reserved value can never be forged by a client.
+- **Egress**: reserved properties are omitted from deliveries to untrusted
+  consumers, so a client cannot observe state another service set.
+
+Local principals are publish-only, so no connection currently consumes
+reserved properties; today they travel from a trusted service into the broker
+only. Speaking AMQP does not by itself confer trust, and an externally
+authenticated AMQP client is never treated as a service.
+
+The admin API (`server.api`) is exempt because it is an operator plane, not a
+client plane: it is unauthenticated and already exposes session inspection and
+configuration reload, so a caller that can reach it holds broker-administrator
+capability. Its queue append and read operations therefore pass properties
+through unchanged. Keep that listener on a private network.
+
+## Origin Identity
+
+Every published message carries `client_id`, `external_id`, and `protocol`
+properties describing who published it and over which transport. These are
+stamped from the authenticated connection, so a publisher cannot attribute its
+message to another principal or claim it arrived over another protocol.
+
+A trusted AMQP 0.9.1 service relaying a message on behalf of an original
+publisher may override `external_id` and `protocol` to preserve the true
+origin, by setting them as message headers. The same trust rule as reserved
+properties applies, with one addition: a **local principal may not** relay an
+origin either. Its identity is fixed by configuration and its publications are
+audit records, so relaying would make the record disagree with the peer that
+actually authenticated. Untrusted connections on every protocol — including
+AMQP 0.9.1 remote and AMQP 1.0 — have any supplied value discarded and
+replaced with their own authenticated identity.
+
+Ordinary user properties are unaffected and continue to flow in both
+directions on every protocol that supports them.
+
 ## Blocking Hooks
 
 Blocking hooks are optional synchronous callouts for operations that need an

--- a/docs/content/docs/configuration/security.md
+++ b/docs/content/docs/configuration/security.md
@@ -130,15 +130,16 @@ abandoned appends waiting on one stream is capped; publications beyond that cap
 are refused before any storage work starts, and both outcomes close the channel
 so a stalled stream cannot accumulate retries.
 
-Local principals are publish-only. Subscription ACLs are not implemented, so
-`permissions.subscribe` must remain `[]`; every consume or `Basic.Get`
-operation is denied.
+On this listener a principal is publish-only: every consume, `basic.get`, and
+`queue.declare` is denied whatever `permissions.subscribe` says. Consumers
+require the [service listener](#service-listener) below.
 
 Local-principal counters are exposed under
 `by_protocol.amqp.local_principals` in `GET /api/v1/stats`. They cover active
-connections, authentication success/failure, publish and operation denials,
-reload success/failure, and forced disconnects. The counters are bounded and
-do not use principal names, certificate values, or routing keys as dimensions.
+connections, authentication success/failure, publish, subscribe and operation
+denials, reload success/failure, and forced disconnects. The counters are
+bounded and do not use principal names, certificate values, or routing keys as
+dimensions.
 
 See [Internal AMQP Local Principals](/deployment/internal-amqp-local-principals)
 for the complete production configuration, rotation process, tests, and
@@ -194,10 +195,18 @@ auth:
 `subscribe` names exact queues; wildcards, duplicates, blank entries, and
 surrounding whitespace are rejected at load. A principal declaring no
 `subscribe` entry is refused a consumer even on the service listener, and one
-declaring no `publish` entry cannot publish. Unlike publish targets, subscribe
-targets need no matching `queues` entry: the durability contract that publish
-targets carry exists because local publishes are acknowledged as crash-durable,
-which does not apply to reading.
+declaring no `publish` entry cannot publish. Unlike exact publish targets,
+subscribe targets need no matching `queues` entry: the durability contract those
+carry exists because local publishes are acknowledged as crash-durable, which
+does not apply to reading.
+
+A subscribe permission grants reads and nothing else. `basic.consume` and
+`basic.get` are allowed for the queues it names, and `queue.declare` is allowed
+only in its passive form, to assert that a queue exists. A non-passive declare
+creates a queue and rewrites the type, retention, TTL and durability of one that
+already exists, which is a configuration write: services consume queues that
+were provisioned for them, so they never need it. `queue.bind`, `queue.unbind`,
+`queue.purge`, and `queue.delete` are refused on both listeners.
 
 #### Publish targets: exact keys and prefixes
 
@@ -213,6 +222,13 @@ exists because a service publishes to topics built from its own runtime data —
 a tenant identifier, a channel identifier, a subtopic — which cannot be
 enumerated in broker configuration. The Rules Engine republishing a rule output
 to `m.<domain>.c.<channel>.<subtopic>` is the motivating case.
+
+The permission that matched decides how the publication is delivered, on either
+listener. An exact target is appended to its protected stream and synced before
+the publisher confirm; a prefix match is routed as an ordinary topic publish and
+carries no durability barrier. This is a property of the permission, not of the
+port the principal connected to, so one `permissions.publish` entry means the
+same thing everywhere.
 
 A prefix is a wildcard by construction and must never be written as one:
 `m.#` is rejected, because accepting it would silently grant the literal `#`

--- a/docs/content/docs/configuration/server.md
+++ b/docs/content/docs/configuration/server.md
@@ -32,7 +32,7 @@ server:
   amqp091:
     plain:
       addr: ":5682"
-    internal:
+    local:
       addr: ":5683"
       max_connections: 32
       cert_file: "/run/secrets/fluxmq_server_cert"
@@ -56,7 +56,7 @@ server:
 ## Key Fields
 
 - Listener families: `tcp`, `websocket`, `http`, `coap`, `amqp`, `amqp091`.
-- `amqp091.internal` is a private mTLS listener reserved for
+- `amqp091.local` is a private mTLS listener reserved for
   `auth.local_principals`; it never uses external auth or blocking hooks and
   requires a positive `max_connections` cap. It carries service-to-service
   traffic from a fixed set of statically configured internal producers, such as

--- a/docs/content/docs/deployment/internal-amqp-local-principals.md
+++ b/docs/content/docs/deployment/internal-amqp-local-principals.md
@@ -235,9 +235,10 @@ The ACL is evaluated against the exchange the router resolves, so a client may
 name the default exchange either as `""` or as its `amq.default` alias. The
 configuration itself accepts only `exchange: ""`.
 
-A principal with the default `publisher` role is publish-only, and for one
-`permissions.subscribe` is unsupported and
-must remain empty (`[]`).
+A principal with the default `publisher` role is publish-only:
+`permissions.subscribe` is rejected at load for it and must stay empty (`[]`).
+Consuming requires `role: service`, described in
+[Principal Roles](/configuration/security#principal-roles).
 
 FluxMQ resolves the preconfigured stream through the shared queue manager; the
 publisher never needs `QueueDeclare` permission. A publisher confirm is an ACK

--- a/docs/content/docs/deployment/internal-amqp-local-principals.md
+++ b/docs/content/docs/deployment/internal-amqp-local-principals.md
@@ -6,10 +6,10 @@ description: Implemented production design for a dedicated mTLS AMQP 0.9.1 liste
 # Internal AMQP Local Principals
 
 **Status:** implemented
-**Last Updated:** 2026-07-29
+**Last Updated:** 2026-08-01
 
 This document describes the implementation and acceptance contract for publishing
-Atom audit events to FluxMQ without sending those publications through Atom's
+Atom domain events to FluxMQ without sending those publications through Atom's
 own external authorization callout.
 
 ## What this feature is for
@@ -17,7 +17,7 @@ own external authorization callout.
 Local principals are a service-to-service ingress for a small, fixed set of
 first-party producers that are part of the deployment itself — audit and event
 streams, internal telemetry, and similar broker-adjacent pipelines. Every
-identity, its certificate URI SAN, and its exact publish target are declared in
+identity, its certificate URI SAN, and its publish ACLs are declared in
 FluxMQ's own configuration and mounted secrets, so the set of local principals
 is known before the process starts and changes only through a deliberate
 configuration change plus `SIGHUP`.
@@ -27,9 +27,9 @@ It is deliberately not a general client authentication mechanism:
 - there is no registration, discovery, or self-service enrollment;
 - there is no per-tenant, per-user, or dynamic identity — adding a principal is
   a configuration and secret-provisioning change, not an API call;
-- the ACL grants exactly one `(default exchange, routing key)` pair per entry,
-  with no wildcards, patterns, or hierarchy;
-- the principal has the default `publisher` role and writes into a
+- each publish ACL entry grants either one exact routing key or one plain
+  routing-key prefix on the default exchange, without AMQP wildcards;
+- the Atom principal has an explicit `publisher` role and writes into a
   pre-provisioned protected stream, so it
   cannot consume, discover topology, or create anything;
 - it scales to a handful of principals, not to a client population. Remote
@@ -47,10 +47,10 @@ Run two independent AMQP 0.9.1 authentication paths in one FluxMQ process:
 
 ```text
 remote clients -> remote AMQP listener -> auth.external -> shared queues/storage
-Atom publisher -> internal AMQP :5683 -> auth.local_principals -> shared queues/storage
+Atom publisher -> local AMQP :5683 -> auth.local_principals -> shared queues/storage
 ```
 
-The remote listener never reads the local-principal store. The internal
+The remote listener never reads the local-principal store. The local
 listener never calls external authentication, authorization, or blocking
 hooks. Unknown local identities fail closed; there is no fallback between the
 two paths.
@@ -104,6 +104,9 @@ server:
       client_auth: "require"
       min_version: "TLS1.2"
 
+cluster:
+  enabled: false
+
 auth:
   external:
     url: "https://auth.internal:9090"
@@ -121,12 +124,13 @@ auth:
   local_principals:
     - name: "atom-audit-publisher"
       certificate_uri_san: "spiffe://absmach/atom/audit-publisher"
+      role: "publisher"
       current_secret_file: "/run/secrets/atom_audit_secret_current"
       previous_secret_file: "/run/secrets/atom_audit_secret_previous"
       permissions:
         publish:
           - exchange: ""
-            routing_key: "atom-audit"
+            routing_key: "atom.events"
         subscribe: []
 ```
 
@@ -136,8 +140,10 @@ example 32 random bytes encoded as hex or base64. Do not use raw binary: the
 value must not contain embedded CR/LF or NUL characters. FluxMQ strips one
 terminal newline, stores only a digest in memory, and uses a constant-time
 comparison. Principal names and certificate URI SANs must be unique. Publish
-ACLs support only the default exchange (`exchange: ""`) and exact, non-empty
-routing keys; other exchanges and wildcards are invalid.
+ACLs support only the default exchange (`exchange: ""`); each entry sets
+exactly one of an exact `routing_key` or a plain `routing_key_prefix`.
+Other exchanges and AMQP wildcards are invalid. Atom must use the exact form
+shown above because its target is a crash-durable stream.
 
 The remote listener requires the separately deployed external auth service;
 FluxMQ does not bundle `fluxmq-auth`. Because authentication calls carry client
@@ -147,22 +153,22 @@ client-certificate settings; terminate mTLS in a sidecar when it is required.
 An external-auth outage fails the remote path closed but does not invoke or
 interrupt the internal local-principal path.
 
-Authentication on the internal listener requires all of the following to
+Authentication on the local listener requires all of the following to
 match the same principal:
 
 - the SASL username;
 - the SASL secret;
 - the URI SAN in a client certificate verified by the configured CA.
 
-## Atom audit stream policy
+## Atom event stream policy
 
 Provision the stream before starting the publisher:
 
 ```yaml
 queues:
-  - name: "atom-audit"
+  - name: "atom.events"
     topics:
-      - "$queue/atom-audit/#"
+      - "$queue/atom.events/#"
     reserved: true
     type: "stream"
     retention:
@@ -181,8 +187,8 @@ default seven-day message TTL cannot shorten the advertised 30-day replay
 availability.
 
 At startup and before activating a local-principal snapshot on `SIGHUP`,
-FluxMQ validates every local publish ACL target against both the configured and
-persisted queue definition. Startup aborts, or reload is rejected while the
+FluxMQ validates every exact local publish ACL target against both the
+configured and persisted queue definition. Startup aborts, or reload is rejected while the
 previous snapshot remains active, if a target is missing, the queue store
 lacks durable-sync support, or the persisted target is not the configured
 reserved, durable, non-replicated stream with matching retention and message
@@ -191,8 +197,8 @@ stop FluxMQ, reconcile it with the YAML queue definition through a controlled
 storage migration or restore, and then restart before retrying the reload.
 
 While FluxMQ is running, the queue manager protects only the streams named by
-local-principal publish ACLs. It rejects create/update/delete operations that
-would change a protected stream's topics, type, durability, reserved flag,
+exact local-principal publish ACLs. It rejects create/update/delete operations
+that would change a protected stream's topics, type, durability, reserved flag,
 replication mode, retention window, retention byte/message limits, maximum
 message size, or message TTL. AMQP `QueueDeclare` attempts that would change
 the contract close the channel with `406 Precondition Failed`; the admin API
@@ -206,24 +212,22 @@ contract because stream depth is not currently enforced; the effective
 retention byte/message limits are protected instead.
 
 Local durable confirms currently support single-node, non-replicated streams
-only. Enabling replication on a local publish target fails startup. Supporting
-a clustered audit stream requires a future end-to-end quorum durability
+only. Enabling replication on an exact local publish target fails startup.
+Supporting a clustered event stream requires a future end-to-end quorum durability
 barrier before FluxMQ can ACK the publication.
 
-The internal listener therefore cannot run on a clustered node, and FluxMQ
-refuses that configuration at startup: `server.amqp091.local.addr` together
-with `cluster.enabled` is a validation error. A local publication is appended
-and synced on the receiving node only and is never forwarded to other nodes,
-because forwarding would acknowledge a publisher on a barrier no single node
-established. In a cluster those records would be unreachable from consumers
-attached to any other node, with nothing to signal it, so the combination fails
-closed instead. Note that `cluster.enabled` defaults to true, so a deployment
-enabling the internal listener must set it to false explicitly, as the shipped
-`config-local-principal.yaml` does.
+An exact publish permission therefore cannot run on a clustered node: its
+publication is appended and synced on the receiving node only and is never
+forwarded. FluxMQ rejects any local-principal listener combined with
+`cluster.enabled` when a principal holds an exact target. Prefix-only
+principals remain valid in a cluster because those publications use ordinary
+topic routing and no queue durability barrier. Atom uses the exact form, and
+`cluster.enabled` defaults to true, so its deployment must set it to false
+explicitly, as the shipped `config-local-principal.yaml` does.
 
 The `atom-audit-publisher` may open connections and channels, enable publisher
 confirms, and publish only to the default exchange with the exact routing key
-`atom-audit`. It cannot consume, get, declare or modify queues or exchanges,
+`atom.events`. It cannot consume, get, declare or modify queues or exchanges,
 bind topology, purge, delete, or use transactions. A denied channel operation
 returns AMQP `403 Access Refused`.
 
@@ -265,7 +269,7 @@ not interruptible. An fsync that has already started cannot be cancelled, so
 FluxMQ enforces the deadline by giving up on the wait: when the append and sync
 do not complete within the internal publish timeout, or the process is shutting
 down, the publication is NACKed and the connection stays responsive instead of
-a stalled disk holding an internal-listener slot open. The abandoned append can
+a stalled disk holding a local-listener slot open. The abandoned append can
 still complete afterwards and become visible to consumers. A NACK therefore
 never proves the record was not written, and the at-least-once retry and
 deduplication rules below apply to it.
@@ -317,14 +321,14 @@ process restart.
 - Keep remote AMQP on `auth.external`; do not add a local lookup to that path.
 - Add a reloadable, immutable local-principal snapshot with active-connection
   revocation.
-- Enforce an internal-listener operation allowlist, including AMQP topology
+- Enforce a local-listener operation allowlist, including AMQP topology
   methods that are outside publish/subscribe authorization today.
 - Resolve statically configured streams through the shared queue manager.
 - Enforce listener connection limits, TLS handshake timeouts, and message-size
   limits before allocating a message body.
 - Add bounded admin statistics and structured logs for local authentication, denials,
   reloads, and active connections. Never log secrets, hashes, or certificates.
-- Include successful internal-listener initialization and binding in
+- Include successful local-listener initialization and binding in
   readiness.
 
 The bounded counters are returned by `GET /api/v1/stats` under
@@ -335,11 +339,11 @@ The bounded counters are returned by `GET /api/v1/stats` under
 Unit and component tests plus the real-process smoke test prove:
 
 - remote AMQP calls only `auth.external` and never checks local identities;
-- internal AMQP never calls external auth or blocking hooks, including when
+- local AMQP never calls external auth or blocking hooks, including when
   those services are unavailable;
 - valid mTLS, URI SAN, username, and current/previous secret combinations work;
 - invalid CA, SAN, username, or secret combinations fail closed;
-- only the exact `atom-audit` publication succeeds;
+- only the exact `atom.events` publication succeeds;
 - consumption and every topology-changing operation are denied;
 - secret reload is atomic and removed credentials disconnect active sessions;
 - the stream accepts publication without a queue declaration;
@@ -357,12 +361,12 @@ make smoke-local-auth
 
 It starts a real FluxMQ process, creates test PKI, exercises both listener
 paths and negative credentials/ACLs, reloads credentials, restarts the broker,
-and verifies stream replay. This smoke test passed on 2026-07-29.
+and verifies stream replay. This smoke test passed on 2026-08-01.
 
 ### Manual rabtap deployment smoke
 
 Run this smoke after deploying the Compose overlay, and before enabling the
-Atom audit publisher. It complements `make smoke-local-auth` by proving that an
+Atom event publisher. It complements `make smoke-local-auth` by proving that an
 independent AMQP 0.9.1 client can publish, receive a durable confirmation, and
 replay the event through the externally authorized listener.
 
@@ -385,8 +389,8 @@ Before running the commands, verify all of the following:
 - The local secret is printable, at least 32 characters, and URI-safe. Hex is
   recommended. Use a short-lived smoke credential because AMQP URI credentials
   can be visible to local process inspection and may appear in client errors.
-- A remote reader accepted by `auth.external` may subscribe to `atom-audit`.
-  The internal principal is deliberately unable to perform the replay.
+- A remote reader accepted by `auth.external` may subscribe to `atom.events`.
+  The local principal is deliberately unable to perform the replay.
 
 The CA passed to `rabtap --tls-ca-file` verifies the FluxMQ **server**
 certificate. It is the opposite trust direction from `ATOM_CLIENT_CA_FILE`,
@@ -404,7 +408,7 @@ newline:
 ```bash
 export AUDIT_EVENT_ID="rabtap-smoke-1"
 export AUDIT_SECRET="$(tr -d '\r\n' </secure/atom/audit-secret-current)"
-export INTERNAL_AMQP_URI="amqps://atom-audit-publisher:${AUDIT_SECRET}@fluxmq:5683/"
+export LOCAL_AMQP_URI="amqps://atom-audit-publisher:${AUDIT_SECRET}@fluxmq:5683/"
 ```
 
 Publish through the default exchange to the one permitted routing key:
@@ -412,9 +416,9 @@ Publish through the default exchange to the one permitted routing key:
 ```bash
 printf '{"id":"%s","action":"entity.create"}\n' "${AUDIT_EVENT_ID}" |
   rabtap pub \
-    --uri="${INTERNAL_AMQP_URI}" \
+    --uri="${LOCAL_AMQP_URI}" \
     --exchange='' \
-    --routingkey='atom-audit' \
+    --routingkey='atom.events' \
     --confirms \
     --mandatory \
     --property='ContentType=application/json' \
@@ -430,7 +434,7 @@ ACK, which this listener sends only after the exact stream append and durable
 sync succeed.
 
 `--mandatory` is kept for parity with the remote listener but does not add a
-check here: the internal listener routes only to its protected stream, so an
+check here: the local listener routes only to its protected stream, so an
 unroutable or rejected publication is reported as a NACK rather than a
 `Basic.Return`. Treat the confirm result, not a returned message, as the
 authoritative outcome.
@@ -441,16 +445,16 @@ exit non-zero with AMQP `403 Access Refused`:
 ```bash
 printf 'denied\n' |
   rabtap pub \
-    --uri="${INTERNAL_AMQP_URI}" \
+    --uri="${LOCAL_AMQP_URI}" \
     --exchange='' \
-    --routingkey='not-atom-audit' \
+    --routingkey='not-atom.events' \
     --confirms \
     --tls-ca-file=/secure/fluxmq/server-ca.crt \
     --tls-cert-file=/secure/atom/audit-publisher.crt \
     --tls-key-file=/secure/atom/audit-publisher.key
 
-rabtap sub atom-audit \
-  --uri="${INTERNAL_AMQP_URI}" \
+rabtap sub atom.events \
+  --uri="${LOCAL_AMQP_URI}" \
   --limit=1 \
   --idle-timeout=3s \
   --tls-ca-file=/secure/fluxmq/server-ca.crt \
@@ -462,7 +466,7 @@ An optional topology guard check must also fail with AMQP `403`:
 
 ```bash
 rabtap queue create forbidden \
-  --uri="${INTERNAL_AMQP_URI}" \
+  --uri="${LOCAL_AMQP_URI}" \
   --tls-ca-file=/secure/fluxmq/server-ca.crt \
   --tls-cert-file=/secure/atom/audit-publisher.crt \
   --tls-key-file=/secure/atom/audit-publisher.key
@@ -480,7 +484,7 @@ docker compose \
 
 curl --fail http://127.0.0.1:8081/health
 
-rabtap sub atom-audit \
+rabtap sub atom.events \
   --uri='amqps://remote-reader:REMOTE_SECRET@fluxmq:5682/' \
   --offset=first \
   --args='x-consumer-group=rabtap-smoke-unique' \
@@ -508,16 +512,16 @@ For a review bot or release operator, the minimum evidence to retain is:
   topology mutation;
 - the replayed event body after restart;
 - external-auth logs showing remote authentication/authorization and no
-  internal-listener callout;
+  local-listener callout;
 - `GET /api/v1/stats` counters showing one accepted message plus the expected
   `publish_denied` and `operation_denied` increments.
 
 Roll out in this order:
 
-1. Deploy the breaking nested auth configuration with the internal listener
+1. Deploy the breaking nested auth configuration with the local listener
    disabled and verify the remote path.
 2. Mount the CA, server certificate, current local secret, and pre-provision
-   `atom-audit`.
+   `atom.events`.
 3. Enable port `5683` only on a private network shared with Atom.
 4. Run `make smoke-local-auth` against the release source.
 5. As deployment-specific rollout gates, validate the rendered Compose or
@@ -526,7 +530,7 @@ Roll out in this order:
 6. As a deployment-specific performance gate, load test both paths and set an
    acceptable remote-auth latency budget for that environment. FluxMQ must not
    add a local-principal lookup or callout to the remote path.
-7. Enable the Atom audit publisher in a separate deployment change.
+7. Enable the Atom event publisher in a separate deployment change.
 
 The feature is implemented and covered by the real-process acceptance smoke.
 A particular production deployment is ready only after its container startup,

--- a/docs/content/docs/deployment/internal-amqp-local-principals.md
+++ b/docs/content/docs/deployment/internal-amqp-local-principals.md
@@ -29,7 +29,8 @@ It is deliberately not a general client authentication mechanism:
   a configuration and secret-provisioning change, not an API call;
 - the ACL grants exactly one `(default exchange, routing key)` pair per entry,
   with no wildcards, patterns, or hierarchy;
-- the principal is publish-only into a pre-provisioned protected stream, so it
+- the principal has the default `publisher` role and writes into a
+  pre-provisioned protected stream, so it
   cannot consume, discover topology, or create anything;
 - it scales to a handful of principals, not to a client population. Remote
   clients, devices, and tenants continue to authenticate through
@@ -94,7 +95,7 @@ server:
       min_version: "TLS1.2"
 
     # Private listener. Never expose it through a public load balancer.
-    internal:
+    local:
       addr: ":5683"
       max_connections: 32
       cert_file: "/run/secrets/fluxmq_server_cert"
@@ -210,7 +211,7 @@ a clustered audit stream requires a future end-to-end quorum durability
 barrier before FluxMQ can ACK the publication.
 
 The internal listener therefore cannot run on a clustered node, and FluxMQ
-refuses that configuration at startup: `server.amqp091.internal.addr` together
+refuses that configuration at startup: `server.amqp091.local.addr` together
 with `cluster.enabled` is a validation error. A local publication is appended
 and synced on the receiving node only and is never forwarded to other nodes,
 because forwarding would acknowledge a publisher on a barrier no single node
@@ -230,7 +231,8 @@ The ACL is evaluated against the exchange the router resolves, so a client may
 name the default exchange either as `""` or as its `amq.default` alias. The
 configuration itself accepts only `exchange: ""`.
 
-Local principals are publish-only. `permissions.subscribe` is unsupported and
+A principal with the default `publisher` role is publish-only, and for one
+`permissions.subscribe` is unsupported and
 must remain empty (`[]`).
 
 FluxMQ resolves the preconfigured stream through the shared queue manager; the
@@ -309,7 +311,7 @@ process restart.
 
 ## Implemented behavior
 
-- Bind a dedicated `server.amqp091.internal` mTLS listener on port `5683`.
+- Bind a dedicated `server.amqp091.local` mTLS listener on port `5683`.
 - Pass listener-scoped authentication, authorization, and hook policies into
   AMQP connections instead of selecting them from broker-global state.
 - Keep remote AMQP on `auth.external`; do not add a local lookup to that path.

--- a/docs/content/docs/reference/configuration-reference.md
+++ b/docs/content/docs/reference/configuration-reference.md
@@ -5,7 +5,7 @@ description: Comprehensive YAML configuration reference for server, broker, stor
 
 # Configuration Reference
 
-**Last Updated:** 2026-07-29
+**Last Updated:** 2026-08-01
 
 FluxMQ uses a single YAML configuration file. Start the broker with:
 
@@ -724,12 +724,13 @@ auth:
   local_principals:
     - name: "atom-audit-publisher"
       certificate_uri_san: "spiffe://absmach/atom/audit-publisher"
+      role: "publisher"
       current_secret_file: "/run/secrets/atom_audit_secret_current"
       previous_secret_file: "/run/secrets/atom_audit_secret_previous"
       permissions:
         publish:
           - exchange: ""
-            routing_key: "atom-audit"
+            routing_key: "atom.events"
         subscribe: []
 ```
 

--- a/docs/content/docs/reference/configuration-reference.md
+++ b/docs/content/docs/reference/configuration-reference.md
@@ -108,7 +108,7 @@ server:
       max_connections: 10000
     tls: {}
     mtls: {}
-    internal:
+    local:
       addr: ":5683"
       max_connections: 32
       cert_file: "/run/secrets/fluxmq_server_cert"
@@ -135,12 +135,12 @@ server:
 
 ### Listener Fields
 
-These apply to listener blocks (for example `server.tcp.v3`, `server.websocket.v3`, `server.amqp091.tls`, and so on). `server.amqp091.internal` is reserved for `auth.local_principals`, requires mTLS, and never uses external auth or blocking hooks.
+These apply to listener blocks (for example `server.tcp.v3`, `server.websocket.v3`, `server.amqp091.tls`, and so on). `server.amqp091.local` is reserved for `auth.local_principals`, requires mTLS, and never uses external auth or blocking hooks. `server.amqp091.internal` and `server.amqp091.service` are deprecated aliases for it.
 
 | Field             | Description                                                                                                                                    |
 | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `addr`            | Listener bind address (`"<host>:<port>"` or `":<port>"`). Empty string disables that listener.                                                 |
-| `max_connections` | Connection cap for that listener (`>= 0`). `0` means no explicit cap except on `server.amqp091.internal`, where a positive cap is required. Applies to TCP/WebSocket/AMQP/AMQP091 listeners. Counted on accepted sockets, so a peer that connects without completing a handshake still consumes quota. |
+| `max_connections` | Connection cap for that listener (`>= 0`). `0` means no explicit cap except on a local-principal listener, where a positive cap is required. Applies to TCP/WebSocket/AMQP/AMQP091 listeners. Counted on accepted sockets, so a peer that connects without completing a handshake still consumes quota. |
 | `read_timeout`    | Bounds the phase before an MQTT session starts (`time.Duration`, `>= 0`). On TCP that is the TLS handshake, protocol sniff and CONNECT; on WebSocket it also bounds the HTTP request and TLS handshake that precede the upgrade. Once the session starts it sets its own read deadlines from the negotiated keep-alive. TCP and WebSocket listeners. |
 | `write_timeout`   | Bounds a single socket write for the life of the connection (`time.Duration`, `>= 0`). TCP and WebSocket listeners.                            |
 | `protocol`        | MQTT parser mode. For TCP, use `v3` on `server.tcp.v3` and `v5` on `server.tcp.v5`; for WebSocket listeners you can use `auto`, `v3`, or `v5`. |
@@ -743,10 +743,11 @@ auth:
 | `external.identity_cache_ttl`                   | `0`     | External identity cache TTL; zero selects the broker default (`24h`), while a negative value disables TTL eviction. |
 | `local_principals[].name`                       | —       | Unique SASL username for the local principal. |
 | `local_principals[].certificate_uri_san`        | —       | Exact URI SAN required on a CA-verified client certificate. |
+| `local_principals[].role`                       | `publisher` | Capability of the principal on every local listener: `publisher` may only publish; `service` may also consume and relay an origin identity. |
 | `local_principals[].current_secret_file`        | —       | File containing an active high-entropy printable value of at least 32 characters, without embedded CR/LF or NUL. One terminal newline is stripped. |
 | `local_principals[].previous_secret_file`       | `""`    | Optional old secret with the same printable-value requirements, accepted during rotation overlap. |
-| `local_principals[].permissions.publish`        | `[]`    | Exact AMQP publish targets. `exchange` must be `""` (the default exchange); `routing_key` must be exact and non-empty. |
-| `local_principals[].permissions.subscribe`      | `[]`    | Unsupported for local principals; it must remain empty. Local principals are publish-only. |
+| `local_principals[].permissions.publish`        | `[]`    | AMQP publish targets. `exchange` must be `""` (the default exchange). Each entry sets exactly one of `routing_key` (exact, and a protected stream under `queues`) or `routing_key_prefix` (a plain string prefix, no queue required). |
+| `local_principals[].permissions.subscribe`      | `[]`    | Exact queue names the principal may consume. Requires `role: service`; declaring entries on a `publisher` is rejected at load. |
 
 Valid `external.protocols` keys: `mqtt`, `amqp`, `amqp091`, `http`, `coap`.
 The old flat `auth.url`, `auth.transport`, `auth.timeout`, `auth.protocols`, and

--- a/docs/content/docs/reference/protocol-reference.md
+++ b/docs/content/docs/reference/protocol-reference.md
@@ -31,6 +31,7 @@ Key principles:
 - **Routing is shared.** All protocols route through the same queue manager and topic index. An MQTT publish and an AMQP 0.9.1 publish to the same `$queue/` topic land in the same queue log.
 - **Delivery semantics come from the queue type.** A durable queue delivers with PEL tracking and ack/nack/reject regardless of whether the consumer is MQTT or AMQP. A stream queue delivers with cursor semantics regardless of protocol.
 - **Protocol-specific features are scoped to the adapter.** AMQP 0.9.1 exchanges exist only as per-connection routing tables. MQTT shared subscriptions use a separate code path from queue consumer groups. AMQP 1.0 link capabilities map to queue properties.
+- **The `_flux.` property namespace is reserved.** Properties with that prefix carry broker-internal state between first-party services. Clients may not set or read them on any protocol; see [Reserved Message Properties](/configuration/security#reserved-message-properties).
 
 ## MQTT (3.1.1 / 5.0)
 

--- a/examples/production.yaml
+++ b/examples/production.yaml
@@ -8,7 +8,7 @@
 #   - TLS certificate + key, plus CA bundle for client mTLS
 #   - External auth callout reachable on auth.internal:9090 (or disable)
 #   - Atom client CA + 32-byte local-principal secret files when enabling
-#     the internal AMQP audit listener
+#     the local AMQP event listener
 #   - OTLP-compatible collector reachable on otel.internal:4317
 #   - Persistent volume mounted at /var/lib/fluxmq
 #
@@ -85,7 +85,7 @@ server:
       key_file: "/etc/fluxmq/certs/server.key"
     # Private, mTLS-only listener for local service principals. Never expose
     # this port through a public load balancer.
-    internal:
+    local:
       addr: ":5683"
       max_connections: 32
       cert_file: "/run/secrets/fluxmq_internal_server_cert"
@@ -160,17 +160,18 @@ auth:
     identity_cache_size: 50000
     identity_cache_ttl: "1h"
 
-  # Local principals are valid only on server.amqp091.internal. Unknown
+  # Local principals are valid only on server.amqp091.local. Unknown
   # principals fail closed and never fall back to auth.external.
   local_principals:
     - name: "atom-audit-publisher"
       certificate_uri_san: "spiffe://absmach/atom/audit-publisher"
+      role: "publisher"
       current_secret_file: "/run/secrets/atom_audit_secret_current"
       previous_secret_file: "/run/secrets/atom_audit_secret_previous"
       permissions:
         publish:
           - exchange: ""
-            routing_key: "atom-audit"
+            routing_key: "atom.events"
         subscribe: []
 
 # Optional blocking hooks. Enable only when an external policy/normalization
@@ -243,9 +244,9 @@ log:
 # Pre-provisioned stream used by the restricted Atom publisher. The publisher
 # is not permitted to declare or mutate broker topology.
 queues:
-  - name: "atom-audit"
+  - name: "atom.events"
     topics:
-      - "$queue/atom-audit/#"
+      - "$queue/atom.events/#"
     reserved: true
     type: "stream"
     retention:

--- a/mqtt/broker/queue_utils.go
+++ b/mqtt/broker/queue_utils.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"strconv"
 
+	corebroker "github.com/absmach/fluxmq/broker"
 	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 )
 
@@ -34,6 +35,12 @@ func extractAllProperties(props *v5.PublishProperties) map[string]string {
 
 	if props.User != nil {
 		for _, prop := range props.User {
+			// A device may not set broker-internal properties. They authenticate
+			// nothing, so a service reading one must be able to rely on it having
+			// come from another service rather than from a publishing client.
+			if corebroker.IsReservedProperty(prop.Key) {
+				continue
+			}
 			result[prop.Key] = prop.Value
 		}
 	}

--- a/mqtt/broker/queue_utils_bench_test.go
+++ b/mqtt/broker/queue_utils_bench_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"testing"
+
+	corebroker "github.com/absmach/fluxmq/broker"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
+)
+
+// The reserved-property filter runs for every user property on every v5
+// PUBLISH, so it must not add allocations to the publish path.
+func BenchmarkExtractAllProperties(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		user []v5.User
+	}{
+		{name: "no properties"},
+		{
+			name: "ordinary properties",
+			user: []v5.User{{Key: testTraceKey, Value: testTraceVal}, {Key: testTenantKey, Value: testTenantValue}},
+		},
+		{
+			name: "reserved property",
+			user: []v5.User{
+				{Key: testTraceKey, Value: testTraceVal},
+				{Key: corebroker.ReservedPropertyPrefix + "re.trace", Value: `["rule-a"]`},
+			},
+		},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			props := &v5.PublishProperties{User: bm.user}
+			b.ReportAllocs()
+			for b.Loop() {
+				_ = extractAllProperties(props)
+			}
+		})
+	}
+}

--- a/mqtt/broker/queue_utils_test.go
+++ b/mqtt/broker/queue_utils_test.go
@@ -7,7 +7,9 @@ import (
 	"encoding/base64"
 	"testing"
 
+	corebroker "github.com/absmach/fluxmq/broker"
 	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestExtractAllProperties_CorrelationDataBase64(t *testing.T) {
@@ -75,5 +77,62 @@ func TestExtractAllProperties_NilProps(t *testing.T) {
 
 	if len(result) != 0 {
 		t.Errorf("expected empty map for nil props, got %v", result)
+	}
+}
+
+const (
+	testRuleTrace   = `["rule-a"]`
+	testTraceVal    = "abc"
+	testTraceKey    = "trace"
+	testTenantValue = "acme"
+	testTenantKey   = "tenant"
+)
+
+// A publishing device must not be able to set broker-internal properties: they
+// are the channel services use to pass state that authenticates nothing on its
+// own, so a forged one would let a client drive service behaviour.
+func TestExtractAllProperties_StripsReservedUserProperties(t *testing.T) {
+	tests := []struct {
+		name   string
+		user   []v5.User
+		want   map[string]string
+		absent []string
+	}{
+		{
+			name: "reserved property is dropped",
+			user: []v5.User{
+				{Key: corebroker.ReservedPropertyPrefix + "re.trace", Value: testRuleTrace},
+			},
+			want:   map[string]string{},
+			absent: []string{corebroker.ReservedPropertyPrefix + "re.trace"},
+		},
+		{
+			name: "ordinary properties are kept",
+			user: []v5.User{
+				{Key: testTraceKey, Value: testTraceVal},
+				{Key: testTenantKey, Value: testTenantValue},
+			},
+			want: map[string]string{testTraceKey: testTraceVal, testTenantKey: testTenantValue},
+		},
+		{
+			name: "reserved dropped alongside ordinary",
+			user: []v5.User{
+				{Key: testTraceKey, Value: testTraceVal},
+				{Key: corebroker.ReservedPropertyPrefix + "re.trace", Value: testRuleTrace},
+			},
+			want:   map[string]string{testTraceKey: testTraceVal},
+			absent: []string{corebroker.ReservedPropertyPrefix + "re.trace"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractAllProperties(&v5.PublishProperties{User: tc.user})
+
+			assert.Equal(t, tc.want, got)
+			for _, key := range tc.absent {
+				assert.NotContains(t, got, key)
+			}
+		})
 	}
 }

--- a/mqtt/broker/session.go
+++ b/mqtt/broker/session.go
@@ -541,8 +541,15 @@ func (b *Broker) restoreSubscriptionsFromTakeover(s *session.Session, state *clu
 			continue
 		}
 
-		// Note: No need to add to cluster since it was already there
-		// The subscription exists in etcd from the previous node
+		// The old owner removes the cluster subscription while closing the
+		// transferred session. Re-register it so publishers on other nodes can
+		// discover the subscriber after takeover.
+		if b.cluster != nil {
+			ctx := context.Background()
+			if err := b.cluster.AddSubscription(ctx, s.ID, sub.Filter, byte(sub.Qos), opts); err != nil {
+				return fmt.Errorf("failed to restore subscription in cluster: %w", err)
+			}
+		}
 	}
 
 	return nil

--- a/mqtt/session/encode.go
+++ b/mqtt/session/encode.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/absmach/fluxmq/broker"
 	"github.com/absmach/fluxmq/mqtt/packets"
 	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
 	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
@@ -125,7 +126,11 @@ func applyPublishProperties(props *v5.PublishProperties, msg *storage.Message) {
 			}
 		}
 	}
-	userCount += len(msg.UserProperties)
+	for k := range msg.UserProperties {
+		if !broker.IsReservedProperty(k) {
+			userCount++
+		}
+	}
 
 	if userCount > 0 {
 		props.User = make([]v5.User, 0, userCount)
@@ -138,6 +143,9 @@ func applyPublishProperties(props *v5.PublishProperties, msg *storage.Message) {
 			}
 		}
 		for k, v := range msg.UserProperties {
+			if broker.IsReservedProperty(k) {
+				continue
+			}
 			props.User = append(props.User, v5.User{Key: k, Value: v})
 		}
 	}
@@ -148,6 +156,7 @@ func isReservedUserPropertyKey(key string) bool {
 	case "content-type", "response-topic", "correlation-id", "payload-format":
 		return true
 	default:
-		return false
+		// Broker-internal properties are never revealed to a subscribing device.
+		return broker.IsReservedProperty(key)
 	}
 }

--- a/mqtt/session/encode_test.go
+++ b/mqtt/session/encode_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/absmach/fluxmq/broker"
 	"github.com/absmach/fluxmq/mqtt/packets"
 	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
 	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/storage"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -32,7 +34,7 @@ func TestEncodePublish_V5RetransmitCarriesProperties(t *testing.T) {
 		PayloadFormat:   &pf,
 		MessageExpiry:   &expiry,
 		Expiry:          time.Now().Add(60 * time.Second),
-		UserProperties:  map[string]string{"trace": "abc"},
+		UserProperties:  map[string]string{testTraceKey: testTraceVal},
 	}
 	msg.SetPayloadFromBytes([]byte("payload"))
 
@@ -73,4 +75,66 @@ func TestEncodePublish_V3FirstSendNoDup(t *testing.T) {
 	require.Equal(t, "t", pub.TopicName)
 	require.False(t, pub.FixedHeader.Dup, "first send must not set the DUP flag")
 	require.Equal(t, byte(2), pub.FixedHeader.QoS)
+}
+
+const (
+	testRuleTrace = `["rule-a"]`
+	testTraceVal  = "abc"
+	testTraceKey  = "trace"
+)
+
+// Broker-internal properties travel between services in the property bag. They
+// must never be encoded into a v5 PUBLISH, or every subscribing device would
+// read the internal state services pass to one another.
+func TestEncodePublish_V5OmitsReservedProperties(t *testing.T) {
+	reserved := broker.ReservedPropertyPrefix + "re.trace"
+
+	tests := []struct {
+		name           string
+		properties     map[string]string
+		userProperties map[string]string
+		want           map[string]string
+	}{
+		{
+			name:       "reserved mapped property is omitted",
+			properties: map[string]string{reserved: testRuleTrace, "tenant": "acme"},
+			want:       map[string]string{"tenant": "acme"},
+		},
+		{
+			name:           "reserved user property is omitted",
+			userProperties: map[string]string{reserved: testRuleTrace, testTraceKey: testTraceVal},
+			want:           map[string]string{testTraceKey: testTraceVal},
+		},
+		{
+			name:       "only reserved properties yields none",
+			properties: map[string]string{reserved: testRuleTrace},
+			want:       map[string]string{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := &storage.Message{
+				Topic:          testTopic,
+				QoS:            1,
+				Properties:     tc.properties,
+				UserProperties: tc.userProperties,
+			}
+			msg.SetPayloadFromBytes([]byte("payload"))
+
+			pkt := EncodePublish(msg, 1, packets.V5, false)
+			pub, ok := pkt.(*v5.Publish)
+			require.True(t, ok, "expected a v5 publish packet")
+			t.Cleanup(pkt.Release)
+
+			got := map[string]string{}
+			if pub.Properties != nil {
+				for _, user := range pub.Properties.User {
+					got[user.Key] = user.Value
+				}
+			}
+			assert.Equal(t, tc.want, got)
+			assert.NotContains(t, got, reserved)
+		})
+	}
 }

--- a/queue/delivery_engine.go
+++ b/queue/delivery_engine.go
@@ -204,10 +204,7 @@ func (e *DeliveryEngine) deliverQueueConfig(ctx context.Context, queueConfig *ty
 			return 0, false
 		}
 
-		patternGroupID := primaryGroup
-		if pattern != "" {
-			patternGroupID = primaryGroup + "@" + pattern
-		}
+		patternGroupID := corebroker.EffectiveConsumerGroupID(primaryGroup, pattern)
 
 		if val, ok := primaryCommitted[patternGroupID]; ok {
 			return val, true
@@ -426,10 +423,7 @@ func (e *DeliveryEngine) deliverToRemoteConsumers(ctx context.Context, config *t
 		var workCommitted uint64
 		var hasWorkCommitted bool
 		if group.Mode == types.GroupModeStream && config.PrimaryGroup != "" {
-			patternGroupID := config.PrimaryGroup
-			if group.Pattern != "" {
-				patternGroupID = config.PrimaryGroup + "@" + group.Pattern
-			}
+			patternGroupID := corebroker.EffectiveConsumerGroupID(config.PrimaryGroup, group.Pattern)
 			if committed, err := e.consumerManager.GetCommittedOffset(ctx, config.Name, patternGroupID); err == nil {
 				workCommitted = committed
 				hasWorkCommitted = true

--- a/queue/manager.go
+++ b/queue/manager.go
@@ -115,6 +115,8 @@ type Manager struct {
 	metrics *consumer.Metrics
 }
 
+var _ corebroker.ExistingQueueSubscriber = (*Manager)(nil)
+
 // Config holds configuration for the queue-based queue manager.
 type Config struct {
 	// Consumer configuration
@@ -1270,6 +1272,16 @@ func (m *Manager) Enqueue(ctx context.Context, topic string, payload []byte, pro
 
 // SubscribeWithCursor adds a consumer with explicit cursor positioning.
 func (m *Manager) SubscribeWithCursor(ctx context.Context, queueName, pattern string, clientID, groupID, proxyNodeID string, cursor *types.CursorOption) error {
+	return m.subscribeWithCursor(ctx, queueName, pattern, clientID, groupID, proxyNodeID, cursor, true)
+}
+
+// SubscribeExistingWithCursor adds a consumer to an existing queue without
+// creating the queue or changing its configured type.
+func (m *Manager) SubscribeExistingWithCursor(ctx context.Context, queueName, pattern string, clientID, groupID, proxyNodeID string, cursor *types.CursorOption) error {
+	return m.subscribeWithCursor(ctx, queueName, pattern, clientID, groupID, proxyNodeID, cursor, false)
+}
+
+func (m *Manager) subscribeWithCursor(ctx context.Context, queueName, pattern string, clientID, groupID, proxyNodeID string, cursor *types.CursorOption, allowQueueMutation bool) error {
 	if proxyNodeID == "" && m.localNodeID != "" {
 		proxyNodeID = m.localNodeID
 	}
@@ -1280,18 +1292,31 @@ func (m *Manager) SubscribeWithCursor(ctx context.Context, queueName, pattern st
 	}
 	if cursor == nil || cursor.Position == types.CursorDefault {
 		if mode != types.GroupModeStream {
-			return m.Subscribe(ctx, queueName, pattern, clientID, groupID, proxyNodeID)
+			return m.subscribe(ctx, queueName, pattern, clientID, groupID, proxyNodeID, allowQueueMutation)
 		}
 		cursor = &types.CursorOption{Position: types.CursorDefault, Mode: mode}
 	}
 
-	// Ensure queue exists
-	queueTopicPattern := "$queue/" + queueName + "/#"
-	queueCfg, err := m.GetOrCreateQueue(ctx, queueName, queueTopicPattern)
-	if err != nil {
-		return fmt.Errorf("failed to get or create queue: %w", err)
+	var (
+		queueCfg *types.QueueConfig
+		err      error
+	)
+	if allowQueueMutation {
+		queueTopicPattern := "$queue/" + queueName + "/#"
+		queueCfg, err = m.GetOrCreateQueue(ctx, queueName, queueTopicPattern)
+	} else {
+		queueCfg, err = m.GetQueue(ctx, queueName)
 	}
-	if mode == types.GroupModeStream && queueCfg != nil && queueCfg.Type != types.QueueTypeStream {
+	if err != nil {
+		return fmt.Errorf("failed to resolve queue for subscription: %w", err)
+	}
+	if queueCfg == nil {
+		return fmt.Errorf("failed to resolve queue for subscription: %w", storage.ErrQueueNotFound)
+	}
+	if mode == types.GroupModeStream && queueCfg.Type != types.QueueTypeStream {
+		if !allowQueueMutation {
+			return fmt.Errorf("%w: %q has type %q", ErrQueueNotStream, queueName, queueCfg.Type)
+		}
 		queueCfg.Type = types.QueueTypeStream
 		if err := m.UpdateQueue(ctx, *queueCfg); err != nil {
 			m.logger.Warn("failed to update stream queue config",
@@ -1395,16 +1420,36 @@ func (m *Manager) SubscribeWithCursor(ctx context.Context, queueName, pattern st
 
 // Subscribe adds a consumer to a stream with optional pattern matching.
 func (m *Manager) Subscribe(ctx context.Context, queueName, pattern string, clientID, groupID, proxyNodeID string) error {
+	return m.subscribe(ctx, queueName, pattern, clientID, groupID, proxyNodeID, true)
+}
+
+// SubscribeExisting adds a consumer to an existing queue without creating it.
+func (m *Manager) SubscribeExisting(ctx context.Context, queueName, pattern string, clientID, groupID, proxyNodeID string) error {
+	return m.subscribe(ctx, queueName, pattern, clientID, groupID, proxyNodeID, false)
+}
+
+func (m *Manager) subscribe(ctx context.Context, queueName, pattern string, clientID, groupID, proxyNodeID string, allowQueueCreation bool) error {
 	if proxyNodeID == "" && m.localNodeID != "" {
 		proxyNodeID = m.localNodeID
 	}
 
-	// Ensure queue exists (auto-create if not)
-	// Use $queue/<name>/# as the topic pattern so messages published to $queue/<name>/... are captured
-	queueTopicPattern := "$queue/" + queueName + "/#"
-	_, err := m.GetOrCreateQueue(ctx, queueName, queueTopicPattern)
+	var (
+		queueCfg *types.QueueConfig
+		err      error
+	)
+	if allowQueueCreation {
+		// Use $queue/<name>/# as the topic pattern so messages published to
+		// $queue/<name>/... are captured.
+		queueTopicPattern := "$queue/" + queueName + "/#"
+		queueCfg, err = m.GetOrCreateQueue(ctx, queueName, queueTopicPattern)
+	} else {
+		queueCfg, err = m.GetQueue(ctx, queueName)
+	}
 	if err != nil {
-		return fmt.Errorf("failed to get or create queue: %w", err)
+		return fmt.Errorf("failed to resolve queue for subscription: %w", err)
+	}
+	if queueCfg == nil {
+		return fmt.Errorf("failed to resolve queue for subscription: %w", storage.ErrQueueNotFound)
 	}
 
 	// Default group ID to client prefix

--- a/queue/manager.go
+++ b/queue/manager.go
@@ -1333,10 +1333,7 @@ func (m *Manager) subscribeWithCursor(ctx context.Context, queueName, pattern st
 		}
 	}
 
-	patternGroupID := groupID
-	if pattern != "" {
-		patternGroupID = fmt.Sprintf("%s@%s", groupID, pattern)
-	}
+	patternGroupID := corebroker.EffectiveConsumerGroupID(groupID, pattern)
 
 	autoCommit := true
 	if cursor != nil && cursor.AutoCommit != nil {
@@ -1458,10 +1455,7 @@ func (m *Manager) subscribe(ctx context.Context, queueName, pattern string, clie
 	}
 
 	// Create unique group ID that includes the pattern
-	patternGroupID := groupID
-	if pattern != "" {
-		patternGroupID = fmt.Sprintf("%s@%s", groupID, pattern)
-	}
+	patternGroupID := corebroker.EffectiveConsumerGroupID(groupID, pattern)
 
 	// Get or create consumer group (queue mode always auto-commits)
 	group, err := m.consumerManager.GetOrCreateGroup(ctx, queueName, patternGroupID, pattern, types.GroupModeQueue, true)
@@ -1516,10 +1510,7 @@ func (m *Manager) Unsubscribe(ctx context.Context, queueName, pattern string, cl
 		groupID = DefaultConsumerGroupID(clientID)
 	}
 
-	patternGroupID := groupID
-	if pattern != "" {
-		patternGroupID = fmt.Sprintf("%s@%s", groupID, pattern)
-	}
+	patternGroupID := corebroker.EffectiveConsumerGroupID(groupID, pattern)
 
 	// Unregister consumer locally
 	if err := m.consumerManager.UnregisterConsumer(ctx, queueName, patternGroupID, clientID); err != nil {

--- a/queue/manager.go
+++ b/queue/manager.go
@@ -1329,7 +1329,7 @@ func (m *Manager) subscribeWithCursor(ctx context.Context, queueName, pattern st
 		if mode == types.GroupModeStream {
 			groupID = clientID
 		} else {
-			groupID = extractGroupFromClientID(clientID)
+			groupID = DefaultConsumerGroupID(clientID)
 		}
 	}
 
@@ -1454,7 +1454,7 @@ func (m *Manager) subscribe(ctx context.Context, queueName, pattern string, clie
 
 	// Default group ID to client prefix
 	if groupID == "" {
-		groupID = extractGroupFromClientID(clientID)
+		groupID = DefaultConsumerGroupID(clientID)
 	}
 
 	// Create unique group ID that includes the pattern
@@ -1513,7 +1513,7 @@ func (m *Manager) subscribe(ctx context.Context, queueName, pattern string, clie
 // Unsubscribe removes a consumer from a stream.
 func (m *Manager) Unsubscribe(ctx context.Context, queueName, pattern string, clientID, groupID string) error {
 	if groupID == "" {
-		groupID = extractGroupFromClientID(clientID)
+		groupID = DefaultConsumerGroupID(clientID)
 	}
 
 	patternGroupID := groupID

--- a/queue/manager_test.go
+++ b/queue/manager_test.go
@@ -1086,6 +1086,41 @@ func TestPublishNormalizesClientIDProperty(t *testing.T) {
 	}
 }
 
+func TestSubscribeExistingDoesNotCreateMissingQueue(t *testing.T) {
+	logStore := memlog.New()
+	mgr := NewManager(logStore, newMockGroupStore(), nil, DefaultConfig(), nil, nil)
+
+	err := mgr.SubscribeExisting(context.Background(), "missing", "", testClientOneID, testGroupWorkers, "")
+	if !errors.Is(err, storage.ErrQueueNotFound) {
+		t.Fatalf("SubscribeExisting() error = %v, want %v", err, storage.ErrQueueNotFound)
+	}
+	if _, err := logStore.GetQueue(context.Background(), "missing"); !errors.Is(err, storage.ErrQueueNotFound) {
+		t.Fatalf("missing queue was created: GetQueue() error = %v", err)
+	}
+}
+
+func TestSubscribeExistingWithCursorDoesNotChangeQueueType(t *testing.T) {
+	logStore := memlog.New()
+	mgr := NewManager(logStore, newMockGroupStore(), nil, DefaultConfig(), nil, nil)
+	queueCfg := types.DefaultQueueConfig(testQueueEvents, "$queue/events/#")
+	if err := mgr.CreateQueue(context.Background(), queueCfg); err != nil {
+		t.Fatalf("CreateQueue() error = %v", err)
+	}
+
+	cursor := &types.CursorOption{Position: types.CursorEarliest, Mode: types.GroupModeStream}
+	err := mgr.SubscribeExistingWithCursor(context.Background(), testQueueEvents, "", testClientOneID, "streamer", "", cursor)
+	if !errors.Is(err, ErrQueueNotStream) {
+		t.Fatalf("SubscribeExistingWithCursor() error = %v, want %v", err, ErrQueueNotStream)
+	}
+	stored, err := mgr.GetQueue(context.Background(), testQueueEvents)
+	if err != nil {
+		t.Fatalf("GetQueue() error = %v", err)
+	}
+	if stored.Type != types.QueueTypeClassic {
+		t.Fatalf("queue type = %q, want %q", stored.Type, types.QueueTypeClassic)
+	}
+}
+
 func TestStreamAckManualCommitPreservesCommittedOffset(t *testing.T) {
 	logStore := memlog.New()
 	groupStore := newMockGroupStore()

--- a/queue/manager_test.go
+++ b/queue/manager_test.go
@@ -33,9 +33,9 @@ var (
 
 const (
 	node1                = "node-1"
-	testAuditQueueName   = "atom-audit"
-	testAuditQueueTopic  = "$queue/atom-audit"
-	testAuditQueueFilter = "$queue/atom-audit/#"
+	testAuditQueueName   = "atom.events"
+	testAuditQueueTopic  = "$queue/atom.events"
+	testAuditQueueFilter = "$queue/atom.events/#"
 )
 
 type targetCheckingDeliverer struct {
@@ -871,12 +871,12 @@ func TestPublishToDurableStreamTargetsOneQueueAndSyncsBeforeSuccess(t *testing.T
 	}); err != nil {
 		t.Fatalf("durable stream publish: %v", err)
 	}
-	if operations := store.Operations(); fmt.Sprint(operations) != "[append:atom-audit sync:atom-audit]" {
-		t.Fatalf("operations = %v, want append then sync for atom-audit", operations)
+	if operations := store.Operations(); fmt.Sprint(operations) != "[append:atom.events sync:atom.events]" {
+		t.Fatalf("operations = %v, want append then sync for atom.events", operations)
 	}
 	auditTail, err := base.Tail(ctx, testAuditQueueName)
 	if err != nil || auditTail != 1 {
-		t.Fatalf("atom-audit tail = %d, error = %v, want 1", auditTail, err)
+		t.Fatalf("atom.events tail = %d, error = %v, want 1", auditTail, err)
 	}
 	overlapTail, err := base.Tail(ctx, "overlap")
 	if err != nil || overlapTail != 0 {
@@ -945,8 +945,8 @@ func TestPublishToDurableStreamPropagatesAppendAndSyncFailures(t *testing.T) {
 		wantErr        error
 		wantOperations string
 	}{
-		{name: "append", appendErr: errTestAppend, wantErr: errTestAppend, wantOperations: "[append:atom-audit]"},
-		{name: "sync", syncErr: errTestSync, wantErr: errTestSync, wantOperations: "[append:atom-audit sync:atom-audit]"},
+		{name: "append", appendErr: errTestAppend, wantErr: errTestAppend, wantOperations: "[append:atom.events]"},
+		{name: "sync", syncErr: errTestSync, wantErr: errTestSync, wantOperations: "[append:atom.events sync:atom.events]"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/queue/messages.go
+++ b/queue/messages.go
@@ -32,6 +32,12 @@ func extractGroupFromClientID(clientID string) string {
 	return clientID
 }
 
+// DefaultConsumerGroupID returns the queue-mode consumer group used when a
+// subscriber does not provide one explicitly.
+func DefaultConsumerGroupID(clientID string) string {
+	return extractGroupFromClientID(clientID)
+}
+
 var messageIDCounter atomic.Uint64
 
 func generateMessageID() string {

--- a/reload/manager.go
+++ b/reload/manager.go
@@ -180,6 +180,15 @@ func (m *Manager) Reload(ctx context.Context) (*ReloadResult, error) {
 		return nil, fmt.Errorf("reload failed: %w", err)
 	}
 
+	// Cross-field rules whose two halves reload at different speeds have to be
+	// asked of the running process, not of the file alone.
+	if err := config.ValidateAgainstRuntime(m.current, newCfg); err != nil {
+		if m.localPrincipalsFailed != nil && len(m.current.Auth.LocalPrincipals) > 0 {
+			m.localPrincipalsFailed(err)
+		}
+		return nil, fmt.Errorf("reload failed: %w", err)
+	}
+
 	diff := config.Diff(m.current, newCfg)
 	if m.localPrincipalsReload != nil && !hasFieldChange(diff.RuntimeSafe, localPrincipalsPath) {
 		// Secret files can change without their configured paths changing. Probe

--- a/reload/manager_test.go
+++ b/reload/manager_test.go
@@ -122,7 +122,7 @@ func TestReloadLocalPrincipalSecretContent(t *testing.T) {
       permissions:
         publish:
           - exchange: ""
-            routing_key: atom-audit
+            routing_key: atom.events
         subscribe: []
 `, secretPath))
 	initial, err := config.Load(path)
@@ -211,7 +211,7 @@ func TestReloadLocalPrincipalsRegisterRollback(t *testing.T) {
       permissions:
         publish:
           - exchange: ""
-            routing_key: atom-audit
+            routing_key: atom.events
         subscribe: []
 `, secretPath))
 	initial, err := config.Load(path)

--- a/reload/manager_test.go
+++ b/reload/manager_test.go
@@ -60,6 +60,49 @@ func TestReloadNoChanges(t *testing.T) {
 	}
 }
 
+func TestReloadRejectsExactGrantWhenDesiredConfigRemovesRunningListener(t *testing.T) {
+	dir := t.TempDir()
+	secretPath := filepath.Join(dir, "local-secret")
+	if err := os.WriteFile(secretPath, []byte("0123456789abcdef0123456789abcdef"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	path := writeConfig(t, dir, fmt.Sprintf(`auth:
+  local_principals:
+    - name: service
+      certificate_uri_san: spiffe://absmach/service
+      current_secret_file: %q
+      permissions:
+        publish:
+          - routing_key: audit
+        subscribe: []
+`, secretPath))
+
+	running := config.Default()
+	running.Cluster.Enabled = true
+	running.Server.AMQP091.Local.Addr = ":5683"
+	running.Auth.LocalPrincipals = []config.LocalPrincipalConfig{{
+		Name:              "service",
+		CertificateURISAN: "spiffe://absmach/service",
+		CurrentSecretFile: secretPath,
+		Permissions: config.LocalPermissionsConfig{Publish: []config.LocalPublishPermission{{
+			RoutingKeyPrefix: "m.",
+		}}},
+	}}
+
+	var callbackCalls atomic.Int64
+	m := New(path, running, WithLocalPrincipalsReload(func([]config.LocalPrincipalConfig) (bool, error) {
+		callbackCalls.Add(1)
+		return true, nil
+	}))
+	_, err := m.Reload(context.Background())
+	if err == nil {
+		t.Fatal("Reload() succeeded while the clustered runtime still had a local listener")
+	}
+	if callbackCalls.Load() != 0 {
+		t.Fatalf("local-principal callback calls = %d, want 0", callbackCalls.Load())
+	}
+}
+
 func TestReloadLocalPrincipalSecretContent(t *testing.T) {
 	dir := t.TempDir()
 	secretPath := filepath.Join(dir, "local-secret")

--- a/server/amqp/server_test.go
+++ b/server/amqp/server_test.go
@@ -36,9 +36,14 @@ type reloadRaceLocalPolicy struct {
 	retired       atomic.Bool
 }
 
-func (p *reloadRaceLocalPolicy) AuthenticateLocal(_ context.Context, _, _, _ string, _ amqpbroker.VerifiedPeerIdentity) (string, string, string, string, bool, error) {
+func (p *reloadRaceLocalPolicy) AuthenticateLocal(_ context.Context, _, _, _ string, _ amqpbroker.VerifiedPeerIdentity) (amqpbroker.LocalAuthentication, bool, error) {
 	close(p.authenticated)
-	return "atom-audit-publisher", "old-credential-fingerprint", "old-permissions-fingerprint", testLocalCertificateURI, true, nil
+	return amqpbroker.LocalAuthentication{
+		PrincipalID:            "atom-audit-publisher",
+		CredentialFingerprint:  "old-credential-fingerprint",
+		PermissionsFingerprint: "old-permissions-fingerprint",
+		CertificateURI:         testLocalCertificateURI,
+	}, true, nil
 }
 
 func (p *reloadRaceLocalPolicy) CanPublishLocal(amqpbroker.LocalSessionIdentity, string, string) amqpbroker.LocalPublishGrant {
@@ -195,7 +200,7 @@ func TestRetiredLocalCredentialDuringHandshakeReleasesConnectionSlot(t *testing.
 	s := New(Config{
 		HandshakeTimeout: 2 * time.Second,
 		MaxConnections:   1,
-		ConnectionPolicy: amqpbroker.NewLocalPublishOnlyConnectionPolicy(
+		ConnectionPolicy: amqpbroker.NewLocalConnectionPolicy(
 			localPolicy,
 			localPolicy,
 			localPolicy,

--- a/server/amqp/server_test.go
+++ b/server/amqp/server_test.go
@@ -45,6 +45,10 @@ func (p *reloadRaceLocalPolicy) CanPublishLocal(amqpbroker.LocalSessionIdentity,
 	return !p.retired.Load()
 }
 
+func (p *reloadRaceLocalPolicy) CanSubscribeLocal(amqpbroker.LocalSessionIdentity, string) bool {
+	return false
+}
+
 func (p *reloadRaceLocalPolicy) IsSessionActive(amqpbroker.LocalSessionIdentity) bool {
 	return !p.retired.Load()
 }

--- a/server/amqp/server_test.go
+++ b/server/amqp/server_test.go
@@ -41,8 +41,11 @@ func (p *reloadRaceLocalPolicy) AuthenticateLocal(_ context.Context, _, _, _ str
 	return "atom-audit-publisher", "old-credential-fingerprint", "old-permissions-fingerprint", testLocalCertificateURI, true, nil
 }
 
-func (p *reloadRaceLocalPolicy) CanPublishLocal(amqpbroker.LocalSessionIdentity, string, string) bool {
-	return !p.retired.Load()
+func (p *reloadRaceLocalPolicy) CanPublishLocal(amqpbroker.LocalSessionIdentity, string, string) amqpbroker.LocalPublishGrant {
+	if p.retired.Load() {
+		return amqpbroker.LocalPublishGrantNone
+	}
+	return amqpbroker.LocalPublishGrantExactTarget
 }
 
 func (p *reloadRaceLocalPolicy) CanSubscribeLocal(amqpbroker.LocalSessionIdentity, string) bool {

--- a/server/api/stats.go
+++ b/server/api/stats.go
@@ -82,6 +82,7 @@ type amqpLocalAuthenticationStats struct {
 
 type amqpLocalAuthorizationStats struct {
 	PublishDenied   uint64 `json:"publish_denied"`
+	SubscribeDenied uint64 `json:"subscribe_denied"`
 	OperationDenied uint64 `json:"operation_denied"`
 }
 
@@ -198,6 +199,7 @@ func (s *Server) buildStatsResponse() statsResponse {
 				},
 				Authorization: amqpLocalAuthorizationStats{
 					PublishDenied:   ast.GetLocalPublishDenials(),
+					SubscribeDenied: ast.GetLocalSubscribeDenials(),
 					OperationDenied: ast.GetLocalOperationDenials(),
 				},
 				Reloads: amqpLocalReloadStats{

--- a/server/api/stats_test.go
+++ b/server/api/stats_test.go
@@ -86,6 +86,7 @@ func TestStatsAMQPOnly(t *testing.T) {
 	ab.GetStats().IncrementLocalAuthSuccess()
 	ab.GetStats().IncrementLocalAuthFailures()
 	ab.GetStats().IncrementLocalPublishDenials()
+	ab.GetStats().IncrementLocalSubscribeDenials()
 	ab.GetStats().IncrementLocalOperationDenials()
 	ab.GetStats().IncrementLocalReloadSuccess()
 	ab.GetStats().IncrementLocalReloadFailures()
@@ -129,7 +130,7 @@ func TestStatsAMQPOnly(t *testing.T) {
 	if local.Authentication.Success != 1 || local.Authentication.Failure != 1 {
 		t.Fatalf("unexpected local authentication stats: %+v", local.Authentication)
 	}
-	if local.Authorization.PublishDenied != 1 || local.Authorization.OperationDenied != 1 {
+	if local.Authorization.PublishDenied != 1 || local.Authorization.SubscribeDenied != 1 || local.Authorization.OperationDenied != 1 {
 		t.Fatalf("unexpected local authorization stats: %+v", local.Authorization)
 	}
 	if local.Reloads.Success != 1 || local.Reloads.Failure != 1 || local.Reloads.ForcedDisconnects != 2 {

--- a/server/queue/handler_test.go
+++ b/server/queue/handler_test.go
@@ -179,7 +179,7 @@ func TestUpdateQueueAppliesConfig(t *testing.T) {
 func TestProtectedQueueAdminUpdateAndDeleteFailPrecondition(t *testing.T) {
 	ctx := context.Background()
 	store := memlog.New()
-	contract := types.DefaultQueueConfig("atom-audit", "$queue/atom-audit/#")
+	contract := types.DefaultQueueConfig("atom.events", "$queue/atom.events/#")
 	contract.Type = types.QueueTypeStream
 	contract.Reserved = true
 	contract.Retention.RetentionTime = 30 * 24 * time.Hour

--- a/tests/smoke/local_principal_test.go
+++ b/tests/smoke/local_principal_test.go
@@ -38,7 +38,7 @@ import (
 const (
 	localUsername = "atom-audit-publisher"
 	localURISAN   = "spiffe://absmach/atom/audit-publisher"
-	auditQueue    = "atom-audit"
+	auditQueue    = "atom.events"
 )
 
 func TestLocalPrincipalRealProcess(t *testing.T) {
@@ -107,7 +107,7 @@ func TestLocalPrincipalRealProcess(t *testing.T) {
 	assertDialRejected(t, ports.internal, untrustedTLS, localUsername, currentSecret)
 	assertSubscribeDenied(t, ports.internal, validTLS, currentSecret)
 	assertTopologyDenied(t, ports.internal, validTLS, currentSecret)
-	assertPublishDenied(t, ports.internal, validTLS, currentSecret, "", "not-atom-audit")
+	assertPublishDenied(t, ports.internal, validTLS, currentSecret, "", "not-atom.events")
 	assertPublishDenied(t, ports.internal, validTLS, currentSecret, "events", auditQueue)
 
 	if got := callout.total(); got != 0 {
@@ -237,7 +237,7 @@ func writeSmokeConfig(t *testing.T, path string, cfg smokeConfig) {
     plain:
       addr: "127.0.0.1:%d"
       max_connections: 32
-    internal:
+    local:
       addr: "127.0.0.1:%d"
       max_connections: 8
       cert_file: %q
@@ -271,6 +271,7 @@ auth:
   local_principals:
     - name: %q
       certificate_uri_san: %q
+      role: "publisher"
       current_secret_file: %q%s
       permissions:
         publish:
@@ -289,7 +290,7 @@ hooks:
 queues:
   - name: %q
     topics:
-      - "$queue/atom-audit/#"
+      - "$queue/atom.events/#"
     reserved: true
     type: "stream"
     retention:


### PR DESCRIPTION
Message properties prefixed `_flux.` carry broker-internal state between first-party services. A client may neither set nor read one: they are dropped on ingress and omitted on egress for every connection that is not trusted, so one cannot be forged, and one set by a service cannot be observed.

Trust is a property of the connection's listener policy rather than of its protocol — speaking AMQP confers nothing, and an externally authenticated AMQP client is never treated as a service. Only the AMQP 0.9.1 local listener is trusted, because it admits solely mTLS peers whose verified certificate URI SAN matches a principal declared in FluxMQ's own configuration.

## Capability belongs to the principal

Nothing binds a principal to a listener: any principal holding a valid certificate and secret can connect to any local listener. A capability granted by a port would therefore be granted to every principal able to reach that port — an audit publisher could gain origin relay simply by dialling the service port, and attribute one of its own records to a principal that never authenticated.

So a principal carries a **role**, and the role decides what it may do:

| Role | Publish | Consume | Relay an origin identity |
| --- | --- | --- | --- |
| `publisher` (default) | per its ACL | no | no |
| `service` | per its ACL | per its ACL | yes |

`publisher` is both the default and the zero value, so an unspecified principal gets the least privilege. The role joins the permissions fingerprint, so demoting a `service` revokes its live sessions exactly as narrowing an ACL or rotating a credential does — a demotion does not wait for a reconnect.

With capability out of the listener, the local listeners became interchangeable. They are served under one `server.amqp091.local` key; `internal` and `service` remain as deprecated aliases, warned about at startup. Configuring several is still meaningful — they name listeners, so more than one places local traffic on separate networks.

## The permission decides the delivery contract

A publish permission sets exactly one of `routing_key` or `routing_key_prefix`, and which one matched decides how the publication is delivered:

- an **exact** target names a protected durable stream, and is appended and synced before the publisher confirm;
- a **prefix** names no queue, and is always an ordinary topic publish.

A prefix grant can never reach a queue, whatever routing key it covers — neither through a `$queue/`-shaped prefix nor through a routing key that happens to name a configured stream. That is a property of the permission, not of the port, so one entry means the same thing everywhere. It is also why an exact target refuses to run alongside `cluster.enabled` while a prefix-only principal runs clustered: only the exact one is durable on the receiving node and never forwarded.

`external_id` and `protocol` follow the same boundary. They are stamped from the authenticated connection, so a publisher cannot attribute a message to another principal or claim it arrived over another protocol. A `service` relaying a message it did not author may state the true origin; a `publisher` may not, because its publications are its own records.

## Reads stay reads

A `service` consumes only the queues its `subscribe` ACL names, resolved before matching so `subscribe: [m]` authorizes `basic.consume` on `$queue/m`. A read grant cannot become an administrative write: `queue.declare` is passive-only, consumption uses a non-mutating queue-manager operation that will not create a queue or change its type, and `basic.get`, `queue.bind`, `queue.unbind`, `queue.purge` and `queue.delete` are refused.

## Notes

Reloads are validated against the running process, not the new file alone. `auth.local_principals` reloads at runtime while clustering and listeners require a restart, so an edit that disabled clustering and added an exact target in one step would otherwise apply the target inside a still-clustered runtime.

`subscribe_denied` is published in `GET /api/v1/stats` and in the OpenAPI schema alongside the existing authorization counters.

## Have you included tests for your changes?

Yes. Each boundary has coverage on both sides — trusted and untrusted, publisher and service, exact and prefix — including the paths that are currently unreachable in configuration, so they do not rot.

## Did you document any new/modified features?

Yes. `docs/content/docs/configuration/security.md` covers roles, the trust boundary, publish-target kinds and the reload rule; the configuration reference and the local-principal deployment guide follow.
