### PR TITLE
Index queue topic patterns with a trie instead of scanning them

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	mqtttls "github.com/absmach/fluxmq/pkg/tls"
+	"github.com/absmach/fluxmq/topics"
 	"gopkg.in/yaml.v3"
 )
 
@@ -1867,6 +1868,16 @@ func (c *Config) Validate() error {
 		seenQueues[q.Name] = true
 		if len(q.Topics) == 0 {
 			return fmt.Errorf("queues[%d].topics cannot be empty", i)
+		}
+		// A malformed filter is not a harmless typo: it never matches, so the
+		// queue is bound to nothing and silently receives no traffic. Refuse it
+		// at load rather than let it be deployed and discovered by absence.
+		for j, filter := range q.Topics {
+			if err := topics.ValidateTopicFilter(filter); err != nil {
+				return fmt.Errorf(
+					"queues[%d].topics[%d] %q is not a valid topic filter: %w; %q must be the final level and %q must occupy a whole level",
+					i, j, filter, err, "#", "+")
+			}
 		}
 		if q.Replication.Enabled {
 			if q.Replication.Group != "" && strings.TrimSpace(q.Replication.Group) == "" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -583,3 +583,37 @@ func TestValidateQueueManagerCaptureBounds(t *testing.T) {
 		})
 	}
 }
+
+// A queue bound to a filter that can never match receives nothing, and nothing
+// about a silent queue says why. The configuration is refused at load instead.
+func TestValidateRejectsMalformedQueueTopicFilters(t *testing.T) {
+	tests := []struct {
+		name      string
+		topics    []string
+		wantError string
+	}{
+		{name: "valid queue address", topics: []string{"$queue/orders/#"}},
+		{name: "valid ordinary pattern", topics: []string{"m/+/events"}},
+		{name: "multi level wildcard not final", topics: []string{"#/events"}, wantError: `queues[0].topics[0] "#/events" is not a valid topic filter`},
+		{name: "second filter malformed", topics: []string{"m/#", "a/#/b"}, wantError: `queues[0].topics[1] "a/#/b" is not a valid topic filter`},
+		{name: "empty filter", topics: []string{""}, wantError: `queues[0].topics[0] "" is not a valid topic filter`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Default()
+			cfg.Queues = []QueueConfig{{Name: "q", Topics: tt.topics}}
+
+			err := cfg.Validate()
+			if tt.wantError == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v", err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("Validate() error = %v, want it to contain %q", err, tt.wantError)
+			}
+		})
+	}
+}

--- a/docs/content/docs/concepts/topics.md
+++ b/docs/content/docs/concepts/topics.md
@@ -29,8 +29,13 @@ For AMQP 0.9.1 pub/sub (default exchange path), filters and routing keys are tra
 
 MQTT wildcard rules apply:
 
-- `+` matches a single level (`sensors/+`)
-- `#` matches multiple levels (`sensors/#`)
+- `+` matches exactly one level (`sensors/+`)
+- `#` matches zero or more remaining levels and **must be the final level**
+  (`sensors/#`). Because it matches zero levels, `sensors/#` also matches
+  `sensors` itself.
+
+A `#` anywhere but the end — `sensors/#/temp` — is not a valid filter and matches
+nothing.
 
 These same patterns are used by queue topic bindings as well.
 

--- a/docs/content/docs/reference/configuration-reference.md
+++ b/docs/content/docs/reference/configuration-reference.md
@@ -309,16 +309,24 @@ queues:
 | `type`          | Queue mode: `classic` or `stream`. Empty value falls back to default mode. |
 | `primary_group` | For stream queues: consumer group used for status reporting.               |
 
-Queue patterns are validated when the configuration loads. A malformed filter — a
+Queue patterns are validated wherever a queue is created. A malformed filter — a
 `#` that is not the final level, a wildcard sharing a level with other characters
-— is a startup error naming the queue, the filter and its position, because such a
-filter can never match and would leave the queue silently receiving nothing.
+— can never match, and would leave the queue silently receiving nothing, so it is
+refused:
 
-This can turn a configuration that previously started into one that does not, and
-that is deliberate. Earlier releases matched a misplaced `#` against *every*
-topic, since the matcher returned a match on seeing one regardless of position, so
-a queue bound to `#/events` was capturing all traffic on the broker rather than
-the events it named. Fix the filter rather than work around the error.
+- in this file, as a startup error naming the queue, the filter and its position;
+- through the admin API, as a rejected create or update.
+
+A queue **already persisted** with such a filter is not refused, because the data
+is on disk and startup is not where it can be fixed. It is reported at startup
+instead, naming the queue and the filter, and the queue keeps working through
+whichever of its filters are valid.
+
+Refusing these can turn a configuration that previously started into one that does
+not, and that is deliberate. Earlier releases matched a misplaced `#` against
+*every* topic, since the matcher returned a match on seeing one regardless of
+position, so a queue bound to `#/events` was capturing all traffic on the broker
+rather than the events it named. Fix the filter rather than work around the error.
 
 ### `queues[].retention`
 

--- a/docs/content/docs/reference/configuration-reference.md
+++ b/docs/content/docs/reference/configuration-reference.md
@@ -304,10 +304,19 @@ queues:
 | Field           | Description                                                                |
 | --------------- | -------------------------------------------------------------------------- |
 | `name`          | Unique queue name.                                                         |
-| `topics`        | Topic filters routed into this queue (must be non-empty).                  |
+| `topics`        | Topic filters routed into this queue (must be non-empty). MQTT wildcards: `+` matches one level, `#` matches zero or more and must be the final level. A `#` placed anywhere else is not a valid filter and matches nothing — see the note below. Patterns are matched against every publish, not only `$queue/` addresses. |
 | `reserved`      | Marks system-managed/builtin queue definitions.                            |
 | `type`          | Queue mode: `classic` or `stream`. Empty value falls back to default mode. |
 | `primary_group` | For stream queues: consumer group used for status reporting.               |
+
+Queue patterns are not validated when the configuration loads, so a malformed
+filter is accepted and simply never matches. Check a `#` is the last level: a
+binding such as `#/events` matches nothing at all.
+
+Earlier releases matched such a pattern against *every* topic, because the matcher
+returned a match on seeing `#` regardless of position. A queue bound that way was
+capturing all traffic on the broker. If a queue appears to have stopped receiving
+after upgrading, that binding is where to look.
 
 ### `queues[].retention`
 

--- a/docs/content/docs/reference/configuration-reference.md
+++ b/docs/content/docs/reference/configuration-reference.md
@@ -309,14 +309,16 @@ queues:
 | `type`          | Queue mode: `classic` or `stream`. Empty value falls back to default mode. |
 | `primary_group` | For stream queues: consumer group used for status reporting.               |
 
-Queue patterns are not validated when the configuration loads, so a malformed
-filter is accepted and simply never matches. Check a `#` is the last level: a
-binding such as `#/events` matches nothing at all.
+Queue patterns are validated when the configuration loads. A malformed filter — a
+`#` that is not the final level, a wildcard sharing a level with other characters
+— is a startup error naming the queue, the filter and its position, because such a
+filter can never match and would leave the queue silently receiving nothing.
 
-Earlier releases matched such a pattern against *every* topic, because the matcher
-returned a match on seeing `#` regardless of position. A queue bound that way was
-capturing all traffic on the broker. If a queue appears to have stopped receiving
-after upgrading, that binding is where to look.
+This can turn a configuration that previously started into one that does not, and
+that is deliberate. Earlier releases matched a misplaced `#` against *every*
+topic, since the matcher returned a match on seeing one regardless of position, so
+a queue bound to `#/events` was capturing all traffic on the broker rather than
+the events it named. Fix the filter rather than work around the error.
 
 ### `queues[].retention`
 

--- a/logstorage/adapter.go
+++ b/logstorage/adapter.go
@@ -6,6 +6,7 @@ package logstorage
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strconv"
 	"time"
 
@@ -70,15 +71,36 @@ func NewAdapter(baseDir string, config AdapterConfig) (*Adapter, error) {
 		topicIndex: storage.NewTopicIndex(),
 	}
 
-	// Rebuild topic index from existing queues
+	// Rebuild topic index from existing queues.
+	//
+	// A queue persisted before filters were validated may carry one that can
+	// never match. Startup is not the place to refuse it — the data is already
+	// on disk and an operator cannot edit it from here — but it must not be
+	// bound silently either, because the queue will simply receive nothing.
+	// Report it and carry on; the index ignores such a filter regardless.
 	queues, err := queueStore.List()
 	if err == nil {
 		for _, cfg := range queues {
+			for _, filter := range cfg.Topics {
+				if err := types.ValidateTopicFilters([]string{filter}); err != nil {
+					reportMalformedFilter(config.RecoveryLogger, cfg.Name, filter, err)
+				}
+			}
 			adapter.topicIndex.AddQueue(cfg.Name, cfg.Topics)
 		}
 	}
 
 	return adapter, nil
+}
+
+// reportMalformedFilter surfaces a persisted binding that can never match. The
+// queue keeps working for its other filters; this one contributes nothing.
+func reportMalformedFilter(logger func(string, ...any), queueName, filter string, err error) {
+	if logger == nil {
+		logger = func(msg string, args ...any) { slog.Warn(msg, args...) }
+	}
+	logger("queue topic filter can never match; queue will not receive traffic through it",
+		"queue", queueName, "filter", filter, "error", err)
 }
 
 // Close closes the adapter and underlying store.
@@ -125,6 +147,13 @@ func (a *Adapter) OffsetBySize(ctx context.Context, queueName string, retentionB
 // missing metadata rather than reporting the queue as already created, so a
 // torn creation cannot strand records that were acknowledged as durable.
 func (a *Adapter) CreateQueue(ctx context.Context, config types.QueueConfig) error {
+	// Defence in depth: the queue manager checks this too, but the adapter is
+	// this package's public write path and must not persist a binding that can
+	// never match.
+	if err := types.ValidateTopicFilters(config.Topics); err != nil {
+		return err
+	}
+
 	if err := a.store.CreateQueue(config.Name); err != nil {
 		if !errors.Is(err, ErrAlreadyExists) {
 			return err
@@ -146,6 +175,10 @@ func (a *Adapter) CreateQueue(ctx context.Context, config types.QueueConfig) err
 
 // UpdateQueue updates an existing queue's configuration.
 func (a *Adapter) UpdateQueue(ctx context.Context, config types.QueueConfig) error {
+	if err := types.ValidateTopicFilters(config.Topics); err != nil {
+		return err
+	}
+
 	if err := a.queueStore.Save(config); err != nil {
 		return err
 	}

--- a/logstorage/adapter_test.go
+++ b/logstorage/adapter_test.go
@@ -291,3 +291,71 @@ func TestMkdirAllSyncedCreatesNestedDirectories(t *testing.T) {
 	require.NoError(t, os.WriteFile(file, []byte("x"), 0o600))
 	require.Error(t, MkdirAllSynced(file, 0o755), "a file in the path must not be reported as a directory")
 }
+
+// The disk-backed adapter is the production store, so it must refuse a binding
+// that can never match rather than persist one.
+func TestAdapterRejectsFiltersThatCannotMatch(t *testing.T) {
+	adapter, err := NewAdapter(t.TempDir(), DefaultAdapterConfig())
+	if err != nil {
+		t.Fatalf("NewAdapter failed: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	ctx := context.Background()
+	if err := adapter.CreateQueue(ctx, types.DefaultQueueConfig("black-holed", "#/events")); err == nil {
+		t.Fatal("CreateQueue persisted a filter that can never match")
+	}
+
+	if err := adapter.CreateQueue(ctx, types.DefaultQueueConfig("working", "m/#")); err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+	if err := adapter.UpdateQueue(ctx, types.DefaultQueueConfig("working", "m/#/events")); err == nil {
+		t.Fatal("UpdateQueue persisted a filter that can never match")
+	}
+}
+
+// A queue persisted before filters were validated must not be bound silently.
+// Startup cannot refuse it — the data is already on disk — so it is reported,
+// and the queue keeps working through whichever of its filters are valid.
+func TestAdapterReportsPersistedFiltersThatCannotMatch(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write the bad filter behind the adapter's validation, as a release that
+	// did not validate would have left it.
+	queueStore, err := NewQueueConfigStore(dir)
+	if err != nil {
+		t.Fatalf("NewQueueConfigStore failed: %v", err)
+	}
+	legacy := types.DefaultQueueConfig("legacy", "#/events", "m/#")
+	if err := queueStore.Save(legacy); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+	if err := queueStore.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	var reported []string
+	config := DefaultAdapterConfig()
+	config.RecoveryLogger = func(msg string, args ...any) {
+		reported = append(reported, msg)
+	}
+
+	adapter, err := NewAdapter(dir, config)
+	if err != nil {
+		t.Fatalf("NewAdapter failed: %v", err)
+	}
+	t.Cleanup(func() { _ = adapter.Close() })
+
+	if len(reported) != 1 {
+		t.Fatalf("reported %d malformed filters, want 1: %v", len(reported), reported)
+	}
+
+	// The queue still matches through its valid filter.
+	matched, err := adapter.FindMatchingQueues(context.Background(), "m/acme")
+	if err != nil {
+		t.Fatalf("FindMatchingQueues failed: %v", err)
+	}
+	if len(matched) != 1 || matched[0] != "legacy" {
+		t.Fatalf("FindMatchingQueues = %v, want [legacy]", matched)
+	}
+}

--- a/queue/manager.go
+++ b/queue/manager.go
@@ -752,6 +752,13 @@ func (m *Manager) GroupStore() storage.ConsumerGroupStore {
 
 // CreateQueue creates a new queue.
 func (m *Manager) CreateQueue(ctx context.Context, config types.QueueConfig) error {
+	// Checked here rather than only at configuration load, because this is the
+	// path an admin-API creation takes. A filter that can never match would bind
+	// the queue to nothing and leave it silently receiving no traffic.
+	if err := types.ValidateTopicFilters(config.Topics); err != nil {
+		return err
+	}
+
 	m.protectedQueuesMu.RLock()
 	defer m.protectedQueuesMu.RUnlock()
 	if err := m.validateProtectedQueueMutationLocked(config); err != nil {
@@ -790,6 +797,12 @@ func (m *Manager) CreateQueue(ctx context.Context, config types.QueueConfig) err
 
 // UpdateQueue updates an existing queue.
 func (m *Manager) UpdateQueue(ctx context.Context, config types.QueueConfig) error {
+	// An update can introduce a filter that never matches just as a creation
+	// can, silently unbinding a queue that was working.
+	if err := types.ValidateTopicFilters(config.Topics); err != nil {
+		return err
+	}
+
 	m.protectedQueuesMu.RLock()
 	defer m.protectedQueuesMu.RUnlock()
 	if err := m.validateProtectedQueueMutationLocked(config); err != nil {

--- a/queue/manager_test.go
+++ b/queue/manager_test.go
@@ -3754,3 +3754,33 @@ func flushCapture(t *testing.T, mgr *Manager, fn func()) {
 	fn()
 	mgr.capture.Stop()
 }
+
+// Configuration load is not the only way a queue is created: the admin API goes
+// through the manager, and production runs on the disk-backed store rather than
+// the in-memory one whose CreateQueue happened to validate. A filter that can
+// never match has to be refused here, or a queue is created bound to nothing and
+// silently receives no traffic.
+func TestCreateQueueRejectsFiltersThatCannotMatch(t *testing.T) {
+	mgr := NewManager(memlog.New(), newMockGroupStore(), nil, DefaultConfig(), slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	ctx := context.Background()
+
+	malformed := types.DefaultQueueConfig("black-holed", "#/events")
+	err := mgr.CreateQueue(ctx, malformed)
+	if err == nil {
+		t.Fatal("CreateQueue accepted a filter that can never match")
+	}
+	if !errors.Is(err, types.ErrInvalidConfig) {
+		t.Fatalf("CreateQueue error = %v, want it to wrap ErrInvalidConfig", err)
+	}
+	if _, getErr := mgr.GetQueue(ctx, "black-holed"); getErr == nil {
+		t.Fatal("the refused queue was created anyway")
+	}
+
+	// An update must not be able to unbind a working queue either.
+	if err := mgr.CreateQueue(ctx, types.DefaultQueueConfig("working", "m/#")); err != nil {
+		t.Fatalf("CreateQueue failed: %v", err)
+	}
+	if err := mgr.UpdateQueue(ctx, types.DefaultQueueConfig("working", "m/#/events")); err == nil {
+		t.Fatal("UpdateQueue accepted a filter that can never match")
+	}
+}

--- a/queue/storage/memory/log/store.go
+++ b/queue/storage/memory/log/store.go
@@ -92,6 +92,15 @@ func (s *Store) CreateQueue(ctx context.Context, config types.QueueConfig) error
 
 // UpdateQueue updates an existing queue's configuration.
 func (s *Store) UpdateQueue(ctx context.Context, config types.QueueConfig) error {
+	// Matches the disk-backed adapter: an update can introduce a filter that
+	// never matches just as a creation can. Only the filters are checked, not
+	// the whole configuration, because this is also how a stored configuration
+	// is replaced wholesale — including with one that has drifted from its
+	// contract, which the queue manager is what detects.
+	if err := types.ValidateTopicFilters(config.Topics); err != nil {
+		return err
+	}
+
 	val, exists := s.logs.Load(config.Name)
 	if !exists {
 		return storage.ErrQueueNotFound

--- a/queue/storage/patterntrie.go
+++ b/queue/storage/patterntrie.go
@@ -1,0 +1,144 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package storage
+
+import "strings"
+
+const patternSeparator = "/"
+
+// patternTrie maps topic patterns to the queues bound to them, and matches a
+// topic against all of them at once.
+//
+// It replaces a linear scan that called topics.TopicMatch per registered
+// pattern. That cost grew with the number of patterns configured rather than
+// with the topic being matched, which put a ceiling on publish throughput on any
+// broker binding many queues to ordinary topics. Descending a trie instead makes
+// matching a function of the topic's own depth and the wildcards actually
+// present, not of how many patterns exist.
+//
+// Matching mirrors the MQTT rules topics.TopicMatch implements: "+" matches
+// exactly one level, "#" matches zero or more trailing levels — so "a/#" matches
+// "a" itself — and a filter with no "#" must consume the whole topic. The one
+// rule it does not implement is the "$" guard, because TopicIndex partitions
+// patterns on that prefix before they reach a trie: a "#" pattern is only ever
+// in the half consulted for ordinary topics.
+//
+// It is not safe for concurrent use; TopicIndex holds the lock.
+type patternTrie struct {
+	root *patternNode
+}
+
+type patternNode struct {
+	children map[string]*patternNode
+	// queues are the queues whose pattern terminates at this node.
+	queues []string
+}
+
+func newPatternTrie() *patternTrie {
+	return &patternTrie{root: newPatternNode()}
+}
+
+func newPatternNode() *patternNode {
+	return &patternNode{children: make(map[string]*patternNode)}
+}
+
+// add binds a queue to a pattern. Adding the same pair twice is a no-op, so a
+// queue cannot be reported twice for one pattern.
+func (t *patternTrie) add(pattern, queueName string) {
+	node := t.root
+	remaining := pattern
+	for {
+		level, rest, more := strings.Cut(remaining, patternSeparator)
+		child, ok := node.children[level]
+		if !ok {
+			child = newPatternNode()
+			node.children[level] = child
+		}
+		node = child
+		if !more {
+			break
+		}
+		remaining = rest
+	}
+
+	for _, existing := range node.queues {
+		if existing == queueName {
+			return
+		}
+	}
+	node.queues = append(node.queues, queueName)
+}
+
+// remove unbinds a queue from a pattern and prunes the nodes the pattern no
+// longer needs, so repeated registration churn cannot grow the trie without
+// bound.
+func (t *patternTrie) remove(pattern, queueName string) {
+	removeQueueFromPattern(t.root, pattern, queueName)
+}
+
+func removeQueueFromPattern(node *patternNode, remaining, queueName string) {
+	level, rest, more := strings.Cut(remaining, patternSeparator)
+	child, ok := node.children[level]
+	if !ok {
+		return
+	}
+
+	if more {
+		removeQueueFromPattern(child, rest, queueName)
+	} else {
+		for i, existing := range child.queues {
+			if existing != queueName {
+				continue
+			}
+			child.queues = append(child.queues[:i], child.queues[i+1:]...)
+			break
+		}
+	}
+
+	// Prune on the way back out: a node with no queues and no children can no
+	// longer contribute to any match.
+	if len(child.queues) == 0 && len(child.children) == 0 {
+		delete(node.children, level)
+	}
+}
+
+// match collects every queue whose pattern matches the topic.
+//
+// It allocates nothing: levels are walked with strings.Cut rather than split
+// into a slice, and the result is appended to only when a queue actually
+// matches.
+func (t *patternTrie) match(topic string, matched *matchedQueues) {
+	matchPatternNode(t.root, topic, false, matched)
+}
+
+func matchPatternNode(node *patternNode, remaining string, consumed bool, matched *matchedQueues) {
+	if consumed {
+		// The topic ended here, so patterns terminating at this node match, as
+		// does a "#" beneath it: "a/#" matches "a".
+		collectQueues(node, matched)
+		if child, ok := node.children["#"]; ok {
+			collectQueues(child, matched)
+		}
+		return
+	}
+
+	level, rest, more := strings.Cut(remaining, patternSeparator)
+
+	if child, ok := node.children[level]; ok {
+		matchPatternNode(child, rest, !more, matched)
+	}
+	if child, ok := node.children["+"]; ok {
+		matchPatternNode(child, rest, !more, matched)
+	}
+	// "#" consumes every remaining level, so it matches without descending.
+	if child, ok := node.children["#"]; ok {
+		collectQueues(child, matched)
+	}
+}
+
+func collectQueues(node *patternNode, matched *matchedQueues) {
+	for _, queueName := range node.queues {
+		matched.add(queueName)
+	}
+}

--- a/queue/storage/patterntrie_test.go
+++ b/queue/storage/patterntrie_test.go
@@ -1,0 +1,187 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package storage
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/absmach/fluxmq/topics"
+)
+
+// referenceFindMatching is the linear scan the trie replaced: one
+// topics.TopicMatch per registered pattern. It is the oracle for the
+// equivalence test below, because the rewrite exists to change the cost of
+// matching and must not change a single answer.
+func referenceFindMatching(patterns map[string][]string, topic string) []string {
+	if topic == "" {
+		return nil
+	}
+
+	var matched matchedQueues
+	// Sorted so the reference is deterministic; the trie's own order is not
+	// specified and both sides are sorted before comparison.
+	keys := make([]string, 0, len(patterns))
+	for pattern := range patterns {
+		keys = append(keys, pattern)
+	}
+	sort.Strings(keys)
+
+	for _, pattern := range keys {
+		if !topics.TopicMatch(pattern, topic) {
+			continue
+		}
+		for _, queueName := range patterns[pattern] {
+			matched.add(queueName)
+		}
+	}
+	return matched.names
+}
+
+// TestPatternTrieMatchesTheLinearScan compares the trie against the scan it
+// replaced over every combination of a small alphabet, so the cases the two
+// could plausibly disagree on — a trailing "#", a "+" against a shorter or
+// longer topic, a pattern that is a prefix of another, several queues on one
+// pattern — are all covered together rather than one at a time.
+func TestPatternTrieMatchesTheLinearScan(t *testing.T) {
+	// "#" only ever appears as the final level, because that is the only place
+	// MQTT allows it. Elsewhere it is a malformed filter, which the two
+	// implementations deliberately disagree about; see
+	// TestPatternTrieIgnoresMisplacedMultiLevelWildcard.
+	interior := []string{"a", "b", "+"}
+	terminal := []string{"a", "b", "+", "#"}
+
+	var candidates []string
+	for _, first := range terminal {
+		candidates = append(candidates, first)
+	}
+	for _, first := range interior {
+		for _, second := range terminal {
+			candidates = append(candidates, first+"/"+second)
+		}
+	}
+	for _, first := range interior {
+		for _, second := range interior {
+			for _, third := range terminal {
+				candidates = append(candidates, first+"/"+second+"/"+third)
+			}
+		}
+	}
+
+	// Every candidate is a pattern, bound to two queues so deduplication and
+	// multi-queue collection are exercised as well.
+	index := NewTopicIndex()
+	patterns := make(map[string][]string, len(candidates))
+	for i, pattern := range candidates {
+		first := fmt.Sprintf("q%d", i)
+		shared := "shared"
+		index.AddQueue(first, []string{pattern})
+		patterns[pattern] = append(patterns[pattern], first)
+		if i%3 == 0 {
+			// AddQueue replaces a queue's patterns, so the shared queue is
+			// registered once at the end with everything it should match.
+			patterns[pattern] = append(patterns[pattern], shared)
+		}
+	}
+	sharedPatterns := make([]string, 0)
+	for i, pattern := range candidates {
+		if i%3 == 0 {
+			sharedPatterns = append(sharedPatterns, pattern)
+		}
+	}
+	index.AddQueue("shared", sharedPatterns)
+
+	// Topics contain no wildcards, as a published topic never does.
+	topicLevels := []string{"a", "b", "c"}
+	var probes []string
+	for _, first := range topicLevels {
+		probes = append(probes, first)
+		for _, second := range topicLevels {
+			probes = append(probes, first+"/"+second)
+			for _, third := range topicLevels {
+				probes = append(probes, first+"/"+second+"/"+third)
+			}
+		}
+	}
+
+	for _, topic := range probes {
+		got := append([]string(nil), index.FindMatching(topic)...)
+		want := append([]string(nil), referenceFindMatching(patterns, topic)...)
+		sort.Strings(got)
+		sort.Strings(want)
+
+		if len(got) != len(want) {
+			t.Fatalf("FindMatching(%q) = %v, reference = %v", topic, got, want)
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("FindMatching(%q) = %v, reference = %v", topic, got, want)
+			}
+		}
+	}
+}
+
+// Removing a pattern must leave nothing behind, or repeated registration churn
+// would grow the trie without bound.
+func TestPatternTriePrunesRemovedPatterns(t *testing.T) {
+	trie := newPatternTrie()
+	trie.add("a/b/c", "q1")
+	trie.add("a/b/d", "q2")
+
+	trie.remove("a/b/c", "q1")
+	if _, exists := trie.root.children["a"].children["b"].children["c"]; exists {
+		t.Fatal("removed pattern left its node behind")
+	}
+	if _, exists := trie.root.children["a"].children["b"].children["d"]; !exists {
+		t.Fatal("removing one pattern pruned a sibling still in use")
+	}
+
+	trie.remove("a/b/d", "q2")
+	if len(trie.root.children) != 0 {
+		t.Fatalf("trie retained %d nodes after every pattern was removed", len(trie.root.children))
+	}
+}
+
+// A pattern shared by several queues must survive until the last one leaves.
+func TestPatternTrieKeepsPatternWhileAnotherQueueUsesIt(t *testing.T) {
+	trie := newPatternTrie()
+	trie.add("m/#", "q1")
+	trie.add("m/#", "q2")
+	// Adding the same pair twice must not duplicate it.
+	trie.add("m/#", "q2")
+
+	var matched matchedQueues
+	trie.match("m/acme", &matched)
+	if len(matched.names) != 2 {
+		t.Fatalf("matched %v, want both queues once each", matched.names)
+	}
+
+	trie.remove("m/#", "q1")
+	var afterRemove matchedQueues
+	trie.match("m/acme", &afterRemove)
+	if len(afterRemove.names) != 1 || afterRemove.names[0] != "q2" {
+		t.Fatalf("matched %v after removing q1, want [q2]", afterRemove.names)
+	}
+}
+
+// A "#" anywhere but the final level is a malformed filter. topics.TopicMatch
+// returns true as soon as it sees one, so under the previous linear scan a queue
+// configured with "#/a" captured every publish on the broker. The trie treats
+// the pattern as the literal path it is, so it captures nothing.
+//
+// Neither answer is useful, and nothing validates queue patterns at load, so
+// this pins the behaviour rather than leaving it to whichever matcher is in use.
+func TestPatternTrieIgnoresMisplacedMultiLevelWildcard(t *testing.T) {
+	index := NewTopicIndex()
+	index.AddQueue("malformed", []string{"#/a"})
+	index.AddQueue("wellformed", []string{"m/#"})
+
+	if got := index.FindMatching("anything/at/all"); len(got) != 0 {
+		t.Fatalf("FindMatching = %v, want nothing; a misplaced # must not capture every topic", got)
+	}
+	if got := index.FindMatching("m/acme"); len(got) != 1 || got[0] != "wellformed" {
+		t.Fatalf("FindMatching = %v, want [wellformed]", got)
+	}
+}

--- a/queue/storage/patterntrie_test.go
+++ b/queue/storage/patterntrie_test.go
@@ -171,8 +171,10 @@ func TestPatternTrieKeepsPatternWhileAnotherQueueUsesIt(t *testing.T) {
 // configured with "#/a" captured every publish on the broker. The trie treats
 // the pattern as the literal path it is, so it captures nothing.
 //
-// Neither answer is useful, and nothing validates queue patterns at load, so
-// this pins the behaviour rather than leaving it to whichever matcher is in use.
+// Such a pattern is now rejected by queue configuration validation, so it should
+// never reach the index. This pins the trie's behaviour anyway, as defence in
+// depth: an index that captured everything on a pattern that reached it by some
+// other path would be far worse than one that captures nothing.
 func TestPatternTrieIgnoresMisplacedMultiLevelWildcard(t *testing.T) {
 	index := NewTopicIndex()
 	index.AddQueue("malformed", []string{"#/a"})

--- a/queue/storage/topic.go
+++ b/queue/storage/topic.go
@@ -6,8 +6,6 @@ package storage
 import (
 	"slices"
 	"sync"
-
-	"github.com/absmach/fluxmq/topics"
 )
 
 // TopicIndex provides efficient topic-to-queue matching.
@@ -31,24 +29,25 @@ type TopicIndex struct {
 	// addressed through "$queue/" would test every one of them on every
 	// ordinary publish and never match.
 	//
-	// Each entry maps pattern -> queue names that use it.
-	dollarPatterns map[string][]string
-	plainPatterns  map[string][]string
+	// Each half is a trie keyed on topic levels, so matching costs the depth of
+	// the topic rather than the number of patterns registered.
+	dollarPatterns *patternTrie
+	plainPatterns  *patternTrie
 }
 
 // NewTopicIndex creates a new topic index.
 func NewTopicIndex() *TopicIndex {
 	return &TopicIndex{
 		queues:         make(map[string][]string),
-		dollarPatterns: make(map[string][]string),
-		plainPatterns:  make(map[string][]string),
+		dollarPatterns: newPatternTrie(),
+		plainPatterns:  newPatternTrie(),
 	}
 }
 
 // patternsFor returns the half of the index that can match topics shaped like
 // the given value. It is used for both lookup and bookkeeping, so a pattern is
 // always filed where a matching topic will look for it.
-func (idx *TopicIndex) patternsFor(patternOrTopic string) map[string][]string {
+func (idx *TopicIndex) patternsFor(patternOrTopic string) *patternTrie {
 	if patternOrTopic != "" && patternOrTopic[0] == '$' {
 		return idx.dollarPatterns
 	}
@@ -67,8 +66,7 @@ func (idx *TopicIndex) AddQueue(queueName string, topicPatterns []string) {
 	idx.queues[queueName] = topicPatterns
 
 	for _, pattern := range topicPatterns {
-		patterns := idx.patternsFor(pattern)
-		patterns[pattern] = append(patterns[pattern], queueName)
+		idx.patternsFor(pattern).add(pattern, queueName)
 	}
 }
 
@@ -88,30 +86,19 @@ func (idx *TopicIndex) removeQueueLocked(queueName string) {
 
 	// Remove queue from pattern index
 	for _, pattern := range topicPatterns {
-		patterns := idx.patternsFor(pattern)
-		queues := patterns[pattern]
-		newQueues := make([]string, 0, len(queues))
-		for _, q := range queues {
-			if q != queueName {
-				newQueues = append(newQueues, q)
-			}
-		}
-		if len(newQueues) == 0 {
-			delete(patterns, pattern)
-		} else {
-			patterns[pattern] = newQueues
-		}
+		idx.patternsFor(pattern).remove(pattern, queueName)
 	}
 
 	delete(idx.queues, queueName)
 }
 
 // FindMatching returns all queue names whose topic patterns match the given topic.
-// Uses MQTT-style topic matching via topics.TopicMatch.
+// Wildcard semantics follow MQTT, matching topics.TopicMatch.
 //
 // This runs on the publish path of every protocol, so the no-match case
 // allocates nothing: only the half of the index that can match the topic is
-// scanned, and the result slice is built lazily.
+// consulted, the trie is walked without splitting the topic, and the result
+// slice is built lazily.
 func (idx *TopicIndex) FindMatching(topic string) []string {
 	if topic == "" {
 		return nil
@@ -121,14 +108,7 @@ func (idx *TopicIndex) FindMatching(topic string) []string {
 	defer idx.mu.RUnlock()
 
 	var matched matchedQueues
-	for pattern, queues := range idx.patternsFor(topic) {
-		if !topics.TopicMatch(pattern, topic) {
-			continue
-		}
-		for _, queueName := range queues {
-			matched.add(queueName)
-		}
-	}
+	idx.patternsFor(topic).match(topic, &matched)
 
 	return matched.names
 }

--- a/queue/storage/topic_bench_test.go
+++ b/queue/storage/topic_bench_test.go
@@ -55,13 +55,14 @@ func BenchmarkTopicIndexFindMatching(b *testing.B) {
 	}
 }
 
-// Scaling "$queue/" patterns measures the partition, which short-circuits them
-// to no work at all, so it flatters the matcher. The sensitive dimension is the
-// number of *ordinary* patterns: those are the half an ordinary publish actually
-// scans, and the scan is linear in them under a shared read lock.
+// Scaling "$queue/" patterns measures the partition, which short-circuits them to
+// no work at all, so it says nothing about the matcher. The dimension that used
+// to cost is the number of *ordinary* patterns: that half is what an ordinary
+// publish consults.
 //
-// This is the benchmark to beat with an indexed matcher, and the case a
-// deployment binding many queues to ordinary topics pays on every publish.
+// Matching is a trie descent, so this asserts the property that replaced the old
+// linear scan — lookup independent of how many patterns are registered. A result
+// that grows with the pattern count means the index has regressed to a scan.
 func BenchmarkTopicIndexFindMatchingOrdinaryPatternScale(b *testing.B) {
 	// A handful of queue-addressed queues alongside them, so the partition is
 	// present but is not the variable under test.
@@ -85,8 +86,8 @@ func BenchmarkTopicIndexFindMatchingOrdinaryPatternScale(b *testing.B) {
 			topic string
 		}{
 			{name: "no_match", topic: benchOrdinaryTopic},
-			// Matching one pattern still scans all of them, so the two cases
-			// differ only by the result allocation.
+			// Both cases descend the same trie; they differ only by the
+			// allocation the result slice makes when something matches.
 			{name: "one_match", topic: "t3/acme/events/temp"},
 		} {
 			b.Run(fmt.Sprintf("%s/%d_ordinary_patterns", tc.name, patterns), func(b *testing.B) {
@@ -100,10 +101,10 @@ func BenchmarkTopicIndexFindMatchingOrdinaryPatternScale(b *testing.B) {
 	}
 }
 
-// The same scan also served publishes addressed to a queue, where the cost grew
-// with the number of configured queues rather than with traffic. That case is
-// indexed by the same trie, so it should be flat too — and it is the dimension a
-// broker with many queues actually grows along.
+// Publishes addressed to a queue once cost the same scan, growing with the number
+// of configured queues rather than with traffic. They are indexed by the same
+// trie, and this holds that: it is the dimension a broker with many queues
+// actually grows along.
 func BenchmarkTopicIndexFindMatchingQueueAddressScale(b *testing.B) {
 	newIndex := func(queues int) *TopicIndex {
 		index := NewTopicIndex()

--- a/queue/storage/topic_bench_test.go
+++ b/queue/storage/topic_bench_test.go
@@ -99,3 +99,29 @@ func BenchmarkTopicIndexFindMatchingOrdinaryPatternScale(b *testing.B) {
 		}
 	}
 }
+
+// The same scan also served publishes addressed to a queue, where the cost grew
+// with the number of configured queues rather than with traffic. That case is
+// indexed by the same trie, so it should be flat too — and it is the dimension a
+// broker with many queues actually grows along.
+func BenchmarkTopicIndexFindMatchingQueueAddressScale(b *testing.B) {
+	newIndex := func(queues int) *TopicIndex {
+		index := NewTopicIndex()
+		for i := range queues {
+			name := fmt.Sprintf("queue-%d", i)
+			index.AddQueue(name, []string{"$queue/" + name + "/#"})
+		}
+		return index
+	}
+
+	for _, queues := range []int{8, 512, 8192} {
+		index := newIndex(queues)
+		b.Run(fmt.Sprintf("one_match/%d_queues", queues), func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				index.FindMatching("$queue/queue-7/items")
+			}
+		})
+	}
+}

--- a/queue/types/config.go
+++ b/queue/types/config.go
@@ -265,17 +265,26 @@ func FromInput(input QueueConfigInput) QueueConfig {
 	return cfg
 }
 
-// Validate validates queue configuration.
+// ValidateTopicFilters reports whether every filter can actually match a topic.
 //
-// Topic filters are checked for well-formedness because a malformed one matches
-// nothing: the queue would be bound to a pattern that can never fire and would
-// receive no traffic at all, with nothing to distinguish it from a queue nobody
-// publishes to.
-func (c *QueueConfig) Validate() error {
-	for _, filter := range c.Topics {
+// A malformed filter is not a harmless typo. It matches nothing, so the queue is
+// bound to a pattern that can never fire and receives no traffic at all, which
+// looks exactly like a queue nobody publishes to. It has to be refused wherever a
+// queue is created, not only where configuration is loaded, because a queue can
+// equally be created through the admin API.
+func ValidateTopicFilters(filters []string) error {
+	for _, filter := range filters {
 		if err := topics.ValidateTopicFilter(filter); err != nil {
 			return fmt.Errorf("%w: topic filter %q: %w", ErrInvalidConfig, filter, err)
 		}
+	}
+	return nil
+}
+
+// Validate validates queue configuration.
+func (c *QueueConfig) Validate() error {
+	if err := ValidateTopicFilters(c.Topics); err != nil {
+		return err
 	}
 
 	switch {

--- a/queue/types/config.go
+++ b/queue/types/config.go
@@ -5,8 +5,11 @@ package types
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"time"
+
+	"github.com/absmach/fluxmq/topics"
 )
 
 // ErrInvalidConfig indicates an invalid queue configuration.
@@ -263,7 +266,18 @@ func FromInput(input QueueConfigInput) QueueConfig {
 }
 
 // Validate validates queue configuration.
+//
+// Topic filters are checked for well-formedness because a malformed one matches
+// nothing: the queue would be bound to a pattern that can never fire and would
+// receive no traffic at all, with nothing to distinguish it from a queue nobody
+// publishes to.
 func (c *QueueConfig) Validate() error {
+	for _, filter := range c.Topics {
+		if err := topics.ValidateTopicFilter(filter); err != nil {
+			return fmt.Errorf("%w: topic filter %q: %w", ErrInvalidConfig, filter, err)
+		}
+	}
+
 	switch {
 	case c.Name == "":
 		return ErrInvalidConfig

--- a/queue/types/config_test.go
+++ b/queue/types/config_test.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -276,4 +277,44 @@ func TestFromInput_Replication(t *testing.T) {
 	assert.Equal(t, ReplicationAsync, config.Replication.Mode)
 	assert.Equal(t, 3, config.Replication.MinInSyncReplicas)
 	assert.Equal(t, 2*time.Second, config.Replication.AckTimeout)
+}
+
+// A malformed topic filter matches nothing, so a queue bound to one silently
+// receives no traffic and looks identical to a queue nobody publishes to. It is
+// rejected rather than accepted and left to be discovered by absence.
+func TestQueueConfigRejectsMalformedTopicFilters(t *testing.T) {
+	tests := []struct {
+		name   string
+		topics []string
+		valid  bool
+	}{
+		{name: "queue address", topics: []string{"$queue/orders/#"}, valid: true},
+		{name: "ordinary pattern", topics: []string{"m/+/events"}, valid: true},
+		{name: "match all", topics: []string{"#"}, valid: true},
+		{name: "multi level wildcard not final", topics: []string{"#/events"}},
+		{name: "multi level wildcard mid pattern", topics: []string{"m/#/events"}},
+		{name: "multi level wildcard sharing a level", topics: []string{"m/a#"}},
+		{name: "single level wildcard sharing a level", topics: []string{"m/a+/b"}},
+		{name: "empty filter", topics: []string{""}},
+		{name: "one bad among good", topics: []string{"m/#", "#/events"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := DefaultQueueConfig("q", tt.topics...)
+			err := config.Validate()
+			if tt.valid {
+				if err != nil {
+					t.Fatalf("Validate() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("Validate() accepted a filter that can never match")
+			}
+			if !errors.Is(err, ErrInvalidConfig) {
+				t.Fatalf("Validate() error = %v, want it to wrap ErrInvalidConfig", err)
+			}
+		})
+	}
 }

--- a/server/queue/handler.go
+++ b/server/queue/handler.go
@@ -57,6 +57,40 @@ func NewHandler(manager *queue.Manager, queueStore storage.QueueStore, groupStor
 	}
 }
 
+// createQueueErrorCode maps a queue creation failure onto a Connect status.
+//
+// A rejected topic filter is the caller's mistake, not a conflict and not a
+// server fault: it has to read as InvalidArgument so a client can tell a bad
+// request from a name that is taken. The previous mapping reported every
+// failure, including a storage error, as AlreadyExists.
+func createQueueErrorCode(err error) connect.Code {
+	switch {
+	case errors.Is(err, types.ErrInvalidConfig):
+		return connect.CodeInvalidArgument
+	case errors.Is(err, queue.ErrProtectedQueueMutation):
+		return connect.CodeFailedPrecondition
+	case errors.Is(err, storage.ErrQueueAlreadyExists):
+		return connect.CodeAlreadyExists
+	default:
+		return connect.CodeInternal
+	}
+}
+
+// updateQueueErrorCode maps a queue update failure onto a Connect status, for
+// the same reasons as createQueueErrorCode.
+func updateQueueErrorCode(err error) connect.Code {
+	switch {
+	case errors.Is(err, types.ErrInvalidConfig):
+		return connect.CodeInvalidArgument
+	case errors.Is(err, queue.ErrProtectedQueueMutation):
+		return connect.CodeFailedPrecondition
+	case errors.Is(err, storage.ErrQueueNotFound):
+		return connect.CodeNotFound
+	default:
+		return connect.CodeInternal
+	}
+}
+
 // --- Queue Management ---.
 func (h *Handler) CreateQueue(ctx context.Context, req *connect.Request[queuev1.CreateQueueRequest]) (*connect.Response[queuev1.Queue], error) {
 	msg := req.Msg
@@ -72,10 +106,7 @@ func (h *Handler) CreateQueue(ctx context.Context, req *connect.Request[queuev1.
 	}
 
 	if err := h.manager.CreateQueue(ctx, config); err != nil {
-		if errors.Is(err, queue.ErrProtectedQueueMutation) {
-			return nil, connect.NewError(connect.CodeFailedPrecondition, err)
-		}
-		return nil, connect.NewError(connect.CodeAlreadyExists, err)
+		return nil, connect.NewError(createQueueErrorCode(err), err)
 	}
 
 	return connect.NewResponse(h.queueToProto(&config)), nil
@@ -177,13 +208,7 @@ func (h *Handler) UpdateQueue(ctx context.Context, req *connect.Request[queuev1.
 
 	if h.manager != nil {
 		if err := h.manager.UpdateQueue(ctx, updated); err != nil {
-			if errors.Is(err, queue.ErrProtectedQueueMutation) {
-				return nil, connect.NewError(connect.CodeFailedPrecondition, err)
-			}
-			if err == storage.ErrQueueNotFound {
-				return nil, connect.NewError(connect.CodeNotFound, err)
-			}
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, connect.NewError(updateQueueErrorCode(err), err)
 		}
 		current, err := h.queueStore.GetQueue(ctx, updated.Name)
 		if err != nil {

--- a/server/queue/handler_test.go
+++ b/server/queue/handler_test.go
@@ -5,6 +5,8 @@ package queue
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sort"
 	"sync"
 	"testing"
@@ -537,5 +539,105 @@ func TestSeekToTimestamp(t *testing.T) {
 	}))
 	if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
 		t.Fatalf("unexpected code for missing timestamp: got %s want %s", got, connect.CodeInvalidArgument)
+	}
+}
+
+// A filter the broker will not accept is the caller's mistake. It has to reach
+// the client as InvalidArgument: AlreadyExists says the name is taken and
+// Internal says the server broke, and a client acting on either would retry or
+// rename instead of fixing the filter it sent.
+func TestQueueMutationsReportInvalidFiltersAsInvalidArgument(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := memlog.New()
+	groupStore := noopGroupStore{}
+	manager := queuepkg.NewManager(store, groupStore, nil, queuepkg.DefaultConfig(), nil, nil)
+	h := NewHandler(manager, store, groupStore, nil)
+
+	t.Run("create", func(t *testing.T) {
+		_, err := h.CreateQueue(ctx, connect.NewRequest(&queuev1.CreateQueueRequest{
+			Name:   "black-holed",
+			Topics: []string{"#/events"},
+		}))
+		if err == nil {
+			t.Fatal("CreateQueue accepted a filter that can never match")
+		}
+		if got := connect.CodeOf(err); got != connect.CodeInvalidArgument {
+			t.Fatalf("CreateQueue code = %v, want %v", got, connect.CodeInvalidArgument)
+		}
+	})
+
+	t.Run("create with a name already taken still reports AlreadyExists", func(t *testing.T) {
+		req := &queuev1.CreateQueueRequest{Name: "taken", Topics: []string{"$queue/taken/#"}}
+		if _, err := h.CreateQueue(ctx, connect.NewRequest(req)); err != nil {
+			t.Fatalf("CreateQueue failed: %v", err)
+		}
+		_, err := h.CreateQueue(ctx, connect.NewRequest(req))
+		if err == nil {
+			t.Fatal("CreateQueue accepted a duplicate name")
+		}
+		if got := connect.CodeOf(err); got != connect.CodeAlreadyExists {
+			t.Fatalf("CreateQueue code = %v, want %v", got, connect.CodeAlreadyExists)
+		}
+	})
+}
+
+// The update path cannot be driven to an invalid filter through the API, because
+// the proto carries no topics on update: they are settable only at creation. Its
+// mapping is still reachable — a queue persisted with a bad filter before
+// validation existed fails when updated — so the two mappings are covered
+// directly, which also pins every branch rather than the one an integration test
+// happens to reach.
+func TestQueueMutationErrorCodes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		err        error
+		wantCreate connect.Code
+		wantUpdate connect.Code
+	}{
+		{
+			name:       "invalid configuration is the caller's mistake",
+			err:        fmt.Errorf("wrapped: %w", types.ErrInvalidConfig),
+			wantCreate: connect.CodeInvalidArgument,
+			wantUpdate: connect.CodeInvalidArgument,
+		},
+		{
+			name:       "protected queue mutation is a precondition",
+			err:        queuepkg.ErrProtectedQueueMutation,
+			wantCreate: connect.CodeFailedPrecondition,
+			wantUpdate: connect.CodeFailedPrecondition,
+		},
+		{
+			name:       "name already taken",
+			err:        qstorage.ErrQueueAlreadyExists,
+			wantCreate: connect.CodeAlreadyExists,
+			wantUpdate: connect.CodeInternal,
+		},
+		{
+			name:       "queue missing",
+			err:        qstorage.ErrQueueNotFound,
+			wantCreate: connect.CodeInternal,
+			wantUpdate: connect.CodeNotFound,
+		},
+		{
+			name:       "anything else is a server fault",
+			err:        errors.New("disk on fire"),
+			wantCreate: connect.CodeInternal,
+			wantUpdate: connect.CodeInternal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := createQueueErrorCode(tt.err); got != tt.wantCreate {
+				t.Fatalf("createQueueErrorCode = %v, want %v", got, tt.wantCreate)
+			}
+			if got := updateQueueErrorCode(tt.err); got != tt.wantUpdate {
+				t.Fatalf("updateQueueErrorCode = %v, want %v", got, tt.wantUpdate)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Matching tested every registered pattern with topics.TopicMatch, under a shared read lock, on the publish path of every protocol. The cost followed the number of patterns configured rather than the topic being matched: 8 patterns 342ns, 512 22us, 8192 193us — roughly a five thousand publish per second ceiling on one core at the top end, for a broker doing nothing but deciding where a message goes.

Key both halves of the index on topic levels instead. Descending a trie costs the depth of the topic and the wildcards actually present, so it does not grow with the configuration at all. Measured flat from 8 to 8192 patterns: 37-72ns when nothing matches, 172-325ns when something does, against 193us and 197us at the top of the old range.

The same scan also served publishes addressed to a queue, which grew with the number of queues: 1.5us at 32. That is the same trie and is now 248ns, flat at 8, 512 and 8192 queues.

The no-match path stays allocation-free. Levels are walked with strings.Cut rather than split into a slice, and the result is appended to only when a queue matches.

Matching semantics are unchanged for well-formed filters, and the equivalence test says so by keeping the scan it replaced as an oracle and comparing the two over every filter and topic buildable from a small alphabet.

They differ on one malformed input, deliberately. topics.TopicMatch returns true as soon as it sees a "#", so a filter with one in a non-final position — "#/a", which MQTT does not allow — matched every topic, and a queue configured that way silently captured all traffic on the broker. The trie treats the pattern as the literal path it is and captures nothing. Neither answer is useful and nothing validates queue patterns at load, so a test pins the new behaviour rather than leaving it to whichever matcher happens to run. Rejecting such patterns at configuration load is the real fix and is not attempted here.
