### PR TITLE
Dispatch topic capture off the publish path

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -741,13 +741,22 @@ components:
           type: integer
           format: int64
           description: |
-            Pub/sub publishes that did not reach every queue whose `topics`
-            pattern matched them, whether the append failed, a matched queue's
-            configuration could not be read, or the matching queues could not be
-            resolved. Counted once per publish however many queues were affected,
-            so it measures how often capture is lossy rather than how many records
-            were lost. Capture never fails the publish, so this is the only signal
-            that a queue is dropping the traffic its pattern binds.
+            Matching queues a captured publish failed to reach, because the
+            append failed or the queue's configuration could not be read. The
+            unit is the queue, so a publish missing two of its matching queues
+            counts twice. A resolution failure, where the matching set is
+            unknown, counts once.
+          example: 0
+        capture_dropped:
+          type: integer
+          format: int64
+          description: |
+            Capture jobs discarded before any append was attempted, because the
+            capture backlog was full or shutdown drained past its deadline.
+            Distinct from `capture_failures`, where the append was tried and did
+            not succeed: a rising `capture_dropped` means capture cannot keep up
+            with the publish rate. Capture runs off the publish path and never
+            fails the publish, so these two counters are its only signal.
           example: 0
         claims:
           $ref: "#/components/schemas/QueueAttemptStats"

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -36,13 +36,13 @@ type QueuePublisher interface {
 // persistence guarantee uses an exact publish target, whose durable append is
 // synced before the confirm and does fail the publish.
 //
-// That isolates a failing queue's errors, not its latency. Implementations run
-// on the publish path before subscriber delivery, and the append honours no
-// cancellation, so a slow or stuck store delays every subscriber of a matching
-// topic and the publisher's acknowledgement with it. Decoupling capture from
-// delivery requires a bounded dispatcher and an overflow policy, which is a
-// contract change rather than a fix; until then, treat a queue whose store can
-// block as able to stall the pub/sub path its pattern covers.
+// Implementations must not perform the storage work on the caller's goroutine.
+// The append honours no cancellation, so running it inline let a queue whose
+// store stalls delay every subscriber of a matching topic and the publisher's
+// acknowledgement with it. The queue manager resolves the matching queues
+// synchronously — an in-memory lookup — and dispatches the appends, so a
+// returned error reports only that resolution failed. An append that fails or is
+// dropped afterwards is reported through the capture counters instead.
 type TopicQueuePublisher interface {
 	PublishToMatchingQueues(ctx context.Context, publish types.PublishRequest) error
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -339,6 +339,49 @@ func (t *brokerDeliveryTarget) HasDeliveryTarget(clientID string) bool {
 	return t.mqtt != nil && t.mqtt.Get(clientID) != nil
 }
 
+// releaseShutdownResources releases resources shared with the queue manager in
+// dependency order. The broker has already called Manager.Stop before this
+// runs. If capture did not quiesce, every dependency is deliberately left open:
+// an in-flight worker may still be appending locally or forwarding through the
+// cluster, and the cluster itself owns references into the broker store.
+func releaseShutdownResources(
+	shutdownComplete bool,
+	stopCluster func() error,
+	closeQueueLogStore func() error,
+	closeBrokerStore func() error,
+	logger *slog.Logger,
+) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if !shutdownComplete {
+		logger.Error("queue resources left open: capture workers are still running",
+			"cluster", "not stopped",
+			"queue_log_store", "not closed",
+			"broker_store", "not closed")
+		return
+	}
+
+	// Stop ingress before closing either store: cluster RPC handlers call the
+	// queue manager and the cluster's hybrid stores use the broker store.
+	if stopCluster != nil {
+		if err := stopCluster(); err != nil {
+			logger.Error("Failed to stop cluster; dependent stores left open", "error", err)
+			return
+		}
+	}
+	if closeQueueLogStore != nil {
+		if err := closeQueueLogStore(); err != nil {
+			logger.Error("Failed to close queue log storage", "error", err)
+		}
+	}
+	if closeBrokerStore != nil {
+		if err := closeBrokerStore(); err != nil {
+			logger.Error("Failed to close broker storage", "error", err)
+		}
+	}
+}
+
 func main() {
 	configFile := flag.String("config", "", "Path to configuration file")
 	flag.Parse()
@@ -410,7 +453,10 @@ func main() {
 		"cluster_enabled", cfg.Cluster.Enabled,
 		"log_level", cfg.Log.Level)
 
-	var store storage.Store
+	var (
+		store            storage.Store
+		closeBrokerStore func() error
+	)
 	switch cfg.Storage.Type {
 	case "memory":
 		store = memory.New()
@@ -425,7 +471,7 @@ func main() {
 			os.Exit(1)
 		}
 		store = badgerStore
-		defer store.Close()
+		closeBrokerStore = store.Close
 		slog.Info("Using BadgerDB persistent storage", "dir", cfg.Storage.BadgerDir)
 	default:
 		slog.Error("Unknown storage type", "type", cfg.Storage.Type)
@@ -566,24 +612,20 @@ func main() {
 	// indefinite. Anything that worker still uses must then be left alone:
 	// closing the store underneath it corrupts a segment it holds, and stopping
 	// the cluster underneath it pulls out the transport its forward is using.
-	// Leaking both into process exit is the cheaper failure.
+	// Leaking their dependencies into process exit is the cheaper failure.
 	defer func() {
-		if qm != nil && !qm.ShutdownComplete() {
-			slog.Error("queue resources left open: capture workers are still writing",
-				"queue_log_store", "not closed",
-				"cluster", "not stopped")
-			return
-		}
+		var closeQueueLogStore func() error
 		if queueLogStore != nil {
-			if err := queueLogStore.Close(); err != nil {
-				slog.Error("Failed to close queue log storage", "error", err)
-			}
+			closeQueueLogStore = queueLogStore.Close
 		}
-		if stopCluster != nil {
-			if err := stopCluster(); err != nil {
-				slog.Error("Failed to stop cluster", "error", err)
-			}
-		}
+		shutdownComplete := qm == nil || qm.ShutdownComplete()
+		releaseShutdownResources(
+			shutdownComplete,
+			stopCluster,
+			closeQueueLogStore,
+			closeBrokerStore,
+			logger,
+		)
 	}()
 
 	defer b.Close()
@@ -757,7 +799,7 @@ func main() {
 		amqpMetrics, err := amqp1broker.NewMetrics()
 		if err != nil {
 			slog.Error("Failed to create AMQP metrics", "error", err)
-			os.Exit(1)
+			os.Exit(1) //nolint:gocritic // exitAfterDefer: fatal initialization errors terminate immediately
 		}
 		amqpBroker.SetMetrics(amqpMetrics)
 		slog.Info("AMQP OTel metrics enabled")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -747,6 +747,16 @@ func main() {
 		// Convert queue configs from main config to queue types
 		queueCfg := queue.DefaultConfig()
 		queueCfg.AutoCommitInterval = cfg.QueueManager.AutoCommitInterval
+		// Zero leaves the dispatcher default in place.
+		if cfg.QueueManager.CaptureWorkers > 0 {
+			queueCfg.CaptureWorkers = cfg.QueueManager.CaptureWorkers
+		}
+		if cfg.QueueManager.CaptureQueueDepth > 0 {
+			queueCfg.CaptureQueueDepth = cfg.QueueManager.CaptureQueueDepth
+		}
+		if cfg.QueueManager.CaptureDrainTimeout > 0 {
+			queueCfg.CaptureDrainTimeout = cfg.QueueManager.CaptureDrainTimeout
+		}
 		queueCfg.WritePolicy = queue.WritePolicy(cfg.Cluster.Raft.WritePolicy)
 		queueCfg.DistributionMode = queue.DistributionMode(cfg.Cluster.Raft.DistributionMode)
 		for _, qc := range cfg.Queues {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -742,7 +742,21 @@ func main() {
 			slog.Error("Failed to initialize queue log storage", "error", err)
 			os.Exit(1)
 		}
-		defer queueLogStore.Close()
+		// Releasing the store is conditional on the queue manager having fully
+		// stopped. A capture worker can outlive Stop when an append will not
+		// return — the store takes no context, so the wait is bounded rather
+		// than indefinite — and closing underneath that worker is a
+		// use-after-close on a segment it still holds. Leaking the handle into
+		// process exit is the cheaper failure.
+		defer func() {
+			if qm != nil && !qm.ShutdownComplete() {
+				slog.Error("queue log store left open: capture workers are still writing")
+				return
+			}
+			if err := queueLogStore.Close(); err != nil {
+				slog.Error("Failed to close queue log storage", "error", err)
+			}
+		}()
 
 		// Convert queue configs from main config to queue types
 		queueCfg := queue.DefaultConfig()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -434,6 +434,15 @@ func main() {
 
 	var cl cluster.Cluster
 	var etcdCluster *cluster.EtcdCluster
+
+	// Declared here rather than beside their construction because the deferred
+	// teardown that releases them has to be registered before b.Close, which is
+	// what stops the queue manager they belong to.
+	var (
+		qm            *queue.Manager
+		queueLogStore *logStorage.Adapter
+		stopCluster   func() error
+	)
 	if cfg.Cluster.Enabled {
 		// Build transport TLS config if enabled
 		var transportTLS *cluster.TransportTLSConfig
@@ -469,7 +478,10 @@ func main() {
 		}
 		etcdCluster = ec
 		cl = etcdCluster
-		defer cl.Stop() //nolint:errcheck // best-effort deferred shutdown
+		// Stopped by the gated teardown rather than deferred here: a capture
+		// worker that outlives the queue manager may still be forwarding
+		// through this cluster.
+		stopCluster = cl.Stop
 
 		if err := cl.Start(); err != nil {
 			slog.Error("Failed to start cluster", "error", err)
@@ -545,6 +557,35 @@ func main() {
 		broker.WithTransportConfig(cfg.Cluster.Transport),
 		broker.WithBrokerConfig(cfg.Broker),
 	)
+	// Registered before b.Close so that it runs after it: defers are LIFO, and
+	// b.Close is what stops the queue manager. Reading the shutdown state any
+	// earlier would always see a manager that has not stopped yet.
+	//
+	// A capture worker can outlive Manager.Stop when an append will not return —
+	// the queue store takes no context, so the wait is bounded rather than
+	// indefinite. Anything that worker still uses must then be left alone:
+	// closing the store underneath it corrupts a segment it holds, and stopping
+	// the cluster underneath it pulls out the transport its forward is using.
+	// Leaking both into process exit is the cheaper failure.
+	defer func() {
+		if qm != nil && !qm.ShutdownComplete() {
+			slog.Error("queue resources left open: capture workers are still writing",
+				"queue_log_store", "not closed",
+				"cluster", "not stopped")
+			return
+		}
+		if queueLogStore != nil {
+			if err := queueLogStore.Close(); err != nil {
+				slog.Error("Failed to close queue log storage", "error", err)
+			}
+		}
+		if stopCluster != nil {
+			if err := stopCluster(); err != nil {
+				slog.Error("Failed to stop cluster", "error", err)
+			}
+		}
+	}()
+
 	defer b.Close()
 
 	// Configure maximum QoS level
@@ -709,11 +750,8 @@ func main() {
 	amqp091Broker.SetRouter(sharedRouter)
 	amqpBroker.SetRouter(sharedRouter)
 
-	var (
-		qm                       *queue.Manager
-		queueLogStore            *logStorage.Adapter
-		configuredQueueContracts []queueTypes.QueueConfig
-	)
+	// qm and queueLogStore are declared with the deferred teardown above.
+	var configuredQueueContracts []queueTypes.QueueConfig
 
 	if metrics != nil {
 		amqpMetrics, err := amqp1broker.NewMetrics()
@@ -742,21 +780,10 @@ func main() {
 			slog.Error("Failed to initialize queue log storage", "error", err)
 			os.Exit(1)
 		}
-		// Releasing the store is conditional on the queue manager having fully
-		// stopped. A capture worker can outlive Stop when an append will not
-		// return — the store takes no context, so the wait is bounded rather
-		// than indefinite — and closing underneath that worker is a
-		// use-after-close on a segment it still holds. Leaking the handle into
-		// process exit is the cheaper failure.
-		defer func() {
-			if qm != nil && !qm.ShutdownComplete() {
-				slog.Error("queue log store left open: capture workers are still writing")
-				return
-			}
-			if err := queueLogStore.Close(); err != nil {
-				slog.Error("Failed to close queue log storage", "error", err)
-			}
-		}()
+		// The store is released by the deferred teardown registered before
+		// b.Close, so that it runs after the broker has stopped the queue
+		// manager. Registering it here would run it first: defers are LIFO, and
+		// this is registered later than b.Close.
 
 		// Convert queue configs from main config to queue types
 		queueCfg := queue.DefaultConfig()

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -29,6 +31,72 @@ const (
 	testNextSecret     = "abcdef0123456789abcdef0123456789"
 	testAuditQueue     = "audit.events"
 )
+
+func TestReleaseShutdownResourcesInDependencyOrder(t *testing.T) {
+	var calls []string
+	record := func(name string) func() error {
+		return func() error {
+			calls = append(calls, name)
+			return nil
+		}
+	}
+
+	releaseShutdownResources(
+		true,
+		record("cluster"),
+		record("queue-store"),
+		record("broker-store"),
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	if got, want := strings.Join(calls, ","), "cluster,queue-store,broker-store"; got != want {
+		t.Fatalf("shutdown order = %q, want %q", got, want)
+	}
+}
+
+func TestReleaseShutdownResourcesLeavesDependenciesOpenWhileCaptureRuns(t *testing.T) {
+	called := false
+	closer := func() error {
+		called = true
+		return nil
+	}
+
+	releaseShutdownResources(
+		false,
+		closer,
+		closer,
+		closer,
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	if called {
+		t.Fatal("a capture dependency was released while a worker could still be using it")
+	}
+}
+
+func TestReleaseShutdownResourcesKeepsStoresOpenWhenClusterStopFails(t *testing.T) {
+	var calls []string
+	releaseShutdownResources(
+		true,
+		func() error {
+			calls = append(calls, "cluster")
+			return errors.New("cluster still serving requests")
+		},
+		func() error {
+			calls = append(calls, "queue-store")
+			return nil
+		},
+		func() error {
+			calls = append(calls, "broker-store")
+			return nil
+		},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	if got, want := strings.Join(calls, ","), "cluster"; got != want {
+		t.Fatalf("shutdown calls = %q, want %q", got, want)
+	}
+}
 
 func TestLocalAMQPPolicyAdapter(t *testing.T) {
 	dir := t.TempDir()

--- a/config/config.go
+++ b/config/config.go
@@ -530,6 +530,16 @@ type QueueManagerConfig struct {
 	// AutoCommitInterval controls how often stream groups auto-commit offsets.
 	// Zero means commit on every delivery batch.
 	AutoCommitInterval time.Duration `yaml:"auto_commit_interval"`
+
+	// Topic capture runs off the publish path so a stalled queue store cannot
+	// delay subscribers. These bound that machinery. Zero selects the default.
+	//
+	// CaptureQueueDepth counts jobs rather than bytes, so the memory ceiling is
+	// capture_workers x capture_queue_depth payloads. A deployment capturing
+	// large messages should lower it.
+	CaptureWorkers      int           `yaml:"capture_workers"`
+	CaptureQueueDepth   int           `yaml:"capture_queue_depth"`
+	CaptureDrainTimeout time.Duration `yaml:"capture_drain_timeout"`
 }
 
 // RateLimitConfig holds rate limiting configuration.
@@ -1834,6 +1844,15 @@ func (c *Config) Validate() error {
 
 	if c.QueueManager.AutoCommitInterval < 0 {
 		return fmt.Errorf("queue_manager.auto_commit_interval must be >= 0")
+	}
+	if c.QueueManager.CaptureWorkers < 0 {
+		return fmt.Errorf("queue_manager.capture_workers must be >= 0")
+	}
+	if c.QueueManager.CaptureQueueDepth < 0 {
+		return fmt.Errorf("queue_manager.capture_queue_depth must be >= 0")
+	}
+	if c.QueueManager.CaptureDrainTimeout < 0 {
+		return fmt.Errorf("queue_manager.capture_drain_timeout must be >= 0")
 	}
 
 	// Queue validation

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -526,3 +526,60 @@ func TestNormalizeProtocolMode(t *testing.T) {
 		})
 	}
 }
+
+// The capture knobs bound how much unwritten capture a stalled queue store can
+// hold, so a negative value is a configuration error rather than a default.
+// Zero is not: it selects the built-in default, which is what an unset field
+// decodes to.
+func TestValidateQueueManagerCaptureBounds(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*QueueManagerConfig)
+		wantError string
+	}{
+		{
+			name:      "defaults are valid",
+			configure: func(*QueueManagerConfig) {},
+		},
+		{
+			name:      "zero selects the default",
+			configure: func(q *QueueManagerConfig) { q.CaptureWorkers, q.CaptureQueueDepth, q.CaptureDrainTimeout = 0, 0, 0 },
+		},
+		{
+			name:      "explicit values are valid",
+			configure: func(q *QueueManagerConfig) { q.CaptureWorkers, q.CaptureQueueDepth = 2, 64 },
+		},
+		{
+			name:      "negative workers rejected",
+			configure: func(q *QueueManagerConfig) { q.CaptureWorkers = -1 },
+			wantError: "queue_manager.capture_workers must be >= 0",
+		},
+		{
+			name:      "negative depth rejected",
+			configure: func(q *QueueManagerConfig) { q.CaptureQueueDepth = -1 },
+			wantError: "queue_manager.capture_queue_depth must be >= 0",
+		},
+		{
+			name:      "negative drain timeout rejected",
+			configure: func(q *QueueManagerConfig) { q.CaptureDrainTimeout = -1 },
+			wantError: "queue_manager.capture_drain_timeout must be >= 0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Default()
+			tt.configure(&cfg.QueueManager)
+			err := cfg.Validate()
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("Validate() error = %v, want it to contain %q", err, tt.wantError)
+			}
+		})
+	}
+}

--- a/docs/content/docs/messaging/durable-queues.mdx
+++ b/docs/content/docs/messaging/durable-queues.mdx
@@ -268,9 +268,17 @@ the moment capture saturated, rather than a log with a hole in the middle.
 Ordering is preserved per queue. A queue is always handled by the same dispatcher
 lane, so its appends land in publish order even though the work is asynchronous.
 
-On shutdown the dispatcher drains what it has queued, bounded by a timeout so a
-stalled store cannot hold shutdown open. Anything still queued when that expires
-is counted in `capture_dropped` like any other loss.
+Lanes are shared rather than one per queue, so the broker's goroutine count does
+not follow its queue count. The trade is that a stalled queue also stalls the
+unrelated queues hashed to the same lane, until its backlog fills and jobs start
+being dropped. Raise `queue_manager.capture_workers` where many queues bind
+ordinary topics and one of them may block.
+
+On shutdown the dispatcher drains what it has queued, bounded by
+`queue_manager.capture_drain_timeout`. An append already in progress cannot be
+interrupted — the queue store takes no context — so a worker still inside one when
+the budget expires is left to finish while shutdown proceeds. Anything not
+written is counted in `capture_dropped` like any other loss.
 
 A publisher that needs a persistence guarantee does not rely on capture at all.
 Use an exact publish target, whose append is synced before the publisher confirm

--- a/docs/content/docs/messaging/durable-queues.mdx
+++ b/docs/content/docs/messaging/durable-queues.mdx
@@ -231,39 +231,46 @@ Three consequences worth knowing:
 
 ### When capture fails
 
-A capture that cannot be stored never fails the publish. The publisher did not
+Capture does not run on the publish path. Matching queues are resolved on the
+publishing goroutine — an in-memory index lookup — and the storage work is handed
+to a bounded dispatcher. Enqueueing never blocks, so neither the publishing
+client's acknowledgement nor the subscribers of a matching topic wait on a queue's
+storage, however slow it is.
+
+A capture that then fails does not fail the publish either. The publisher did not
 ask for persistence, is told nothing about it, and the append carries no
-durability barrier, so failing the publish would deny every subscriber the
-message without buying any guarantee — one queue's storage error would silence
-pub/sub across every topic its pattern covers. The broker logs the failure and
-keeps delivering.
+durability barrier, so failing the publish would deny every subscriber the message
+without buying any guarantee. Each matching queue is a separate job, so one
+failing queue neither stops the others nor hides them.
 
-That makes the failure invisible to the publisher by design, so watch it from
-the operator plane instead. `GET /api/v1/stats` reports `queues.capture_failures`,
-which counts every publish that did not reach all of its matching queues —
-whether the append failed, a matched queue's configuration could not be read, or
-the matching queues could not be resolved at all. It is counted once per publish
-however many queues were affected, so it measures how often capture is lossy
-rather than how many records were lost. A non-zero and rising value means a queue
-is dropping the traffic its pattern binds.
+Both properties make loss invisible to the publisher by design, so watch it from
+the operator plane. `GET /api/v1/stats` reports two counters under `queues`:
 
-A publish matching several queues is attempted against each of them
-independently, so one failing queue neither stops the others nor hides them.
+| Counter | Meaning |
+| --- | --- |
+| `capture_failures` | The append was attempted and did not succeed, or the queue's configuration could not be read. Counted per queue, so a publish missing two of its matching queues counts twice. |
+| `capture_dropped` | The append was never attempted, because the backlog was full or shutdown drained past its deadline. |
 
-A publisher that needs a persistence guarantee does not rely on capture. Use an
-exact publish target, whose append is synced before the publisher confirm and
-does fail the publish — see
+They answer different questions. A rising `capture_dropped` means capture cannot
+keep up with the publish rate, or a queue's store has stalled long enough to fill
+its backlog. A rising `capture_failures` means the store is reachable but
+rejecting writes.
+
+When a backlog fills, the **newest** job is dropped. A saturated queue therefore
+holds a contiguous prefix of the stream: a consumer knows it has everything up to
+the moment capture saturated, rather than a log with a hole in the middle.
+
+Ordering is preserved per queue. A queue is always handled by the same dispatcher
+lane, so its appends land in publish order even though the work is asynchronous.
+
+On shutdown the dispatcher drains what it has queued, bounded by a timeout so a
+stalled store cannot hold shutdown open. Anything still queued when that expires
+is counted in `capture_dropped` like any other loss.
+
+A publisher that needs a persistence guarantee does not rely on capture at all.
+Use an exact publish target, whose append is synced before the publisher confirm
+and does fail the publish — see
 [Local principals and capture](/configuration/security#local-principals-and-capture).
-
-<Callout type="warn">
-  A failing queue is isolated; a *slow* one is not. Capture runs on the publish
-  path before subscribers are delivered to, and the append honours no
-  cancellation, so a queue whose storage stalls delays every subscriber of a
-  matching topic — and the publishing client's acknowledgement — for as long as
-  the append takes. Keep queues bound to high-rate ordinary topics on storage
-  that cannot block, and watch `queues.capture_failures` alongside publish
-  latency rather than on its own.
-</Callout>
 
 ### Delivery address of a captured message
 

--- a/docs/content/docs/messaging/durable-queues.mdx
+++ b/docs/content/docs/messaging/durable-queues.mdx
@@ -217,6 +217,11 @@ normal subscribers **and** has the message persisted in `messages`. Capture is i
 addition to pub/sub delivery, never instead of it: the publisher does not opt in,
 does not address the queue, and cannot tell that it happened.
 
+It also does not wait for it. The persistence happens shortly after the publish
+rather than as part of it, so a message is delivered to subscribers and
+acknowledged before it is necessarily in the queue — see
+[When capture fails](#when-capture-fails).
+
 Three consequences worth knowing:
 
 - **The queue's `topics` pattern is what grants persistence.** No publisher-side

--- a/docs/content/docs/messaging/durable-queues.mdx
+++ b/docs/content/docs/messaging/durable-queues.mdx
@@ -279,12 +279,30 @@ On shutdown the dispatcher drains what it has queued, bounded by
 `capture_dropped` like any other loss.
 
 An append already in progress cannot be interrupted — the queue store takes no
-context — so a worker may still be inside one when that budget expires. The
-broker then reports an unclean shutdown and **deliberately leaves the queue store
-open**, because closing it underneath an in-flight append would corrupt a segment
-that worker still holds. The handle is leaked into process exit instead, which is
-the cheaper failure. A log line names the cause when this happens. Raise
-`capture_drain_timeout` if a slow store makes it routine.
+context — so a worker may still be inside one when that budget expires. The broker
+then reports an unclean shutdown and **deliberately releases nothing that worker
+could still be using**, because closing a store underneath an in-flight append
+corrupts a segment it holds. Three things are left as they are:
+
+| Left open | Why it is reachable from a stuck capture |
+| --- | --- |
+| Cluster | A capture job forwards to nodes holding queues this one does not know, so a worker may still be using the transport. |
+| Queue log store | The append itself. |
+| Broker store | The cluster holds it, so it is reachable through the forward above. |
+
+They are leaked into process exit instead, which is the cheaper failure. A log
+line names the cause.
+
+<Callout type="warn">
+  On the `badger` storage backend this means the **broker** store is not closed
+  cleanly either, so session and retained writes are not flushed and the next
+  start replays the value log to recover them. A queue whose storage stalls
+  therefore costs more than that queue: raise `capture_drain_timeout` if a slow
+  store makes unclean shutdown routine, rather than treating it as harmless.
+</Callout>
+
+When shutdown is clean, the three are released in that same order — cluster
+first, so no request arrives for a store that is closing.
 
 The one job a worker is still writing is not counted in `capture_dropped`: its
 outcome is genuinely unknown, since the append may yet succeed, and the worker

--- a/docs/content/docs/messaging/durable-queues.mdx
+++ b/docs/content/docs/messaging/durable-queues.mdx
@@ -275,10 +275,20 @@ being dropped. Raise `queue_manager.capture_workers` where many queues bind
 ordinary topics and one of them may block.
 
 On shutdown the dispatcher drains what it has queued, bounded by
-`queue_manager.capture_drain_timeout`. An append already in progress cannot be
-interrupted — the queue store takes no context — so a worker still inside one when
-the budget expires is left to finish while shutdown proceeds. Anything not
-written is counted in `capture_dropped` like any other loss.
+`queue_manager.capture_drain_timeout`. Anything it could not write is counted in
+`capture_dropped` like any other loss.
+
+An append already in progress cannot be interrupted — the queue store takes no
+context — so a worker may still be inside one when that budget expires. The
+broker then reports an unclean shutdown and **deliberately leaves the queue store
+open**, because closing it underneath an in-flight append would corrupt a segment
+that worker still holds. The handle is leaked into process exit instead, which is
+the cheaper failure. A log line names the cause when this happens. Raise
+`capture_drain_timeout` if a slow store makes it routine.
+
+The one job a worker is still writing is not counted in `capture_dropped`: its
+outcome is genuinely unknown, since the append may yet succeed, and the worker
+accounts for it either way once the store returns.
 
 A publisher that needs a persistence guarantee does not rely on capture at all.
 Use an exact publish target, whose append is synced before the publisher confirm

--- a/docs/content/docs/reference/configuration-reference.md
+++ b/docs/content/docs/reference/configuration-reference.md
@@ -248,7 +248,7 @@ queue_manager:
 | Field                   | Default | Description                                                                 |
 | ----------------------- | ------- | --------------------------------------------------------------------------- |
 | `auto_commit_interval`  | `5s`    | Stream-group auto-commit cadence. `0` means commit on every delivery batch. |
-| `capture_workers`       | `4`     | Lanes writing captured publishes off the publish path. A queue is always handled by the same lane, so its appends keep publish order and a stalled queue holds up only its own lane. `0` selects the default. |
+| `capture_workers`       | `4`     | Lanes writing captured publishes off the publish path. A queue is always handled by the same lane, so its appends keep publish order. Lanes are shared: queues are hashed onto them, so a stalled queue also stalls the unrelated queues sharing its lane until its backlog fills. Raise this where many queues bind ordinary topics and one may block. `0` selects the default. |
 | `capture_queue_depth`   | `1024`  | Per-lane backlog, counted in **jobs, not bytes**. The memory ceiling is `capture_workers × capture_queue_depth` payloads, so lower it when capturing large messages. When a lane fills, the newest job is dropped and counted in `queues.capture_dropped`. `0` selects the default. |
 | `capture_drain_timeout` | `5s`    | How long shutdown waits for queued captures to be written. Anything still queued is counted in `queues.capture_dropped` rather than delaying shutdown. `0` selects the default. |
 

--- a/docs/content/docs/reference/configuration-reference.md
+++ b/docs/content/docs/reference/configuration-reference.md
@@ -250,7 +250,7 @@ queue_manager:
 | `auto_commit_interval`  | `5s`    | Stream-group auto-commit cadence. `0` means commit on every delivery batch. |
 | `capture_workers`       | `4`     | Lanes writing captured publishes off the publish path. A queue is always handled by the same lane, so its appends keep publish order. Lanes are shared: queues are hashed onto them, so a stalled queue also stalls the unrelated queues sharing its lane until its backlog fills. Raise this where many queues bind ordinary topics and one may block. `0` selects the default. |
 | `capture_queue_depth`   | `1024`  | Per-lane backlog, counted in **jobs, not bytes**. The memory ceiling is `capture_workers × capture_queue_depth` payloads, so lower it when capturing large messages. When a lane fills, the newest job is dropped and counted in `queues.capture_dropped`. `0` selects the default. |
-| `capture_drain_timeout` | `5s`    | How long shutdown waits for queued captures to be written. Anything still queued is counted in `queues.capture_dropped` rather than delaying shutdown. `0` selects the default. |
+| `capture_drain_timeout` | `5s`    | How long shutdown waits for queued captures to be written. Anything still queued is counted in `queues.capture_dropped` rather than delaying shutdown. If a worker is still inside an append when it expires, shutdown is reported unclean and the cluster, queue log store and broker store are all left open, since the worker may still be using them — on `badger` that means the broker store is not flushed and the next start replays. Raise this if that becomes routine. `0` selects the default. |
 
 Capture never blocks the publish path: see [Capturing Ordinary Topics](/messaging/durable-queues#capturing-ordinary-topics).
 

--- a/docs/content/docs/reference/configuration-reference.md
+++ b/docs/content/docs/reference/configuration-reference.md
@@ -240,11 +240,19 @@ session:
 ```yaml
 queue_manager:
   auto_commit_interval: "5s"
+  capture_workers: 4
+  capture_queue_depth: 1024
+  capture_drain_timeout: "5s"
 ```
 
-| Field                  | Default | Description                                                                 |
-| ---------------------- | ------- | --------------------------------------------------------------------------- |
-| `auto_commit_interval` | `5s`    | Stream-group auto-commit cadence. `0` means commit on every delivery batch. |
+| Field                   | Default | Description                                                                 |
+| ----------------------- | ------- | --------------------------------------------------------------------------- |
+| `auto_commit_interval`  | `5s`    | Stream-group auto-commit cadence. `0` means commit on every delivery batch. |
+| `capture_workers`       | `4`     | Lanes writing captured publishes off the publish path. A queue is always handled by the same lane, so its appends keep publish order and a stalled queue holds up only its own lane. `0` selects the default. |
+| `capture_queue_depth`   | `1024`  | Per-lane backlog, counted in **jobs, not bytes**. The memory ceiling is `capture_workers × capture_queue_depth` payloads, so lower it when capturing large messages. When a lane fills, the newest job is dropped and counted in `queues.capture_dropped`. `0` selects the default. |
+| `capture_drain_timeout` | `5s`    | How long shutdown waits for queued captures to be written. Anything still queued is counted in `queues.capture_dropped` rather than delaying shutdown. `0` selects the default. |
+
+Capture never blocks the publish path: see [Capturing Ordinary Topics](/messaging/durable-queues#capturing-ordinary-topics).
 
 ## Queues
 

--- a/queue/capture.go
+++ b/queue/capture.go
@@ -23,7 +23,8 @@ const (
 	// than bytes. It bounds how long a stalled store can absorb publishes before
 	// jobs are dropped, so memory stays flat instead of growing with the stall —
 	// but the ceiling is workers x depth payloads, so a deployment capturing
-	// large messages should lower it rather than assume the default is small.
+	// large messages should lower queue_manager.capture_queue_depth rather than
+	// assume the default is small.
 	defaultCaptureQueueDepth = 1024
 	// defaultCaptureDrainTimeout bounds how long Stop waits for queued capture
 	// to be written. Anything still queued after it is counted as dropped

--- a/queue/capture.go
+++ b/queue/capture.go
@@ -8,6 +8,7 @@ import (
 	"hash/fnv"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/absmach/fluxmq/queue/types"
@@ -18,6 +19,13 @@ const (
 	// is always handled by the same lane, so per-queue append order matches
 	// publish order, and a queue whose store stalls blocks only the lane it
 	// hashes to rather than every capture on the node.
+	//
+	// Lanes are shared, not per queue: queues are hashed onto a fixed number of
+	// them so the goroutine count does not follow the queue count. The cost is
+	// that a stalled queue also stalls the unrelated queues sharing its lane,
+	// until its backlog fills and their jobs are dropped. More lanes make that
+	// collision less likely without eliminating it; only a lane per queue would,
+	// at a goroutine per queue.
 	defaultCaptureWorkers = 4
 	// defaultCaptureQueueDepth is the per-lane backlog, counted in jobs rather
 	// than bytes. It bounds how long a stalled store can absorb publishes before
@@ -63,10 +71,28 @@ type captureDispatcher struct {
 	logger       *slog.Logger
 	drainTimeout time.Duration
 
+	// closedMu makes accepting a job and shutting down mutually exclusive. A
+	// send that merely happened to run after stopCh closed would sit in a lane
+	// no worker reads again: accepted by the caller, never written, and never
+	// counted. Stop takes the write lock, so once it has it no enqueue is in
+	// flight and none can start.
+	closedMu sync.RWMutex
+	closed   bool
+
+	// lastWarn throttles the drop log. Dropping happens on the publishing
+	// goroutine and a saturated backlog reaches it on every publish, so logging
+	// each one would put the I/O this type exists to remove back on the publish
+	// path.
+	lastWarn atomic.Int64
+
 	stopCh   chan struct{}
 	stopOnce sync.Once
 	wg       sync.WaitGroup
 }
+
+// dropWarnInterval bounds how often a drop is logged. The counter is exact; the
+// log is only a sample of it.
+const dropWarnInterval = 10 * time.Second
 
 // captureMetrics is the subset of counters the dispatcher owns.
 type captureMetrics interface {
@@ -132,11 +158,15 @@ func (d *captureDispatcher) laneFor(job captureJob) chan captureJob {
 // holds a contiguous prefix of the stream: a consumer knows it has everything up
 // to the moment capture saturated, instead of a log with a hole in it.
 func (d *captureDispatcher) enqueue(job captureJob) bool {
-	select {
-	case <-d.stopCh:
+	// Held across the send, so a job cannot land in a lane that shutdown has
+	// already stopped reading. It is a read lock: publishes never contend with
+	// each other, only with Stop.
+	d.closedMu.RLock()
+	defer d.closedMu.RUnlock()
+
+	if d.closed {
 		d.drop(job, "dispatcher stopped")
 		return false
-	default:
 	}
 
 	select {
@@ -148,20 +178,34 @@ func (d *captureDispatcher) enqueue(job captureJob) bool {
 	}
 }
 
+// drop counts a lost job and, at most once per dropWarnInterval, logs one.
+//
+// Counting is unconditional because queues.capture_dropped is the contract.
+// Logging is throttled because drop runs on the publishing goroutine, and a
+// saturated backlog would otherwise write a log line per publish — the very
+// thing dispatching capture exists to keep off that path.
 func (d *captureDispatcher) drop(job captureJob, reason string) {
 	if d.metrics != nil {
 		d.metrics.RecordCaptureDropped()
 	}
-	if d.logger != nil {
-		queueName := ""
-		if job.target != nil {
-			queueName = job.target.name
-		}
-		d.logger.Warn("capture job dropped",
-			slog.String("reason", reason),
-			slog.String("queue", queueName),
-			slog.String("topic", job.publish.Topic))
+	if d.logger == nil || !d.shouldWarn() {
+		return
 	}
+
+	queueName := ""
+	if job.target != nil {
+		queueName = job.target.name
+	}
+	d.logger.Warn("capture job dropped",
+		slog.String("reason", reason),
+		slog.String("queue", queueName),
+		slog.String("topic", job.publish.Topic))
+}
+
+func (d *captureDispatcher) shouldWarn() bool {
+	now := time.Now().UnixNano()
+	last := d.lastWarn.Load()
+	return now-last >= int64(dropWarnInterval) && d.lastWarn.CompareAndSwap(last, now)
 }
 
 func (d *captureDispatcher) run(ctx context.Context, lane chan captureJob) {
@@ -197,8 +241,57 @@ func (d *captureDispatcher) drain(ctx context.Context, lane chan captureJob) {
 	}
 }
 
-// Stop signals the workers, waits for them to finish draining, and returns.
+// Stop refuses further jobs, drains what is queued, and returns within
+// drainTimeout whether or not the workers finished.
+//
+// A worker already inside an append cannot be interrupted: the store takes no
+// context and the write is not cancellable. Waiting on it would let one stalled
+// queue hold shutdown open indefinitely — the same failure dispatching capture
+// exists to prevent, moved to a different moment — so the wait is bounded and a
+// worker still wedged when the budget expires is left to finish on its own.
 func (d *captureDispatcher) Stop() {
+	// Close acceptance first, and under the write lock, so no enqueue is in
+	// flight when the lanes stop being read.
+	d.closedMu.Lock()
+	d.closed = true
+	d.closedMu.Unlock()
+
 	d.stopOnce.Do(func() { close(d.stopCh) })
-	d.wg.Wait()
+
+	drained := make(chan struct{})
+	go func() {
+		d.wg.Wait()
+		close(drained)
+	}()
+
+	timer := time.NewTimer(d.drainTimeout)
+	defer timer.Stop()
+	select {
+	case <-drained:
+	case <-timer.C:
+		if d.logger != nil {
+			d.logger.Warn("capture drain timed out; a queue store is still blocking a worker",
+				slog.Duration("timeout", d.drainTimeout))
+		}
+	}
+
+	// Count whatever the workers did not reach, so a job lost to shutdown is
+	// visible in the same counter as any other. Acceptance is already closed, so
+	// no lane can grow while this runs; a worker racing for the same job only
+	// means one of the two accounts for it.
+	for _, lane := range d.lanes {
+		d.sweep(lane)
+	}
+}
+
+// sweep counts every job left in a lane.
+func (d *captureDispatcher) sweep(lane chan captureJob) {
+	for {
+		select {
+		case job := <-lane:
+			d.drop(job, "shutdown left the job unwritten")
+		default:
+			return
+		}
+	}
 }

--- a/queue/capture.go
+++ b/queue/capture.go
@@ -1,0 +1,203 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package queue
+
+import (
+	"context"
+	"hash/fnv"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/absmach/fluxmq/queue/types"
+)
+
+const (
+	// defaultCaptureWorkers is the number of independent capture lanes. A queue
+	// is always handled by the same lane, so per-queue append order matches
+	// publish order, and a queue whose store stalls blocks only the lane it
+	// hashes to rather than every capture on the node.
+	defaultCaptureWorkers = 4
+	// defaultCaptureQueueDepth is the per-lane backlog, counted in jobs rather
+	// than bytes. It bounds how long a stalled store can absorb publishes before
+	// jobs are dropped, so memory stays flat instead of growing with the stall —
+	// but the ceiling is workers x depth payloads, so a deployment capturing
+	// large messages should lower it rather than assume the default is small.
+	defaultCaptureQueueDepth = 1024
+	// defaultCaptureDrainTimeout bounds how long Stop waits for queued capture
+	// to be written. Anything still queued after it is counted as dropped
+	// rather than delaying shutdown indefinitely.
+	defaultCaptureDrainTimeout = 5 * time.Second
+)
+
+// captureJob is one captured publish bound for one queue, or — when target is
+// nil — the per-publish cluster forward for queues this node does not know.
+//
+// Jobs are per target rather than per publish so that a lane can be chosen by
+// queue name. The publish they share is already detached from the protocol
+// broker's buffers by the time it is enqueued, and the workers only read it.
+type captureJob struct {
+	publish types.PublishRequest
+	target  *queuePublishTarget
+}
+
+// captureDispatcher moves the storage half of topic capture off the publish
+// path.
+//
+// Capture is broker policy applied to whichever queues match a topic; the
+// publisher neither asked for it nor learns of it. Running it inline made a
+// queue whose store stalls delay every subscriber of a matching topic, because
+// the append honours no cancellation. The dispatcher keeps the publish path
+// free of that: enqueueing never blocks, and a full lane drops the job and
+// counts it rather than waiting for room.
+//
+// Lanes are never closed. Producers may race Stop, and sending on a closed
+// channel panics, so shutdown is signalled with stopCh and the buffered jobs are
+// drained by the workers instead.
+type captureDispatcher struct {
+	lanes        []chan captureJob
+	apply        func(context.Context, captureJob)
+	metrics      captureMetrics
+	logger       *slog.Logger
+	drainTimeout time.Duration
+
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	wg       sync.WaitGroup
+}
+
+// captureMetrics is the subset of counters the dispatcher owns.
+type captureMetrics interface {
+	RecordCaptureDropped()
+}
+
+func newCaptureDispatcher(
+	workers, depth int,
+	drainTimeout time.Duration,
+	metrics captureMetrics,
+	logger *slog.Logger,
+	apply func(context.Context, captureJob),
+) *captureDispatcher {
+	if workers <= 0 {
+		workers = defaultCaptureWorkers
+	}
+	if depth <= 0 {
+		depth = defaultCaptureQueueDepth
+	}
+	if drainTimeout <= 0 {
+		drainTimeout = defaultCaptureDrainTimeout
+	}
+
+	d := &captureDispatcher{
+		lanes:        make([]chan captureJob, workers),
+		apply:        apply,
+		metrics:      metrics,
+		logger:       logger,
+		drainTimeout: drainTimeout,
+		stopCh:       make(chan struct{}),
+	}
+	for i := range d.lanes {
+		d.lanes[i] = make(chan captureJob, depth)
+	}
+	return d
+}
+
+// Start launches one worker per lane.
+func (d *captureDispatcher) Start(ctx context.Context) {
+	for i := range d.lanes {
+		d.wg.Add(1)
+		go d.run(ctx, d.lanes[i])
+	}
+}
+
+// laneFor picks the lane a queue is always handled by. Jobs with no target are
+// the per-publish cluster forward, which has no queue to order against and so
+// rides the first lane.
+func (d *captureDispatcher) laneFor(job captureJob) chan captureJob {
+	if job.target == nil {
+		return d.lanes[0]
+	}
+	hash := fnv.New32a()
+	// Hash writes never fail.
+	_, _ = hash.Write([]byte(job.target.name))
+	return d.lanes[int(hash.Sum32())%len(d.lanes)]
+}
+
+// enqueue submits a job without ever blocking the caller. It reports whether the
+// job was accepted; a rejected job has already been counted as dropped.
+//
+// The newest job is dropped rather than the oldest so that a saturated queue
+// holds a contiguous prefix of the stream: a consumer knows it has everything up
+// to the moment capture saturated, instead of a log with a hole in it.
+func (d *captureDispatcher) enqueue(job captureJob) bool {
+	select {
+	case <-d.stopCh:
+		d.drop(job, "dispatcher stopped")
+		return false
+	default:
+	}
+
+	select {
+	case d.laneFor(job) <- job:
+		return true
+	default:
+		d.drop(job, "capture backlog full")
+		return false
+	}
+}
+
+func (d *captureDispatcher) drop(job captureJob, reason string) {
+	if d.metrics != nil {
+		d.metrics.RecordCaptureDropped()
+	}
+	if d.logger != nil {
+		queueName := ""
+		if job.target != nil {
+			queueName = job.target.name
+		}
+		d.logger.Warn("capture job dropped",
+			slog.String("reason", reason),
+			slog.String("queue", queueName),
+			slog.String("topic", job.publish.Topic))
+	}
+}
+
+func (d *captureDispatcher) run(ctx context.Context, lane chan captureJob) {
+	defer d.wg.Done()
+
+	for {
+		select {
+		case job := <-lane:
+			d.apply(ctx, job)
+		case <-d.stopCh:
+			d.drain(ctx, lane)
+			return
+		}
+	}
+}
+
+// drain writes what is already queued, bounded by drainTimeout so a stalled
+// store cannot hold shutdown open. Whatever is left is counted as dropped, so
+// the loss appears in the same counter as any other.
+func (d *captureDispatcher) drain(ctx context.Context, lane chan captureJob) {
+	deadline := time.Now().Add(d.drainTimeout)
+	for {
+		select {
+		case job := <-lane:
+			if time.Now().After(deadline) {
+				d.drop(job, "shutdown drain timed out")
+				continue
+			}
+			d.apply(ctx, job)
+		default:
+			return
+		}
+	}
+}
+
+// Stop signals the workers, waits for them to finish draining, and returns.
+func (d *captureDispatcher) Stop() {
+	d.stopOnce.Do(func() { close(d.stopCh) })
+	d.wg.Wait()
+}

--- a/queue/capture.go
+++ b/queue/capture.go
@@ -242,14 +242,20 @@ func (d *captureDispatcher) drain(ctx context.Context, lane chan captureJob) {
 }
 
 // Stop refuses further jobs, drains what is queued, and returns within
-// drainTimeout whether or not the workers finished.
+// drainTimeout whether or not the workers finished. It reports whether they did.
 //
 // A worker already inside an append cannot be interrupted: the store takes no
 // context and the write is not cancellable. Waiting on it would let one stalled
 // queue hold shutdown open indefinitely — the same failure dispatching capture
-// exists to prevent, moved to a different moment — so the wait is bounded and a
-// worker still wedged when the budget expires is left to finish on its own.
-func (d *captureDispatcher) Stop() {
+// exists to prevent, moved to a different moment — so the wait is bounded.
+//
+// A false return means a worker is still inside the queue store. It is then not
+// safe to tear down anything that worker touches: the store guards writes that
+// *start* after it closes, but an append already in flight holds a segment
+// obtained beforehand, and closing underneath it is a use-after-close. The
+// caller must leave those resources alone rather than free them; leaking a
+// handle into process exit is cheaper than writing into a closing segment.
+func (d *captureDispatcher) Stop() bool {
 	// Close acceptance first, and under the write lock, so no enqueue is in
 	// flight when the lanes stop being read.
 	d.closedMu.Lock()
@@ -264,13 +270,15 @@ func (d *captureDispatcher) Stop() {
 		close(drained)
 	}()
 
+	quiesced := true
 	timer := time.NewTimer(d.drainTimeout)
 	defer timer.Stop()
 	select {
 	case <-drained:
 	case <-timer.C:
+		quiesced = false
 		if d.logger != nil {
-			d.logger.Warn("capture drain timed out; a queue store is still blocking a worker",
+			d.logger.Warn("capture drain timed out; a queue store is still blocking a worker, so its resources must not be released",
 				slog.Duration("timeout", d.drainTimeout))
 		}
 	}
@@ -279,9 +287,16 @@ func (d *captureDispatcher) Stop() {
 	// visible in the same counter as any other. Acceptance is already closed, so
 	// no lane can grow while this runs; a worker racing for the same job only
 	// means one of the two accounts for it.
+	//
+	// A job a worker is still inside is deliberately not counted here. Its
+	// outcome is genuinely unknown — the append may yet succeed — and the worker
+	// accounts for it either way when the store returns. Counting it as dropped
+	// would be a guess, and the wrong one whenever the write lands.
 	for _, lane := range d.lanes {
 		d.sweep(lane)
 	}
+
+	return quiesced
 }
 
 // sweep counts every job left in a lane.

--- a/queue/capture_test.go
+++ b/queue/capture_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -187,5 +188,144 @@ func TestCapturePreservesPerQueueOrder(t *testing.T) {
 		if got := msg.GetPayload()[0]; got != byte(i%256) {
 			t.Fatalf("offset %d holds payload %d, want %d; capture reordered a queue", i, got, i%256)
 		}
+	}
+}
+
+// countingQueueStore records how many appends actually reached storage.
+type countingQueueStore struct {
+	storage.QueueStore
+	appended atomic.Int64
+}
+
+func (s *countingQueueStore) Append(ctx context.Context, queueName string, msg *types.Message) (uint64, error) {
+	s.appended.Add(1)
+	return s.QueueStore.Append(ctx, queueName, msg)
+}
+
+// Every capture is either written or counted as dropped. A job accepted by a
+// send that raced shutdown would be neither: it would sit in a lane no worker
+// reads again, lost with nothing to show for it.
+func TestCaptureAccountsForEveryJobAcrossShutdown(t *testing.T) {
+	const publishers = 8
+	const perPublisher = 250
+
+	counting := &countingQueueStore{QueueStore: memlog.New()}
+	mgr := NewManager(counting, newMockGroupStore(), nil, DefaultConfig(), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	ctx := context.Background()
+
+	if err := mgr.CreateQueue(ctx, types.DefaultQueueConfig(testCaptureQueue, "m/#")); err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+	mgr.capture.Start(ctx)
+
+	// Publish hard from several goroutines while shutdown runs underneath them,
+	// so sends land on both sides of the moment acceptance closes.
+	var wg sync.WaitGroup
+	for range publishers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range perPublisher {
+				if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
+					Topic:   testCapturedTopic,
+					Payload: []byte("payload"),
+				}); err != nil {
+					t.Errorf("PublishToMatchingQueues failed: %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	mgr.capture.Stop()
+	wg.Wait()
+	// Publishes that finished after Stop are refused and counted; sweep anything
+	// their sends left behind.
+	mgr.capture.Stop()
+
+	written := counting.appended.Load()
+	dropped := int64(mgr.GetMetrics().CaptureDropped)
+	if total := written + dropped; total != publishers*perPublisher {
+		t.Fatalf("wrote %d and dropped %d, accounting for %d of %d publishes; %d went missing",
+			written, dropped, total, publishers*perPublisher, publishers*perPublisher-total)
+	}
+}
+
+// The window between checking for shutdown and sending is a few instructions
+// wide, so the concurrent test above rarely lands in it. This states the
+// guarantee that closes it directly: once Stop has returned, no job is ever
+// accepted, so none can be stranded in a lane nothing reads.
+func TestCaptureRefusesAndCountsJobsAfterStop(t *testing.T) {
+	counting := &countingQueueStore{QueueStore: memlog.New()}
+	mgr := NewManager(counting, newMockGroupStore(), nil, DefaultConfig(), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	ctx := context.Background()
+
+	if err := mgr.CreateQueue(ctx, types.DefaultQueueConfig(testCaptureQueue, "m/#")); err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+	mgr.capture.Start(ctx)
+	mgr.capture.Stop()
+
+	const after = 5
+	for range after {
+		if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
+			Topic:   testCapturedTopic,
+			Payload: []byte("payload"),
+		}); err != nil {
+			t.Fatalf("PublishToMatchingQueues failed: %v", err)
+		}
+	}
+
+	if got := mgr.GetMetrics().CaptureDropped; got != after {
+		t.Fatalf("capture dropped = %d, want %d; a job after shutdown was accepted rather than counted", got, after)
+	}
+	if got := counting.appended.Load(); got != 0 {
+		t.Fatalf("%d appends ran after shutdown", got)
+	}
+}
+
+// Shutdown must not wait on an append that cannot be interrupted. The store
+// takes no context, so a wedged worker would otherwise hold the broker open for
+// as long as the storage stall lasts.
+func TestCaptureStopIsBoundedByDrainTimeout(t *testing.T) {
+	blocking := &blockingQueueStore{
+		QueueStore: memlog.New(),
+		release:    make(chan struct{}),
+		entered:    make(chan struct{}),
+	}
+	config := DefaultConfig()
+	config.CaptureWorkers = 1
+	config.CaptureDrainTimeout = 200 * time.Millisecond
+	mgr := NewManager(blocking, newMockGroupStore(), nil, config, slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	ctx := context.Background()
+
+	if err := mgr.CreateQueue(ctx, types.DefaultQueueConfig(testCaptureQueue, "m/#")); err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+	mgr.capture.Start(ctx)
+	t.Cleanup(func() { close(blocking.release) })
+
+	if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
+		Topic:   testCapturedTopic,
+		Payload: []byte("payload"),
+	}); err != nil {
+		t.Fatalf("PublishToMatchingQueues failed: %v", err)
+	}
+	select {
+	case <-blocking.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("capture worker never reached the store")
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		mgr.capture.Stop()
+		close(stopped)
+	}()
+
+	select {
+	case <-stopped:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Stop waited on an uninterruptible append instead of its drain timeout")
 	}
 }

--- a/queue/capture_test.go
+++ b/queue/capture_test.go
@@ -5,6 +5,7 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"sync"
@@ -327,5 +328,73 @@ func TestCaptureStopIsBoundedByDrainTimeout(t *testing.T) {
 	case <-stopped:
 	case <-time.After(5 * time.Second):
 		t.Fatal("Stop waited on an uninterruptible append instead of its drain timeout")
+	}
+}
+
+// Stop bounds its wait, so a worker can outlive it. When that happens the
+// manager must say so, because everything the worker is still using — the queue
+// store above all — has to be left open rather than closed underneath it.
+//
+// TestCaptureStopIsBoundedByDrainTimeout releases the store during cleanup, so
+// it proves the bound but never reaches this question.
+func TestManagerStopReportsCaptureStillUsingTheStore(t *testing.T) {
+	blocking := &blockingQueueStore{
+		QueueStore: memlog.New(),
+		release:    make(chan struct{}),
+		entered:    make(chan struct{}),
+	}
+	config := DefaultConfig()
+	config.CaptureWorkers = 1
+	config.CaptureDrainTimeout = 200 * time.Millisecond
+	mgr := NewManager(blocking, newMockGroupStore(), nil, config, slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := mgr.CreateQueue(ctx, types.DefaultQueueConfig(testCaptureQueue, "m/#")); err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+	if err := mgr.Start(ctx); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	// Released only after the assertions, so the worker is genuinely still
+	// inside the store while Stop is examined.
+	t.Cleanup(func() { close(blocking.release) })
+
+	if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
+		Topic:   testCapturedTopic,
+		Payload: []byte("payload"),
+	}); err != nil {
+		t.Fatalf("PublishToMatchingQueues failed: %v", err)
+	}
+	select {
+	case <-blocking.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("capture worker never reached the store")
+	}
+
+	err := mgr.Stop()
+	if !errors.Is(err, ErrCaptureStillRunning) {
+		t.Fatalf("Stop() error = %v, want %v", err, ErrCaptureStillRunning)
+	}
+	if mgr.ShutdownComplete() {
+		t.Fatal("ShutdownComplete reported true while a worker is still inside the store; the caller would close it")
+	}
+}
+
+// The ordinary path must still report a clean stop, or callers would leak the
+// store on every shutdown.
+func TestManagerStopReportsCleanShutdown(t *testing.T) {
+	mgr := NewManager(memlog.New(), newMockGroupStore(), nil, DefaultConfig(), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := mgr.Start(ctx); err != nil {
+		t.Fatalf("Start failed: %v", err)
+	}
+	if err := mgr.Stop(); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	if !mgr.ShutdownComplete() {
+		t.Fatal("ShutdownComplete reported false after a clean stop; the caller would leak the store")
 	}
 }

--- a/queue/capture_test.go
+++ b/queue/capture_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package queue
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/absmach/fluxmq/queue/storage"
+	memlog "github.com/absmach/fluxmq/queue/storage/memory/log"
+	"github.com/absmach/fluxmq/queue/types"
+)
+
+// blockingQueueStore holds every append until it is released, standing in for a
+// store whose disk has stalled.
+type blockingQueueStore struct {
+	storage.QueueStore
+	release chan struct{}
+	entered chan struct{}
+	once    sync.Once
+}
+
+func (s *blockingQueueStore) Append(ctx context.Context, queueName string, msg *types.Message) (uint64, error) {
+	s.once.Do(func() { close(s.entered) })
+	<-s.release
+	return s.QueueStore.Append(ctx, queueName, msg)
+}
+
+// The whole point of dispatching capture is that a queue whose store has stalled
+// cannot hold up the publisher or the subscribers of a matching topic. Nothing
+// else in the package proves that: an inline capture would simply never return.
+func TestCaptureDoesNotBlockThePublishPath(t *testing.T) {
+	blocking := &blockingQueueStore{
+		QueueStore: memlog.New(),
+		release:    make(chan struct{}),
+		entered:    make(chan struct{}),
+	}
+	mgr := NewManager(blocking, newMockGroupStore(), nil, DefaultConfig(), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	ctx := context.Background()
+
+	if err := mgr.CreateQueue(ctx, types.DefaultQueueConfig(testCaptureQueue, "m/#")); err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+
+	mgr.capture.Start(ctx)
+	t.Cleanup(func() {
+		close(blocking.release)
+		mgr.capture.Stop()
+	})
+
+	// Publish once and wait for the worker to be stuck inside the store, so the
+	// stall is real rather than assumed by timing.
+	if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
+		Topic:   testCapturedTopic,
+		Payload: []byte("payload"),
+	}); err != nil {
+		t.Fatalf("PublishToMatchingQueues failed: %v", err)
+	}
+	select {
+	case <-blocking.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("capture worker never reached the store")
+	}
+
+	// With one worker wedged, further publishes must still return promptly.
+	// They are only queued, so this measures the publish path and nothing else.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range 100 {
+			if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
+				Topic:   testCapturedTopic,
+				Payload: []byte("payload"),
+			}); err != nil {
+				t.Errorf("PublishToMatchingQueues failed: %v", err)
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a stalled queue store blocked the publish path")
+	}
+}
+
+// A backlog that cannot drain must bound its memory by dropping, and every drop
+// has to be visible: it is a lost message that no error reports.
+func TestCaptureDropsAndCountsWhenBacklogIsFull(t *testing.T) {
+	const depth = 4
+
+	blocking := &blockingQueueStore{
+		QueueStore: memlog.New(),
+		release:    make(chan struct{}),
+		entered:    make(chan struct{}),
+	}
+	config := DefaultConfig()
+	// One lane so the wedged worker is the only one, and a shallow backlog so
+	// saturation is reached deterministically.
+	config.CaptureWorkers = 1
+	config.CaptureQueueDepth = depth
+	mgr := NewManager(blocking, newMockGroupStore(), nil, config, slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	ctx := context.Background()
+
+	if err := mgr.CreateQueue(ctx, types.DefaultQueueConfig(testCaptureQueue, "m/#")); err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+
+	mgr.capture.Start(ctx)
+	t.Cleanup(func() {
+		close(blocking.release)
+		mgr.capture.Stop()
+	})
+
+	publish := func() {
+		if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
+			Topic:   testCapturedTopic,
+			Payload: []byte("payload"),
+		}); err != nil {
+			t.Fatalf("PublishToMatchingQueues failed: %v", err)
+		}
+	}
+
+	publish()
+	select {
+	case <-blocking.entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("capture worker never reached the store")
+	}
+
+	// The worker holds one job; the lane buffers depth more. Everything past
+	// that has nowhere to go.
+	const overflow = 10
+	for range depth + overflow {
+		publish()
+	}
+
+	if got := mgr.GetMetrics().CaptureDropped; got != overflow {
+		t.Fatalf("capture dropped = %d, want %d", got, overflow)
+	}
+	if got := mgr.GetMetrics().CaptureFailures; got != 0 {
+		t.Fatalf("capture failures = %d, want 0; a drop is not an append failure", got)
+	}
+}
+
+// A queue is always handled by the same lane, so its appends keep publish order.
+func TestCapturePreservesPerQueueOrder(t *testing.T) {
+	const messages = 200
+
+	logStore := memlog.New()
+	mgr := NewManager(logStore, newMockGroupStore(), nil, DefaultConfig(), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	ctx := context.Background()
+
+	if err := mgr.CreateQueue(ctx, types.DefaultQueueConfig(testCaptureQueue, "m/#")); err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+
+	flushCapture(t, mgr, func() {
+		for i := range messages {
+			if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
+				Topic:   testCapturedTopic,
+				Payload: []byte{byte(i % 256)},
+			}); err != nil {
+				t.Fatalf("PublishToMatchingQueues failed: %v", err)
+			}
+		}
+	})
+
+	count, err := logStore.Count(ctx, testCaptureQueue)
+	if err != nil {
+		t.Fatalf("Count failed: %v", err)
+	}
+	if count != messages {
+		t.Fatalf("stored %d messages, want %d", count, messages)
+	}
+	for i := range messages {
+		msg, err := logStore.Read(ctx, testCaptureQueue, uint64(i))
+		if err != nil {
+			t.Fatalf("Read offset %d failed: %v", i, err)
+		}
+		if got := msg.GetPayload()[0]; got != byte(i%256) {
+			t.Fatalf("offset %d holds payload %d, want %d; capture reordered a queue", i, got, i%256)
+		}
+	}
+}

--- a/queue/consumer/metrics.go
+++ b/queue/consumer/metrics.go
@@ -29,7 +29,8 @@ type Metrics struct {
 	DLQCount uint64 // Messages moved to DLQ
 
 	// Capture metrics
-	CaptureFailures uint64 // Pub/sub publishes not stored by every matching queue
+	CaptureFailures uint64 // Matching queues a captured publish failed to reach
+	CaptureDropped  uint64 // Capture jobs discarded without being attempted
 
 	// Latency tracking (in nanoseconds)
 	TotalClaimLatency uint64 // Sum of claim latencies
@@ -89,17 +90,29 @@ func (m *Metrics) RecordDLQ() {
 	atomic.AddUint64(&m.DLQCount, 1)
 }
 
-// RecordCaptureFailure records one pub/sub publish that did not reach every
-// queue whose topic pattern matched it, whether the append failed, a matched
-// queue's configuration could not be read, or the matching queues could not be
-// resolved at all.
+// RecordCaptureFailure records one matching queue a captured publish failed to
+// reach, whether its append failed or its configuration could not be read.
 //
-// The unit is the publish, not the queue: a publish that misses several matching
-// queues counts once, so the counter measures how often capture is lossy rather
-// than how many records were lost. Capture never fails the publish, so this is
-// the only signal that a queue is dropping the traffic bound to it.
+// The unit is the queue, not the publish: a publish matching three queues and
+// failing two counts twice, so the counter measures records lost rather than how
+// often capture was lossy. Capture runs off the publish path and never fails the
+// publish, so this and CaptureDropped are the only signals it has.
+//
+// One case is coarser: when the matching queues cannot be resolved at all, the
+// set of queues that would have matched is unknown, so it counts once.
 func (m *Metrics) RecordCaptureFailure() {
 	atomic.AddUint64(&m.CaptureFailures, 1)
+}
+
+// RecordCaptureDropped records one capture job discarded before it was
+// attempted, because the backlog was full or shutdown drained past its deadline.
+//
+// It is deliberately separate from CaptureFailures: a failure means the append
+// was tried and did not succeed, while a drop means it was never tried. Both
+// lose a message, but only a rising drop count says capture cannot keep up with
+// the publish rate.
+func (m *Metrics) RecordCaptureDropped() {
+	atomic.AddUint64(&m.CaptureDropped, 1)
 }
 
 // UpdatePELSize updates the current PEL size.
@@ -172,6 +185,7 @@ func (m *Metrics) Snapshot() Metrics {
 		RejectCount:       atomic.LoadUint64(&m.RejectCount),
 		DLQCount:          atomic.LoadUint64(&m.DLQCount),
 		CaptureFailures:   atomic.LoadUint64(&m.CaptureFailures),
+		CaptureDropped:    atomic.LoadUint64(&m.CaptureDropped),
 		TotalClaimLatency: atomic.LoadUint64(&m.TotalClaimLatency),
 		TotalStealLatency: atomic.LoadUint64(&m.TotalStealLatency),
 		TotalAckLatency:   atomic.LoadUint64(&m.TotalAckLatency),
@@ -193,6 +207,7 @@ func (m *Metrics) Reset() {
 	atomic.StoreUint64(&m.RejectCount, 0)
 	atomic.StoreUint64(&m.DLQCount, 0)
 	atomic.StoreUint64(&m.CaptureFailures, 0)
+	atomic.StoreUint64(&m.CaptureDropped, 0)
 	atomic.StoreUint64(&m.TotalClaimLatency, 0)
 	atomic.StoreUint64(&m.TotalStealLatency, 0)
 	atomic.StoreUint64(&m.TotalAckLatency, 0)

--- a/queue/manager.go
+++ b/queue/manager.go
@@ -113,6 +113,9 @@ type Manager struct {
 
 	delivery *DeliveryEngine
 
+	// capture writes topic captures off the publish path.
+	capture *captureDispatcher
+
 	// Metrics
 	metrics *consumer.Metrics
 }
@@ -145,6 +148,13 @@ type Config struct {
 
 	// Retention configuration
 	RetentionCheckInterval time.Duration
+
+	// Capture dispatcher configuration. Topic capture runs off the publish
+	// path so a stalled queue store cannot delay subscribers; these bound how
+	// much unwritten capture is held and how long shutdown waits for it.
+	CaptureWorkers      int
+	CaptureQueueDepth   int
+	CaptureDrainTimeout time.Duration
 
 	// Replication/distribution configuration
 	WritePolicy      WritePolicy
@@ -183,6 +193,9 @@ func DefaultConfig() Config {
 		RetentionCheckInterval: 5 * time.Minute,
 		WritePolicy:            WritePolicyLocal,
 		DistributionMode:       DistributionForward,
+		CaptureWorkers:         defaultCaptureWorkers,
+		CaptureQueueDepth:      defaultCaptureQueueDepth,
+		CaptureDrainTimeout:    defaultCaptureDrainTimeout,
 	}
 }
 
@@ -277,7 +290,37 @@ func NewManager(queueStore storage.QueueStore, groupStore storage.ConsumerGroupS
 		metrics:                 metrics,
 	}
 
+	mgr.capture = newCaptureDispatcher(
+		config.CaptureWorkers,
+		config.CaptureQueueDepth,
+		config.CaptureDrainTimeout,
+		metrics,
+		logger,
+		mgr.applyCaptureJob,
+	)
+
 	return mgr
+}
+
+// applyCaptureJob performs one dispatched capture off the publish path. A job
+// with no target is the per-publish cluster forward.
+func (m *Manager) applyCaptureJob(ctx context.Context, job captureJob) {
+	if job.target == nil {
+		if m.cluster != nil {
+			m.forwardToRemoteNodes(ctx, job.publish)
+		}
+		return
+	}
+
+	// Capture is best effort: one target failing must not affect the others,
+	// and they are separate jobs precisely so it cannot.
+	if err := m.writeToTargets(ctx, job.publish, []queuePublishTarget{*job.target}, fanoutBestEffort); err != nil {
+		m.metrics.RecordCaptureFailure()
+		m.logger.Warn("capture append failed",
+			slog.String("queue", job.target.name),
+			slog.String("topic", job.publish.Topic),
+			slog.String("error", err.Error()))
+	}
 }
 
 // Start starts background workers.
@@ -308,6 +351,11 @@ func (m *Manager) Start(ctx context.Context) error {
 
 	// Start delivery engine
 	m.delivery.Start(ctx)
+
+	// Start capture workers. Uses a context detached from the caller's so a
+	// cancelled start context cannot silently stop capture in a running broker;
+	// Stop is what ends them.
+	m.capture.Start(context.WithoutCancel(ctx))
 
 	// Start work stealing if enabled
 	if m.config.StealEnabled {
@@ -382,6 +430,11 @@ func (m *Manager) ensureReservedQueues(ctx context.Context) error {
 // Stop stops the manager and all workers.
 func (m *Manager) Stop() error {
 	m.delivery.Stop()
+
+	// Drain queued capture before the stores go away. The dispatcher bounds its
+	// own wait and counts whatever it could not write, so a stalled store
+	// delays shutdown by at most that bound instead of indefinitely.
+	m.capture.Stop()
 
 	m.stopOnce.Do(func() {
 		close(m.stopCh)
@@ -830,27 +883,37 @@ func (m *Manager) Publish(ctx context.Context, publish types.PublishRequest) err
 // PublishToMatchingQueues captures an ordinary pub/sub publish in existing
 // queues whose configured topic patterns match it. Unlike Publish, it never
 // auto-creates a queue when no pattern matches.
+//
+// It resolves the matching queues on the caller's goroutine — that is an
+// in-memory index lookup — and then hands the storage work to the capture
+// dispatcher. Enqueueing never blocks, so a queue whose store stalls can no
+// longer delay the subscribers of a matching topic or the publisher's
+// acknowledgement.
+//
+// The returned error therefore reports only what is known before the append is
+// attempted: that the matching queues could not be resolved. An append that
+// fails or is dropped afterwards is reported through queues.capture_failures
+// and queues.capture_dropped, which is the only signal capture has.
 func (m *Manager) PublishToMatchingQueues(ctx context.Context, publish types.PublishRequest) error {
-	// Every way this can lose a message counts, not only a failed append:
-	// failing to resolve targets, or dropping one whose configuration cannot be
-	// read, loses exactly as much as an append error does.
-	//
-	// The counter is per publish, not per queue, so the increment is decided
-	// once at the end however many targets were affected.
+	// A target dropped during resolution loses a message as surely as a failed
+	// append, and each lost queue counts. A resolution error is the one coarse
+	// case: the set of queues that would have matched is unknown, so it counts
+	// once.
 	targets, unresolved, err := m.resolveMatchingPublishTargets(ctx, publish.Topic)
 	if err != nil {
 		m.metrics.RecordCaptureFailure()
 		return err
 	}
+	for range unresolved {
+		m.metrics.RecordCaptureFailure()
+	}
 	if len(targets) == 0 {
-		if unresolved > 0 {
-			m.metrics.RecordCaptureFailure()
-		}
 		return nil
 	}
 
-	// Protocol brokers release or reuse their message buffers after this call.
-	// Take ownership of independent data before appending or forwarding it.
+	// Protocol brokers release or reuse their message buffers after this call,
+	// and the dispatcher reads the publish long after it returns, so ownership
+	// has to be taken before it is queued.
 	//
 	// The map is cloned whenever it exists rather than only when it holds
 	// entries: an empty non-nil map is still the caller's, and
@@ -860,13 +923,16 @@ func (m *Manager) PublishToMatchingQueues(ctx context.Context, publish types.Pub
 	publish.Properties = maps.Clone(publish.Properties)
 	publish = normalizePublishRequest(publish)
 
-	// Callers must not fail the publish over this, so the counter is the only
-	// durable signal that a queue is dropping the traffic bound to it.
-	err = m.publishToTargets(ctx, publish, targets, fanoutBestEffort)
-	if unresolved > 0 || err != nil {
-		m.metrics.RecordCaptureFailure()
+	// One job per target, so each queue is ordered by its own lane and a
+	// stalled queue cannot hold up captures into the others.
+	for i := range targets {
+		m.capture.enqueue(captureJob{publish: publish, target: &targets[i]})
 	}
-	return err
+	if m.cluster != nil {
+		m.capture.enqueue(captureJob{publish: publish})
+	}
+
+	return nil
 }
 
 // fanoutPolicy decides what a failing target means for the targets beside it.
@@ -888,8 +954,9 @@ const (
 	fanoutBestEffort
 )
 
-// publishToTargets routes one publish to every queue whose pattern matched it.
-func (m *Manager) publishToTargets(
+// writeToTargets routes one publish to every queue whose pattern matched it,
+// without any cluster forwarding.
+func (m *Manager) writeToTargets(
 	ctx context.Context,
 	publish types.PublishRequest,
 	targets []queuePublishTarget,
@@ -958,12 +1025,27 @@ func (m *Manager) publishToTargets(
 		}
 	}
 
+	return errors.Join(errs...)
+}
+
+// publishToTargets writes the targets and then forwards the publish to nodes
+// holding queues this node does not know. The two halves are separable because
+// the forward is per publish rather than per target: capture dispatches them as
+// independent jobs so a queue can be ordered by name.
+func (m *Manager) publishToTargets(
+	ctx context.Context,
+	publish types.PublishRequest,
+	targets []queuePublishTarget,
+	policy fanoutPolicy,
+) error {
+	err := m.writeToTargets(ctx, publish, targets, policy)
+
 	// Preserve legacy forwarding for queues known only by remote nodes.
 	if m.cluster != nil {
 		m.forwardToRemoteNodes(ctx, publish)
 	}
 
-	return errors.Join(errs...)
+	return err
 }
 
 // PublishToDurableStream appends to exactly queueName and establishes a

--- a/queue/manager.go
+++ b/queue/manager.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	corebroker "github.com/absmach/fluxmq/broker"
@@ -43,6 +44,10 @@ var (
 	// ErrQueueNotProtected is returned when the exact durable stream publish
 	// path is used for a queue without a registered immutable contract.
 	ErrQueueNotProtected = errors.New("queue has no protected contract")
+	// ErrCaptureStillRunning is returned by Stop when a capture worker is still
+	// inside the queue store after the drain timeout. The manager's resources —
+	// the queue store especially — must not be released while that is true.
+	ErrCaptureStillRunning = errors.New("capture workers did not finish; queue resources left open")
 	// ErrProtectedQueueMutation is returned when a create, update, or delete
 	// would violate a registered queue contract.
 	ErrProtectedQueueMutation = errors.New("protected queue mutation rejected")
@@ -115,6 +120,11 @@ type Manager struct {
 
 	// capture writes topic captures off the publish path.
 	capture *captureDispatcher
+
+	// shutdownComplete records that Stop finished with no capture worker left
+	// inside the queue store, which is what makes the manager's resources safe
+	// to release. See ShutdownComplete.
+	shutdownComplete atomic.Bool
 
 	// Metrics
 	metrics *consumer.Metrics
@@ -428,19 +438,36 @@ func (m *Manager) ensureReservedQueues(ctx context.Context) error {
 }
 
 // Stop stops the manager and all workers.
+// Stop shuts the manager down and reports whether that completed cleanly.
+//
+// Capture drains first. Its workers append through the queue store, schedule
+// delivery, and on replicated queues call the Raft coordinator, so those have to
+// outlive the drain rather than the other way round.
+//
+// A returned ErrCaptureStillRunning means a capture worker is still inside the
+// queue store and could not be interrupted. Everything it touches — the store
+// above all — must then be left alone: closing it underneath an in-flight append
+// is a use-after-close, and leaking the handle into process exit is the cheaper
+// outcome.
 func (m *Manager) Stop() error {
-	m.delivery.Stop()
+	// Bounded: a stalled store delays shutdown by at most the drain timeout.
+	quiesced := m.capture.Stop()
 
-	// Drain queued capture before the stores go away. The dispatcher bounds its
-	// own wait and counts whatever it could not write, so a stalled store
-	// delays shutdown by at most that bound instead of indefinitely.
-	m.capture.Stop()
+	m.delivery.Stop()
 
 	m.stopOnce.Do(func() {
 		close(m.stopCh)
 	})
 
 	m.wg.Wait()
+
+	if !quiesced {
+		// Deliberately skip the Raft coordinator too: a worker still running may
+		// be mid-append on a replicated queue and would then be using it.
+		m.logger.Error("queue manager stopped with capture still running; its resources were left open",
+			slog.String("reason", "a queue store did not return within the capture drain timeout"))
+		return ErrCaptureStillRunning
+	}
 
 	// Stop Raft manager if enabled
 	if m.raftCoordinator != nil {
@@ -449,8 +476,22 @@ func (m *Manager) Stop() error {
 		}
 	}
 
+	m.shutdownComplete.Store(true)
 	m.logger.Info("queue-based queue manager stopped")
 	return nil
+}
+
+// ShutdownComplete reports whether Stop finished with every capture worker out
+// of the queue store.
+//
+// It gates releasing anything the manager shares with those workers, the queue
+// store above all. An append already in flight cannot be cancelled — the store
+// takes no context — so Stop bounds its wait rather than hanging, and a worker
+// may outlive it. Closing the store then would be a use-after-close on a segment
+// that worker still holds. Callers that own such a resource must consult this
+// and leak the handle instead; the process is exiting either way.
+func (m *Manager) ShutdownComplete() bool {
+	return m.shutdownComplete.Load()
 }
 
 // SetRaftManager sets the Raft replication manager.

--- a/queue/manager_test.go
+++ b/queue/manager_test.go
@@ -1104,14 +1104,16 @@ func TestPublishToMatchingQueuesCapturesOnlyExistingQueues(t *testing.T) {
 
 	payload := []byte("original")
 	properties := map[string]string{"source": "device"}
-	if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
-		ClientID:   testCapturePublisher,
-		Topic:      testCapturedTopic,
-		Payload:    payload,
-		Properties: properties,
-	}); err != nil {
-		t.Fatalf("PublishToMatchingQueues failed: %v", err)
-	}
+	flushCapture(t, mgr, func() {
+		if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
+			ClientID:   testCapturePublisher,
+			Topic:      testCapturedTopic,
+			Payload:    payload,
+			Properties: properties,
+		}); err != nil {
+			t.Fatalf("PublishToMatchingQueues failed: %v", err)
+		}
+	})
 
 	payload[0] = 'X'
 	properties["source"] = "mutated"
@@ -1180,12 +1182,14 @@ func TestPublishToMatchingQueuesRoutesCapturedStreamToRemoteConsumerOnce(t *test
 		t.Fatalf("CreateQueue messages failed: %v", err)
 	}
 
-	if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
-		Topic:   testCapturedTopic,
-		Payload: []byte("payload"),
-	}); err != nil {
-		t.Fatalf("PublishToMatchingQueues failed: %v", err)
-	}
+	flushCapture(t, mgr, func() {
+		if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
+			Topic:   testCapturedTopic,
+			Payload: []byte("payload"),
+		}); err != nil {
+			t.Fatalf("PublishToMatchingQueues failed: %v", err)
+		}
+	})
 	mgr.deliverMessages()
 
 	routed := mockCl.GetRoutedMessages()
@@ -3494,23 +3498,29 @@ func TestPublishToMatchingQueuesCountsCaptureFailures(t *testing.T) {
 		t.Fatalf("initial capture failures = %d, want 0", got)
 	}
 
-	err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
-		Topic:   testCapturedTopic,
-		Payload: []byte("payload"),
+	// The append now happens off the publish path, so the caller is told
+	// nothing; the counter is the report.
+	flushCapture(t, mgr, func() {
+		if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
+			Topic:   testCapturedTopic,
+			Payload: []byte("payload"),
+		}); err != nil {
+			t.Fatalf("capture must not fail the publish: %v", err)
+		}
 	})
-	if err == nil {
-		t.Fatal("expected the capture failure to be reported to the caller")
-	}
 	if got := mgr.GetMetrics().CaptureFailures; got != 1 {
 		t.Fatalf("capture failures = %d, want 1", got)
 	}
 
-	if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
-		Topic:   "h/acme/temp",
-		Payload: []byte("payload"),
-	}); err != nil {
-		t.Fatalf("healthy queue capture failed: %v", err)
-	}
+	mgr.capture = newCaptureDispatcher(0, 0, 0, mgr.metrics, mgr.logger, mgr.applyCaptureJob)
+	flushCapture(t, mgr, func() {
+		if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
+			Topic:   "h/acme/temp",
+			Payload: []byte("payload"),
+		}); err != nil {
+			t.Fatalf("healthy queue capture failed: %v", err)
+		}
+	})
 	if got := mgr.GetMetrics().CaptureFailures; got != 1 {
 		t.Fatalf("a healthy capture changed the failure counter to %d", got)
 	}
@@ -3539,14 +3549,16 @@ func TestPublishToMatchingQueuesDoesNotAliasCallerState(t *testing.T) {
 
 	properties := map[string]string{}
 	payload := []byte("original")
-	if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
-		ClientID:   testCapturePublisher,
-		Topic:      testCapturedTopic,
-		Payload:    payload,
-		Properties: properties,
-	}); err != nil {
-		t.Fatalf("PublishToMatchingQueues failed: %v", err)
-	}
+	flushCapture(t, mgr, func() {
+		if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
+			ClientID:   testCapturePublisher,
+			Topic:      testCapturedTopic,
+			Payload:    payload,
+			Properties: properties,
+		}); err != nil {
+			t.Fatalf("PublishToMatchingQueues failed: %v", err)
+		}
+	})
 
 	if len(properties) != 0 {
 		t.Fatalf("caller's property map was written to: %v", properties)
@@ -3597,13 +3609,14 @@ func TestPublishToMatchingQueuesAttemptsEveryTarget(t *testing.T) {
 		}
 	}
 
-	err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
-		Topic:   testCapturedTopic,
-		Payload: []byte("payload"),
+	flushCapture(t, mgr, func() {
+		if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
+			Topic:   testCapturedTopic,
+			Payload: []byte("payload"),
+		}); err != nil {
+			t.Fatalf("capture must not fail the publish: %v", err)
+		}
 	})
-	if err == nil {
-		t.Fatal("expected the refused replicated target to be reported")
-	}
 
 	for _, name := range []string{"healthy-a", "healthy-b"} {
 		count, countErr := logStore.Count(ctx, name)
@@ -3701,9 +3714,10 @@ func TestPublishRejectWritePolicyWritesNothing(t *testing.T) {
 	}
 }
 
-// The counter's unit is the publish, not the queue, so a publish that misses
-// several matching queues in several ways still moves it exactly once.
-func TestPublishToMatchingQueuesCountsOncePerPublish(t *testing.T) {
+// Each matching queue a captured publish fails to reach counts. Capture jobs are
+// dispatched per queue, so the unit is the queue rather than the publish: a
+// publish that misses two of its matching queues counts twice.
+func TestPublishToMatchingQueuesCountsEachLostTarget(t *testing.T) {
 	logStore := memlog.New()
 	store := &unreadableQueueStore{QueueStore: &appendFailingStore{QueueStore: logStore, failQueue: "broken"}, failQueue: testCaptureQueue}
 	mgr := NewManager(store, newMockGroupStore(), nil, DefaultConfig(), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
@@ -3717,14 +3731,26 @@ func TestPublishToMatchingQueuesCountsOncePerPublish(t *testing.T) {
 		}
 	}
 
-	if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
-		Topic:   testCapturedTopic,
-		Payload: []byte("payload"),
-	}); err == nil {
-		t.Fatal("expected the failing append to be reported")
-	}
+	flushCapture(t, mgr, func() {
+		if err := mgr.PublishToMatchingQueues(ctx, types.PublishRequest{
+			Topic:   testCapturedTopic,
+			Payload: []byte("payload"),
+		}); err != nil {
+			t.Fatalf("capture must not fail the publish: %v", err)
+		}
+	})
 
-	if got := mgr.GetMetrics().CaptureFailures; got != 1 {
-		t.Fatalf("capture failures = %d, want 1; the counter is per publish", got)
+	if got := mgr.GetMetrics().CaptureFailures; got != 2 {
+		t.Fatalf("capture failures = %d, want 2; each lost queue counts", got)
 	}
+}
+
+// flushCapture runs fn with the capture dispatcher live, then drains every job
+// it queued. Stop drains synchronously and waits for its workers, so assertions
+// afterwards see the finished state without polling or sleeping.
+func flushCapture(t *testing.T, mgr *Manager, fn func()) {
+	t.Helper()
+	mgr.capture.Start(context.Background())
+	fn()
+	mgr.capture.Stop()
 }

--- a/server/api/stats.go
+++ b/server/api/stats.go
@@ -100,11 +100,15 @@ type byProtocolStats struct {
 // queueStats reports the queue manager's counters. Queues are shared by every
 // protocol, so this sits beside by_protocol rather than inside it.
 type queueStats struct {
-	// CaptureFailures counts pub/sub publishes that a queue bound to their
-	// topic could not store. Capture never fails the publish, so without this
-	// counter a queue silently dropping the traffic its pattern binds would
-	// leave no trace outside the logs.
+	// CaptureFailures counts matching queues a captured publish failed to
+	// reach, and CaptureDropped counts capture jobs discarded before they were
+	// attempted. Capture runs off the publish path and never fails the publish,
+	// so without these a queue silently dropping the traffic its pattern binds
+	// would leave no trace outside the logs. A rising CaptureDropped says
+	// capture cannot keep up; a rising CaptureFailures says the store is
+	// rejecting writes.
 	CaptureFailures uint64            `json:"capture_failures"`
+	CaptureDropped  uint64            `json:"capture_dropped"`
 	Claims          queueAttemptStats `json:"claims"`
 	Steals          queueAttemptStats `json:"steals"`
 	Acknowledgments queueAckStats     `json:"acknowledgments"`
@@ -250,6 +254,7 @@ func (s *Server) buildStatsResponse() statsResponse {
 		qm := s.queueManager.GetMetrics()
 		resp.Queues = &queueStats{
 			CaptureFailures: qm.CaptureFailures,
+			CaptureDropped:  qm.CaptureDropped,
 			Claims: queueAttemptStats{
 				Attempts:  qm.ClaimAttempts,
 				Successes: qm.ClaimSuccesses,

--- a/server/api/stats_test.go
+++ b/server/api/stats_test.go
@@ -226,13 +226,15 @@ func TestStatsRejectsPost(t *testing.T) {
 	}
 }
 
-// appendFailingQueueStore stands in for a queue whose storage is unavailable.
-type appendFailingQueueStore struct {
+// unreadableQueueStore matches a queue in the topic index but cannot return its
+// configuration, so the capture is lost during resolution — before any append is
+// dispatched, and therefore counted on the publishing goroutine.
+type unreadableQueueStore struct {
 	qstorage.QueueStore
 }
 
-func (s *appendFailingQueueStore) Append(_ context.Context, _ string, _ *qtypes.Message) (uint64, error) {
-	return 0, errors.New("storage unavailable")
+func (s *unreadableQueueStore) GetQueue(_ context.Context, _ string) (*qtypes.QueueConfig, error) {
+	return nil, errors.New("configuration unreadable")
 }
 
 // A queue silently dropping the traffic its topic pattern binds is the failure
@@ -241,7 +243,7 @@ func (s *appendFailingQueueStore) Append(_ context.Context, _ string, _ *qtypes.
 func TestStatsReportsQueueMetrics(t *testing.T) {
 	store := memory.New()
 	b := mqttbroker.NewBroker(store, nil, mqttbroker.WithLogger(slog.Default()))
-	logStore := &appendFailingQueueStore{QueueStore: memlog.New()}
+	logStore := &unreadableQueueStore{QueueStore: memlog.New()}
 	manager := queue.NewManager(logStore, nil, nil, queue.DefaultConfig(), slog.Default(), nil)
 	srv := New(Config{}, b, nil, nil, manager, nil, nil, slog.Default())
 
@@ -249,11 +251,13 @@ func TestStatsReportsQueueMetrics(t *testing.T) {
 	if err := manager.CreateQueue(ctx, qtypes.DefaultQueueConfig("messages", "m/#")); err != nil {
 		t.Fatalf("CreateQueue failed: %v", err)
 	}
+	// Resolution runs on the publishing goroutine, so this loss is counted
+	// before anything is dispatched and the endpoint can be read straight after.
 	if err := manager.PublishToMatchingQueues(ctx, qtypes.PublishRequest{
 		Topic:   "m/acme/temp",
 		Payload: []byte("payload"),
-	}); err == nil {
-		t.Fatal("expected the capture to fail")
+	}); err != nil {
+		t.Fatalf("capture must not fail the publish: %v", err)
 	}
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/stats", nil)


### PR DESCRIPTION
A queue's `topics` pattern is matched against ordinary publishes, and the append
that followed ran on the publishing goroutine, ahead of subscriber delivery. That
append honours no cancellation — `Adapter.Append` takes a context and ignores it,
and `AppendAndSync` is uninterruptible once started — so a queue whose store
stalled delayed every subscriber of a matching topic, and the publishing client's
acknowledgement with it, for as long as the store took.

Capture failures were already isolated. Capture *latency* was not, and one queue's
storage could silence pub/sub across every topic its pattern covered.

## What changed

Matching queues are resolved inline, which is an in-memory index lookup, and the
storage work is handed to a bounded dispatcher. Enqueueing never blocks, so the
publish path no longer depends on any store.

- **One job per matching queue, hashed to a fixed lane.** A queue is always handled
  by the same lane, so appends keep publish order despite being asynchronous. Lanes
  are shared rather than per queue, so goroutines do not follow queue count; the
  trade is that a stalled queue also stalls the queues sharing its lane, which is
  documented beside the tuning knob.
- **Drop-newest when a backlog fills**, so a saturated queue holds a contiguous
  prefix — everything up to the moment capture saturated — instead of a log with a
  hole in it. Every discard is counted.
- **`queues.capture_dropped`**, reported beside `capture_failures` and kept distinct
  from it: a failure means the append was tried and did not succeed, a drop means it
  was never tried. Only a rising drop count says capture cannot keep up.
- **`capture_failures` is now per queue**, not per publish. Dispatching per queue
  makes that the honest unit: a publish missing two matching queues loses two
  records and counts two.
- **Tunable** under `queue_manager`: `capture_workers`, `capture_queue_depth`,
  `capture_drain_timeout`. The backlog is bounded in jobs rather than bytes, so the
  ceiling is `workers × depth` payloads — which is why it is configurable and why
  the reference says to lower it when capturing large messages.