### PR TITLE
[PKI PR-012] Implement relying-party certificate integration

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -804,6 +804,9 @@ components:
         cache_invalidations:
           type: integer
           format: uint64
+        sessions_disconnected:
+          type: integer
+          format: uint64
         tenant_denials:
           type: integer
           format: uint64

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -767,6 +767,53 @@ components:
         pending:
           $ref: "#/components/schemas/QueuePendingStats"
 
+    CertificateMetrics:
+      type: object
+      description: Label-free Atom certificate resolver, cache, event, and trust counters.
+      properties:
+        active_sessions:
+          type: integer
+          format: int64
+        resolver_requests:
+          type: integer
+          format: uint64
+        resolver_failures:
+          type: integer
+          format: uint64
+        resolver_timeouts:
+          type: integer
+          format: uint64
+        cache_hits:
+          type: integer
+          format: uint64
+        cache_misses:
+          type: integer
+          format: uint64
+        cache_evictions:
+          type: integer
+          format: uint64
+        cache_entries:
+          type: integer
+          format: int64
+        events_received:
+          type: integer
+          format: uint64
+        events_rejected:
+          type: integer
+          format: uint64
+        cache_invalidations:
+          type: integer
+          format: uint64
+        tenant_denials:
+          type: integer
+          format: uint64
+        trust_refresh_success:
+          type: integer
+          format: uint64
+        trust_refresh_failures:
+          type: integer
+          format: uint64
+
     StatsResponse:
       type: object
       description: |
@@ -793,6 +840,8 @@ components:
           $ref: "#/components/schemas/ByProtocolStats"
         queues:
           $ref: "#/components/schemas/QueueStats"
+        certificates:
+          $ref: "#/components/schemas/CertificateMetrics"
 
     # ── Cluster ──
 

--- a/broker/auth.go
+++ b/broker/auth.go
@@ -3,7 +3,11 @@
 
 package broker
 
-import "time"
+import (
+	"context"
+	"sync"
+	"time"
+)
 
 // Default bounds for the identity cache. These are deliberately conservative;
 // operators with large client populations should raise IdentityCacheSize.
@@ -38,8 +42,9 @@ type Authorizer interface {
 type AuthEngineOption func(*authEngineOptions)
 
 type authEngineOptions struct {
-	cacheSize int
-	cacheTTL  time.Duration
+	cacheSize       int
+	cacheTTL        time.Duration
+	certificateAuth CertificateAuthenticator
 }
 
 // WithIdentityCache sets the bounded identity-cache size and TTL. A non-positive
@@ -51,6 +56,14 @@ func WithIdentityCache(size int, ttl time.Duration) AuthEngineOption {
 	}
 }
 
+// WithCertificateAuthentication enables resolver-tier authentication for MQTT
+// transports that present a verified peer leaf certificate.
+func WithCertificateAuthentication(auth CertificateAuthenticator) AuthEngineOption {
+	return func(o *authEngineOptions) {
+		o.certificateAuth = auth
+	}
+}
+
 // AuthEngine handles authentication and authorization.
 // It transparently maps protocol-level client IDs to external identities
 // returned by the Authenticator, so protocol handlers don't need to be
@@ -59,9 +72,13 @@ func WithIdentityCache(size int, ttl time.Duration) AuthEngineOption {
 // The identity cache is bounded (TTL + LRU) so misbehaving disconnect
 // paths cannot leak memory.
 type AuthEngine struct {
-	auth       Authenticator
-	authz      Authorizer
-	identities *identityCache
+	auth            Authenticator
+	authz           Authorizer
+	identities      *identityCache
+	certificateAuth CertificateAuthenticator
+	certificateMu   sync.RWMutex
+	certificates    map[string]CertificateIdentity
+	certificateCap  int
 }
 
 // NewAuthEngine creates a new AuthEngine with the given authenticator and authorizer.
@@ -75,9 +92,12 @@ func NewAuthEngine(auth Authenticator, authz Authorizer, opts ...AuthEngineOptio
 		fn(&o)
 	}
 	return &AuthEngine{
-		auth:       auth,
-		authz:      authz,
-		identities: newIdentityCache(o.cacheSize, o.cacheTTL),
+		auth:            auth,
+		authz:           authz,
+		identities:      newIdentityCache(o.cacheSize, o.cacheTTL),
+		certificateAuth: o.certificateAuth,
+		certificates:    make(map[string]CertificateIdentity),
+		certificateCap:  o.cacheSize,
 	}
 }
 
@@ -87,26 +107,69 @@ func NewAuthEngine(auth Authenticator, authz Authorizer, opts ...AuthEngineOptio
 // authenticator did not provide one) and caches it for subsequent
 // authorization calls.
 func (e *AuthEngine) Authenticate(clientID, username, password string) (bool, string, error) {
+	return e.AuthenticateWithPeer(context.Background(), clientID, username, password, PeerCertificate{})
+}
+
+// AuthenticateWithPeer authenticates a verified TLS leaf through Atom when a
+// certificate resolver is configured. Connections without a leaf follow the
+// historical username/secret path unchanged.
+func (e *AuthEngine) AuthenticateWithPeer(ctx context.Context, clientID, username, password string, peer PeerCertificate) (bool, string, error) {
+	if len(peer.LeafDER) != 0 && e.certificateAuth != nil {
+		identity, err := e.certificateAuth.AuthenticateCertificate(ctx, peer)
+		if err != nil {
+			return false, "", err
+		}
+		if identity.EntityID == "" || identity.CredentialID == "" || identity.Fingerprint == "" {
+			return false, "", nil
+		}
+
+		e.certificateMu.Lock()
+		existing, exists := e.certificates[clientID]
+		if exists && existing.EntityID != identity.EntityID {
+			e.certificateMu.Unlock()
+			return false, "", ErrCertificateClientIdentityConflict
+		}
+		if !exists && e.certificateCap > 0 && len(e.certificates) >= e.certificateCap {
+			e.certificateMu.Unlock()
+			return false, "", ErrCertificateSessionCapacity
+		}
+		e.certificates[clientID] = identity
+		e.certificateMu.Unlock()
+		e.identities.Store(clientID, identity.EntityID)
+		return true, identity.EntityID, nil
+	}
+
 	if e.auth == nil {
+		e.removeCertificateIdentity(clientID)
+		e.identities.Delete(clientID)
 		return true, "", nil
 	}
 	result, err := e.auth.Authenticate(clientID, username, password)
 	if err != nil {
 		return false, "", err
 	}
-	if result == nil {
+	if result == nil || !result.Authenticated {
 		return false, "", nil
 	}
-	if result.Authenticated && result.ID != "" {
+
+	// Replace an existing certificate binding only after the alternate
+	// credential has authenticated. A rejected takeover must not strip tenant
+	// enforcement from the currently connected certificate session.
+	e.removeCertificateIdentity(clientID)
+	if result.ID != "" {
 		e.identities.Store(clientID, result.ID)
 		return true, result.ID, nil
 	}
-	return result.Authenticated, "", nil
+	e.identities.Delete(clientID)
+	return true, "", nil
 }
 
 // CanPublish checks if a client is authorized to publish to a topic.
 // Returns true if authorized or if no authorizer is configured.
 func (e *AuthEngine) CanPublish(clientID, topic string) bool {
+	if !e.authorizeCertificate(clientID, topic) {
+		return false
+	}
 	if e.authz == nil {
 		return true
 	}
@@ -116,6 +179,9 @@ func (e *AuthEngine) CanPublish(clientID, topic string) bool {
 // CanSubscribe checks if a client is authorized to subscribe to a topic filter.
 // Returns true if authorized or if no authorizer is configured.
 func (e *AuthEngine) CanSubscribe(clientID, filter string) bool {
+	if !e.authorizeCertificate(clientID, filter) {
+		return false
+	}
 	if e.authz == nil {
 		return true
 	}
@@ -125,11 +191,18 @@ func (e *AuthEngine) CanSubscribe(clientID, filter string) bool {
 // Forget removes the cached identity mapping for a client.
 // Should be called when a client disconnects.
 func (e *AuthEngine) Forget(clientID string) {
+	e.removeCertificateIdentity(clientID)
 	e.identities.Delete(clientID)
 }
 
 // SetExternalID stores or replaces the resolved external identity for a client.
 func (e *AuthEngine) SetExternalID(clientID, externalID string) {
+	if identity, ok := e.certificateIdentity(clientID); ok {
+		// A hook may deny the connection, but it cannot replace Atom's resolved
+		// certificate identity with a different subject.
+		e.identities.Store(clientID, identity.EntityID)
+		return
+	}
 	if externalID == "" {
 		e.identities.Delete(clientID)
 		return
@@ -139,6 +212,9 @@ func (e *AuthEngine) SetExternalID(clientID, externalID string) {
 
 // ExternalID returns the authenticated external identity for a protocol client ID.
 func (e *AuthEngine) ExternalID(clientID string) string {
+	if identity, ok := e.certificateIdentity(clientID); ok {
+		return identity.EntityID
+	}
 	id, _ := e.identities.Load(clientID)
 	return id
 }
@@ -148,6 +224,38 @@ func (e *AuthEngine) ExternalID(clientID string) string {
 // count points to leaked Forget calls.
 func (e *AuthEngine) IdentityCacheLen() int {
 	return e.identities.Len()
+}
+
+// CertificateSessionCount returns bounded certificate session state for
+// operational monitoring. It contains no identity labels.
+func (e *AuthEngine) CertificateSessionCount() int {
+	e.certificateMu.RLock()
+	defer e.certificateMu.RUnlock()
+	return len(e.certificates)
+}
+
+func (e *AuthEngine) authorizeCertificate(clientID, topic string) bool {
+	identity, ok := e.certificateIdentity(clientID)
+	if !ok {
+		return true
+	}
+	if e.certificateAuth == nil {
+		return false
+	}
+	return e.certificateAuth.AuthorizeCertificate(context.Background(), identity, topic) == nil
+}
+
+func (e *AuthEngine) certificateIdentity(clientID string) (CertificateIdentity, bool) {
+	e.certificateMu.RLock()
+	defer e.certificateMu.RUnlock()
+	identity, ok := e.certificates[clientID]
+	return identity, ok
+}
+
+func (e *AuthEngine) removeCertificateIdentity(clientID string) {
+	e.certificateMu.Lock()
+	delete(e.certificates, clientID)
+	e.certificateMu.Unlock()
 }
 
 func (e *AuthEngine) resolveID(clientID string) string {

--- a/broker/auth.go
+++ b/broker/auth.go
@@ -162,14 +162,13 @@ func (e *AuthEngine) AuthenticateWithPeer(ctx context.Context, clientID, usernam
 		return true, identity.EntityID, nil
 	}
 
-	if current, pending := e.certificateState(clientID); current || pending {
-		if pending && !current {
-			return false, "", ErrCertificateAuthenticationPending
-		}
-		return false, "", ErrCertificateClientIdentityConflict
-	}
-
 	if e.auth == nil {
+		if current, pending := e.certificateState(clientID); current || pending {
+			if pending && !current {
+				return false, "", ErrCertificateAuthenticationPending
+			}
+			return false, "", ErrCertificateClientIdentityConflict
+		}
 		e.identities.Delete(clientID)
 		return true, "", nil
 	}

--- a/broker/auth.go
+++ b/broker/auth.go
@@ -128,7 +128,9 @@ func (e *AuthEngine) AuthenticateContext(ctx context.Context, clientID, username
 
 // AuthenticateWithPeer authenticates a verified TLS leaf through Atom when a
 // certificate resolver is configured. Connections without a leaf follow the
-// historical username/secret path unchanged.
+// historical username/secret path unchanged: failed ordinary credentials stay
+// an ordinary denial, while a successful attempt is rejected before it can
+// replace a live certificate binding.
 func (e *AuthEngine) AuthenticateWithPeer(ctx context.Context, clientID, username, password string, peer PeerCertificate) (bool, string, error) {
 	if len(peer.LeafDER) != 0 && e.certificateAuth != nil {
 		identity, err := e.certificateAuth.AuthenticateCertificate(ctx, peer)

--- a/broker/auth.go
+++ b/broker/auth.go
@@ -48,7 +48,8 @@ type authEngineOptions struct {
 }
 
 // WithIdentityCache sets the bounded identity-cache size and TTL. A non-positive
-// size disables size-based eviction; a non-positive TTL disables expiry.
+// size disables size-based eviction for ordinary identities; certificate
+// session bindings retain the default bound. A non-positive TTL disables expiry.
 func WithIdentityCache(size int, ttl time.Duration) AuthEngineOption {
 	return func(o *authEngineOptions) {
 		o.cacheSize = size
@@ -78,6 +79,9 @@ type AuthEngine struct {
 	certificateAuth CertificateAuthenticator
 	certificateMu   sync.RWMutex
 	certificates    map[string]CertificateIdentity
+	pendingCerts    map[string]CertificateIdentity
+	certBindings    map[string]uint64
+	nextCertBinding uint64
 	certificateCap  int
 }
 
@@ -91,13 +95,19 @@ func NewAuthEngine(auth Authenticator, authz Authorizer, opts ...AuthEngineOptio
 	for _, fn := range opts {
 		fn(&o)
 	}
+	certificateCap := o.cacheSize
+	if o.certificateAuth != nil && certificateCap <= 0 {
+		certificateCap = DefaultIdentityCacheSize
+	}
 	return &AuthEngine{
 		auth:            auth,
 		authz:           authz,
 		identities:      newIdentityCache(o.cacheSize, o.cacheTTL),
 		certificateAuth: o.certificateAuth,
 		certificates:    make(map[string]CertificateIdentity),
-		certificateCap:  o.cacheSize,
+		pendingCerts:    make(map[string]CertificateIdentity),
+		certBindings:    make(map[string]uint64),
+		certificateCap:  certificateCap,
 	}
 }
 
@@ -124,23 +134,36 @@ func (e *AuthEngine) AuthenticateWithPeer(ctx context.Context, clientID, usernam
 		}
 
 		e.certificateMu.Lock()
+		if _, pending := e.pendingCerts[clientID]; pending {
+			e.certificateMu.Unlock()
+			return false, "", ErrCertificateAuthenticationPending
+		}
 		existing, exists := e.certificates[clientID]
 		if exists && existing.EntityID != identity.EntityID {
 			e.certificateMu.Unlock()
 			return false, "", ErrCertificateClientIdentityConflict
 		}
-		if !exists && e.certificateCap > 0 && len(e.certificates) >= e.certificateCap {
+		if !exists && e.certificateCap > 0 && len(e.certificates)+len(e.pendingCerts) >= e.certificateCap {
 			e.certificateMu.Unlock()
 			return false, "", ErrCertificateSessionCapacity
 		}
-		e.certificates[clientID] = identity
+		// Authentication is not a live session yet. Hold the resolution pending
+		// until the protocol handler has completed hooks and persistent-session
+		// ownership checks. This also serializes concurrent CONNECT attempts for
+		// one client ID, so neither attempt can commit the other's credential.
+		e.pendingCerts[clientID] = identity
 		e.certificateMu.Unlock()
-		e.identities.Store(clientID, identity.EntityID)
 		return true, identity.EntityID, nil
 	}
 
+	if current, pending := e.certificateState(clientID); current || pending {
+		if pending && !current {
+			return false, "", ErrCertificateAuthenticationPending
+		}
+		return false, "", ErrCertificateClientIdentityConflict
+	}
+
 	if e.auth == nil {
-		e.removeCertificateIdentity(clientID)
 		e.identities.Delete(clientID)
 		return true, "", nil
 	}
@@ -152,15 +175,26 @@ func (e *AuthEngine) AuthenticateWithPeer(ctx context.Context, clientID, usernam
 		return false, "", nil
 	}
 
-	// Replace an existing certificate binding only after the alternate
-	// credential has authenticated. A rejected takeover must not strip tenant
-	// enforcement from the currently connected certificate session.
-	e.removeCertificateIdentity(clientID)
+	// Recheck after the external call: a concurrent certificate attempt may
+	// have claimed this client ID while ordinary credentials were being
+	// validated. Never strip that binding from the other attempt.
+	e.certificateMu.RLock()
+	_, currentCertificate := e.certificates[clientID]
+	_, pendingCertificate := e.pendingCerts[clientID]
+	if currentCertificate || pendingCertificate {
+		e.certificateMu.RUnlock()
+		if pendingCertificate && !currentCertificate {
+			return false, "", ErrCertificateAuthenticationPending
+		}
+		return false, "", ErrCertificateClientIdentityConflict
+	}
 	if result.ID != "" {
 		e.identities.Store(clientID, result.ID)
+		e.certificateMu.RUnlock()
 		return true, result.ID, nil
 	}
 	e.identities.Delete(clientID)
+	e.certificateMu.RUnlock()
 	return true, "", nil
 }
 
@@ -191,13 +225,14 @@ func (e *AuthEngine) CanSubscribe(clientID, filter string) bool {
 // Forget removes the cached identity mapping for a client.
 // Should be called when a client disconnects.
 func (e *AuthEngine) Forget(clientID string) {
-	e.removeCertificateIdentity(clientID)
-	e.identities.Delete(clientID)
+	if e.rejectPendingOrForgetCertificate(clientID) {
+		e.identities.Delete(clientID)
+	}
 }
 
 // SetExternalID stores or replaces the resolved external identity for a client.
 func (e *AuthEngine) SetExternalID(clientID, externalID string) {
-	if identity, ok := e.certificateIdentity(clientID); ok {
+	if identity, ok := e.certificateAuthenticationIdentity(clientID); ok {
 		// A hook may deny the connection, but it cannot replace Atom's resolved
 		// certificate identity with a different subject.
 		e.identities.Store(clientID, identity.EntityID)
@@ -212,7 +247,7 @@ func (e *AuthEngine) SetExternalID(clientID, externalID string) {
 
 // ExternalID returns the authenticated external identity for a protocol client ID.
 func (e *AuthEngine) ExternalID(clientID string) string {
-	if identity, ok := e.certificateIdentity(clientID); ok {
+	if identity, ok := e.certificateAuthenticationIdentity(clientID); ok {
 		return identity.EntityID
 	}
 	id, _ := e.identities.Load(clientID)
@@ -234,6 +269,82 @@ func (e *AuthEngine) CertificateSessionCount() int {
 	return len(e.certificates)
 }
 
+// CertificateAuthenticationEnabled reports whether this engine has an Atom
+// certificate resolver configured.
+func (e *AuthEngine) CertificateAuthenticationEnabled() bool {
+	return e.certificateAuth != nil
+}
+
+// CommitCertificateAuthentication promotes a same-entity reconnect that was
+// held pending while the old connection remained live. It returns the binding
+// generation that the MQTT session must retain for generation-safe cleanup.
+func (e *AuthEngine) CommitCertificateAuthentication(clientID string) (uint64, bool) {
+	e.certificateMu.Lock()
+	pending, ok := e.pendingCerts[clientID]
+	if !ok {
+		e.certificateMu.Unlock()
+		return 0, false
+	}
+	e.certificates[clientID] = pending
+	delete(e.pendingCerts, clientID)
+	binding := e.nextCertificateBindingLocked()
+	e.certBindings[clientID] = binding
+	e.certificateMu.Unlock()
+	e.identities.Store(clientID, pending.EntityID)
+	return binding, true
+}
+
+// CertificateSessionBinding returns the current live binding generation.
+func (e *AuthEngine) CertificateSessionBinding(clientID string) (uint64, bool) {
+	e.certificateMu.RLock()
+	defer e.certificateMu.RUnlock()
+	binding, ok := e.certBindings[clientID]
+	return binding, ok && binding != 0
+}
+
+// ForgetCertificateSession removes a binding only when its generation still
+// matches. A delayed disconnect from a replaced connection therefore cannot
+// erase the certificate identity of its replacement.
+func (e *AuthEngine) ForgetCertificateSession(clientID string, binding uint64) {
+	e.certificateMu.Lock()
+	if binding == 0 || e.certBindings[clientID] != binding {
+		e.certificateMu.Unlock()
+		return
+	}
+	delete(e.certificates, clientID)
+	delete(e.certBindings, clientID)
+	e.certificateMu.Unlock()
+	e.identities.Delete(clientID)
+}
+
+// InvalidateCertificateSessions atomically removes certificate bindings that
+// match a lifecycle event and returns the affected protocol client IDs. The
+// caller can then disconnect those live sessions without holding auth locks.
+func (e *AuthEngine) InvalidateCertificateSessions(match func(CertificateIdentity) bool) []string {
+	if match == nil {
+		return nil
+	}
+	e.certificateMu.Lock()
+	clientIDs := make([]string, 0)
+	for clientID, identity := range e.certificates {
+		if match(identity) {
+			delete(e.certificates, clientID)
+			delete(e.certBindings, clientID)
+			clientIDs = append(clientIDs, clientID)
+		}
+	}
+	for clientID, identity := range e.pendingCerts {
+		if match(identity) {
+			delete(e.pendingCerts, clientID)
+		}
+	}
+	e.certificateMu.Unlock()
+	for _, clientID := range clientIDs {
+		e.identities.Delete(clientID)
+	}
+	return clientIDs
+}
+
 func (e *AuthEngine) authorizeCertificate(clientID, topic string) bool {
 	identity, ok := e.certificateIdentity(clientID)
 	if !ok {
@@ -252,10 +363,48 @@ func (e *AuthEngine) certificateIdentity(clientID string) (CertificateIdentity, 
 	return identity, ok
 }
 
-func (e *AuthEngine) removeCertificateIdentity(clientID string) {
+// certificateAuthenticationIdentity includes an in-progress authentication
+// only when there is no committed identity. A reconnect is constrained to the
+// same entity before it enters pending state, so the committed value remains
+// authoritative for an already-live session.
+func (e *AuthEngine) certificateAuthenticationIdentity(clientID string) (CertificateIdentity, bool) {
+	e.certificateMu.RLock()
+	defer e.certificateMu.RUnlock()
+	if identity, ok := e.certificates[clientID]; ok {
+		return identity, true
+	}
+	identity, ok := e.pendingCerts[clientID]
+	return identity, ok
+}
+
+func (e *AuthEngine) certificateState(clientID string) (current, pending bool) {
+	e.certificateMu.RLock()
+	defer e.certificateMu.RUnlock()
+	_, current = e.certificates[clientID]
+	_, pending = e.pendingCerts[clientID]
+	return current, pending
+}
+
+func (e *AuthEngine) rejectPendingOrForgetCertificate(clientID string) bool {
 	e.certificateMu.Lock()
+	if _, pending := e.pendingCerts[clientID]; pending {
+		delete(e.pendingCerts, clientID)
+		_, current := e.certificates[clientID]
+		e.certificateMu.Unlock()
+		return !current
+	}
 	delete(e.certificates, clientID)
+	delete(e.certBindings, clientID)
 	e.certificateMu.Unlock()
+	return true
+}
+
+func (e *AuthEngine) nextCertificateBindingLocked() uint64 {
+	e.nextCertBinding++
+	if e.nextCertBinding == 0 {
+		e.nextCertBinding++
+	}
+	return e.nextCertBinding
 }
 
 func (e *AuthEngine) resolveID(clientID string) string {

--- a/broker/auth.go
+++ b/broker/auth.go
@@ -117,7 +117,13 @@ func NewAuthEngine(auth Authenticator, authz Authorizer, opts ...AuthEngineOptio
 // authenticator did not provide one) and caches it for subsequent
 // authorization calls.
 func (e *AuthEngine) Authenticate(clientID, username, password string) (bool, string, error) {
-	return e.AuthenticateWithPeer(context.Background(), clientID, username, password, PeerCertificate{})
+	return e.AuthenticateContext(context.Background(), clientID, username, password)
+}
+
+// AuthenticateContext is the context-aware form of Authenticate for protocol
+// adapters that already own a request context.
+func (e *AuthEngine) AuthenticateContext(ctx context.Context, clientID, username, password string) (bool, string, error) {
+	return e.AuthenticateWithPeer(ctx, clientID, username, password, PeerCertificate{})
 }
 
 // AuthenticateWithPeer authenticates a verified TLS leaf through Atom when a
@@ -201,7 +207,12 @@ func (e *AuthEngine) AuthenticateWithPeer(ctx context.Context, clientID, usernam
 // CanPublish checks if a client is authorized to publish to a topic.
 // Returns true if authorized or if no authorizer is configured.
 func (e *AuthEngine) CanPublish(clientID, topic string) bool {
-	if !e.authorizeCertificate(clientID, topic) {
+	return e.CanPublishContext(context.Background(), clientID, topic)
+}
+
+// CanPublishContext is the context-aware form of CanPublish.
+func (e *AuthEngine) CanPublishContext(ctx context.Context, clientID, topic string) bool {
+	if !e.authorizeCertificate(ctx, clientID, topic) {
 		return false
 	}
 	if e.authz == nil {
@@ -213,7 +224,12 @@ func (e *AuthEngine) CanPublish(clientID, topic string) bool {
 // CanSubscribe checks if a client is authorized to subscribe to a topic filter.
 // Returns true if authorized or if no authorizer is configured.
 func (e *AuthEngine) CanSubscribe(clientID, filter string) bool {
-	if !e.authorizeCertificate(clientID, filter) {
+	return e.CanSubscribeContext(context.Background(), clientID, filter)
+}
+
+// CanSubscribeContext is the context-aware form of CanSubscribe.
+func (e *AuthEngine) CanSubscribeContext(ctx context.Context, clientID, filter string) bool {
+	if !e.authorizeCertificate(ctx, clientID, filter) {
 		return false
 	}
 	if e.authz == nil {
@@ -227,13 +243,19 @@ func (e *AuthEngine) CanSubscribe(clientID, filter string) bool {
 // The pending Atom identity is used directly so a hook or prior client-ID
 // mapping cannot change the subject presented to normal authorization.
 func (e *AuthEngine) CanPublishPendingCertificate(clientID, topic string) bool {
+	return e.CanPublishPendingCertificateContext(context.Background(), clientID, topic)
+}
+
+// CanPublishPendingCertificateContext is the context-aware form of
+// CanPublishPendingCertificate.
+func (e *AuthEngine) CanPublishPendingCertificateContext(ctx context.Context, clientID, topic string) bool {
 	e.certificateMu.RLock()
 	identity, ok := e.pendingCerts[clientID]
 	e.certificateMu.RUnlock()
 	if !ok || e.certificateAuth == nil {
 		return false
 	}
-	if e.certificateAuth.AuthorizeCertificate(context.Background(), identity, topic) != nil {
+	if e.certificateAuth.AuthorizeCertificate(ctx, identity, topic) != nil {
 		return false
 	}
 	if e.authz == nil {
@@ -365,7 +387,7 @@ func (e *AuthEngine) InvalidateCertificateSessions(match func(CertificateIdentit
 	return clientIDs
 }
 
-func (e *AuthEngine) authorizeCertificate(clientID, topic string) bool {
+func (e *AuthEngine) authorizeCertificate(ctx context.Context, clientID, topic string) bool {
 	identity, ok := e.certificateIdentity(clientID)
 	if !ok {
 		return true
@@ -373,7 +395,7 @@ func (e *AuthEngine) authorizeCertificate(clientID, topic string) bool {
 	if e.certificateAuth == nil {
 		return false
 	}
-	return e.certificateAuth.AuthorizeCertificate(context.Background(), identity, topic) == nil
+	return e.certificateAuth.AuthorizeCertificate(ctx, identity, topic) == nil
 }
 
 func (e *AuthEngine) certificateIdentity(clientID string) (CertificateIdentity, bool) {

--- a/broker/auth.go
+++ b/broker/auth.go
@@ -222,6 +222,26 @@ func (e *AuthEngine) CanSubscribe(clientID, filter string) bool {
 	return e.authz.CanSubscribe(e.resolveID(clientID), filter)
 }
 
+// CanPublishPendingCertificate authorizes a publish requested as part of
+// CONNECT (notably an MQTT Will) before the certificate binding is committed.
+// The pending Atom identity is used directly so a hook or prior client-ID
+// mapping cannot change the subject presented to normal authorization.
+func (e *AuthEngine) CanPublishPendingCertificate(clientID, topic string) bool {
+	e.certificateMu.RLock()
+	identity, ok := e.pendingCerts[clientID]
+	e.certificateMu.RUnlock()
+	if !ok || e.certificateAuth == nil {
+		return false
+	}
+	if e.certificateAuth.AuthorizeCertificate(context.Background(), identity, topic) != nil {
+		return false
+	}
+	if e.authz == nil {
+		return true
+	}
+	return e.authz.CanPublish(identity.EntityID, topic)
+}
+
 // Forget removes the cached identity mapping for a client.
 // Should be called when a client disconnects.
 func (e *AuthEngine) Forget(clientID string) {

--- a/broker/certificate.go
+++ b/broker/certificate.go
@@ -1,0 +1,65 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"context"
+	"time"
+)
+
+// CertificateIdentity is the minimum resolver result retained by the broker.
+// It deliberately excludes certificate subjects, public keys, and DER.
+type CertificateIdentity struct {
+	EntityID     string
+	TenantID     string
+	CredentialID string
+	IssuerID     string
+	Fingerprint  string
+	ExpiresAt    time.Time
+}
+
+// PeerCertificate contains the verified TLS material extracted by a transport.
+// IssuerDER is optional for chains in which the peer sent only the leaf.
+type PeerCertificate struct {
+	LeafDER   []byte
+	IssuerDER []byte
+}
+
+// CertificateAuthenticator authoritatively resolves a peer certificate and
+// revalidates its tenant binding before normal operation authorization.
+type CertificateAuthenticator interface {
+	AuthenticateCertificate(ctx context.Context, peer PeerCertificate) (CertificateIdentity, error)
+	AuthorizeCertificate(ctx context.Context, identity CertificateIdentity, topic string) error
+}
+
+// PeerCertificateSource is implemented by transports that terminate TLS and
+// can expose the verified peer leaf to the authentication layer.
+type PeerCertificateSource interface {
+	PeerCertificateDER() []byte
+	PeerIssuerCertificateDER() []byte
+}
+
+// CertificateMetrics is a label-free snapshot suitable for the admin API.
+// Identity values are intentionally never exposed as metric labels.
+type CertificateMetrics struct {
+	ActiveSessions       int    `json:"active_sessions"`
+	ResolverRequests     uint64 `json:"resolver_requests"`
+	ResolverFailures     uint64 `json:"resolver_failures"`
+	ResolverTimeouts     uint64 `json:"resolver_timeouts"`
+	CacheHits            uint64 `json:"cache_hits"`
+	CacheMisses          uint64 `json:"cache_misses"`
+	CacheEvictions       uint64 `json:"cache_evictions"`
+	CacheEntries         int    `json:"cache_entries"`
+	EventsReceived       uint64 `json:"events_received"`
+	EventsRejected       uint64 `json:"events_rejected"`
+	CacheInvalidations   uint64 `json:"cache_invalidations"`
+	TenantDenials        uint64 `json:"tenant_denials"`
+	TrustRefreshSuccess  uint64 `json:"trust_refresh_success"`
+	TrustRefreshFailures uint64 `json:"trust_refresh_failures"`
+}
+
+// CertificateMetricsProvider supplies a current operational snapshot.
+type CertificateMetricsProvider interface {
+	CertificateMetrics() CertificateMetrics
+}

--- a/broker/certificate.go
+++ b/broker/certificate.go
@@ -54,6 +54,7 @@ type CertificateMetrics struct {
 	EventsReceived       uint64 `json:"events_received"`
 	EventsRejected       uint64 `json:"events_rejected"`
 	CacheInvalidations   uint64 `json:"cache_invalidations"`
+	SessionsDisconnected uint64 `json:"sessions_disconnected"`
 	TenantDenials        uint64 `json:"tenant_denials"`
 	TrustRefreshSuccess  uint64 `json:"trust_refresh_success"`
 	TrustRefreshFailures uint64 `json:"trust_refresh_failures"`

--- a/broker/certificate.go
+++ b/broker/certificate.go
@@ -40,6 +40,16 @@ type PeerCertificateSource interface {
 	PeerIssuerCertificateDER() []byte
 }
 
+// CertificateAuthenticationSource is implemented by transports that are
+// explicitly configured to authenticate verified peer certificates through
+// Atom. A TLS listener can request or verify client certificates for purposes
+// unrelated to MQTT authentication, so the presence of a verified leaf alone
+// must never select the certificate-authentication path.
+type CertificateAuthenticationSource interface {
+	PeerCertificateSource
+	CertificateAuthenticationEnabled() bool
+}
+
 // CertificateMetrics is a label-free snapshot suitable for the admin API.
 // Identity values are intentionally never exposed as metric labels.
 type CertificateMetrics struct {

--- a/broker/certificate_test.go
+++ b/broker/certificate_test.go
@@ -16,6 +16,7 @@ const (
 	testCertificateClientID     = "mqtt-client"
 	testCertificateEntityID     = "8a0a5c59-4ea8-4fc1-badb-f96cf739b224"
 	testCertificateCredentialID = "ca49950c-3ed2-41b4-a319-896085285686"
+	testRotatedCredentialID     = "05119e28-6260-4a06-8742-f925bcfdccd4"
 	testCertificateFingerprint  = "abc123"
 	testCertificateGlobalTopic  = "$SYS/global/status"
 )
@@ -134,7 +135,7 @@ func TestAuthEngineCertificateRotationRebindsClientBeforeNextOperation(t *testin
 	oldBinding, committed := engine.CommitCertificateAuthentication(testCertificateClientID)
 	require.True(t, committed)
 
-	certificateAuth.identity.CredentialID = "05119e28-6260-4a06-8742-f925bcfdccd4"
+	certificateAuth.identity.CredentialID = testRotatedCredentialID
 	certificateAuth.identity.Fingerprint = "new-fingerprint"
 	_, _, err = engine.AuthenticateWithPeer(context.Background(), testCertificateClientID, "", "", PeerCertificate{LeafDER: []byte{2}})
 	require.NoError(t, err)
@@ -160,7 +161,7 @@ func TestAuthEngineRejectsCrossEntityCertificateClientIDTakeover(t *testing.T) {
 	require.True(t, committed)
 
 	certificateAuth.identity.EntityID = "ac47c9fd-1d4a-4270-bb11-ab6476a0bd3a"
-	certificateAuth.identity.CredentialID = "05119e28-6260-4a06-8742-f925bcfdccd4"
+	certificateAuth.identity.CredentialID = testRotatedCredentialID
 	certificateAuth.identity.Fingerprint = "second-fingerprint"
 	_, _, err = engine.AuthenticateWithPeer(context.Background(), testCertificateClientID, "", "", PeerCertificate{LeafDER: []byte{2}})
 	require.ErrorIs(t, err, ErrCertificateClientIdentityConflict)
@@ -258,7 +259,7 @@ func TestAuthEngineRejectedReconnectPreservesCommittedCertificate(t *testing.T) 
 	oldBinding, committed := engine.CommitCertificateAuthentication(testCertificateClientID)
 	require.True(t, committed)
 
-	certificateAuth.identity.CredentialID = "05119e28-6260-4a06-8742-f925bcfdccd4"
+	certificateAuth.identity.CredentialID = testRotatedCredentialID
 	certificateAuth.identity.Fingerprint = "rejected-fingerprint"
 	_, _, err = engine.AuthenticateWithPeer(context.Background(), testCertificateClientID, "", "", PeerCertificate{LeafDER: []byte{2}})
 	require.NoError(t, err)

--- a/broker/certificate_test.go
+++ b/broker/certificate_test.go
@@ -202,6 +202,27 @@ func TestRejectedPlainTakeoverPreservesCertificateSession(t *testing.T) {
 	require.Equal(t, 1, certificateAuth.authorizeCalls)
 }
 
+func TestAuthenticatedPlainTakeoverIsRejectedAndPreservesCertificateSession(t *testing.T) {
+	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
+		EntityID:     testCertificateEntityID,
+		CredentialID: testCertificateCredentialID,
+		Fingerprint:  testCertificateFingerprint,
+	}}
+	authn := &stubAuthenticator{result: &AuthnResult{Authenticated: true, ID: "attacker"}}
+	engine := NewAuthEngine(authn, nil, WithCertificateAuthentication(certificateAuth))
+	_, _, err := engine.AuthenticateWithPeer(context.Background(), testCertificateClientID, "", "", PeerCertificate{LeafDER: []byte{1}})
+	require.NoError(t, err)
+	_, committed := engine.CommitCertificateAuthentication(testCertificateClientID)
+	require.True(t, committed)
+
+	ok, _, err := engine.Authenticate(testCertificateClientID, "attacker", "valid")
+	require.False(t, ok)
+	require.ErrorIs(t, err, ErrCertificateClientIdentityConflict)
+	require.Equal(t, 1, engine.CertificateSessionCount())
+	require.Equal(t, certificateAuth.identity.EntityID, engine.ExternalID(testCertificateClientID))
+	require.True(t, engine.CanPublish(testCertificateClientID, testCertificateGlobalTopic))
+}
+
 func TestAuthEngineSerializesConcurrentCertificateAuthentication(t *testing.T) {
 	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
 		EntityID:     testCertificateEntityID,

--- a/broker/certificate_test.go
+++ b/broker/certificate_test.go
@@ -12,6 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	testCertificateClientID     = "mqtt-client"
+	testCertificateEntityID     = "8a0a5c59-4ea8-4fc1-badb-f96cf739b224"
+	testCertificateCredentialID = "ca49950c-3ed2-41b4-a319-896085285686"
+	testCertificateFingerprint  = "abc123"
+	testCertificateGlobalTopic  = "$SYS/global/status"
+)
+
 type certificateAuthenticatorStub struct {
 	identity               CertificateIdentity
 	authenticateErr        error
@@ -35,10 +43,10 @@ func (stub *certificateAuthenticatorStub) AuthorizeCertificate(_ context.Context
 
 func TestAuthEngineCertificateIdentityPrecedesNormalAuthorization(t *testing.T) {
 	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
-		EntityID:     "8a0a5c59-4ea8-4fc1-badb-f96cf739b224",
+		EntityID:     testCertificateEntityID,
 		TenantID:     "d204f7df-8293-4194-963b-a47a65bc8f04",
-		CredentialID: "ca49950c-3ed2-41b4-a319-896085285686",
-		Fingerprint:  "abc123",
+		CredentialID: testCertificateCredentialID,
+		Fingerprint:  testCertificateFingerprint,
 		ExpiresAt:    time.Now().Add(time.Hour),
 	}}
 	authorizer := &stubAuthorizer{allow: true}
@@ -46,7 +54,7 @@ func TestAuthEngineCertificateIdentityPrecedesNormalAuthorization(t *testing.T) 
 
 	ok, entityID, err := engine.AuthenticateWithPeer(
 		context.Background(),
-		"mqtt-client",
+		testCertificateClientID,
 		"ignored",
 		"ignored",
 		PeerCertificate{LeafDER: []byte{1, 2, 3}},
@@ -54,7 +62,9 @@ func TestAuthEngineCertificateIdentityPrecedesNormalAuthorization(t *testing.T) 
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.Equal(t, certificateAuth.identity.EntityID, entityID)
-	require.True(t, engine.CanPublish("mqtt-client", "m/d204f7df-8293-4194-963b-a47a65bc8f04/c/channel"))
+	_, committed := engine.CommitCertificateAuthentication(testCertificateClientID)
+	require.True(t, committed)
+	require.True(t, engine.CanPublish(testCertificateClientID, "m/d204f7df-8293-4194-963b-a47a65bc8f04/c/channel"))
 	require.Equal(t, 1, certificateAuth.authorizeCalls)
 	require.Equal(t, certificateAuth.identity.EntityID, authorizer.receivedClientID)
 }
@@ -62,87 +72,99 @@ func TestAuthEngineCertificateIdentityPrecedesNormalAuthorization(t *testing.T) 
 func TestAuthEngineCertificateDenialStopsNormalAuthorization(t *testing.T) {
 	certificateAuth := &certificateAuthenticatorStub{
 		identity: CertificateIdentity{
-			EntityID:     "8a0a5c59-4ea8-4fc1-badb-f96cf739b224",
-			CredentialID: "ca49950c-3ed2-41b4-a319-896085285686",
-			Fingerprint:  "abc123",
+			EntityID:     testCertificateEntityID,
+			CredentialID: testCertificateCredentialID,
+			Fingerprint:  testCertificateFingerprint,
 		},
-		authorizeErr: ErrTenantMismatchForTest,
+		authorizeErr: errTenantMismatchForTest,
 	}
 	authorizer := &stubAuthorizer{allow: true}
 	engine := NewAuthEngine(nil, authorizer, WithCertificateAuthentication(certificateAuth))
-	_, _, err := engine.AuthenticateWithPeer(context.Background(), "mqtt-client", "", "", PeerCertificate{LeafDER: []byte{1}})
+	_, _, err := engine.AuthenticateWithPeer(context.Background(), testCertificateClientID, "", "", PeerCertificate{LeafDER: []byte{1}})
 	require.NoError(t, err)
+	_, committed := engine.CommitCertificateAuthentication(testCertificateClientID)
+	require.True(t, committed)
 
-	require.False(t, engine.CanSubscribe("mqtt-client", "m/other/#"))
+	require.False(t, engine.CanSubscribe(testCertificateClientID, "m/other/#"))
 	require.Empty(t, authorizer.receivedClientID, "normal authorization must not run after tenant denial")
 }
 
 func TestAuthEngineNormalAuthorizationCanDenyCertificateIdentity(t *testing.T) {
 	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
-		EntityID:     "8a0a5c59-4ea8-4fc1-badb-f96cf739b224",
-		CredentialID: "ca49950c-3ed2-41b4-a319-896085285686",
-		Fingerprint:  "abc123",
+		EntityID:     testCertificateEntityID,
+		CredentialID: testCertificateCredentialID,
+		Fingerprint:  testCertificateFingerprint,
 	}}
 	authorizer := &stubAuthorizer{allow: false}
 	engine := NewAuthEngine(nil, authorizer, WithCertificateAuthentication(certificateAuth))
-	_, _, err := engine.AuthenticateWithPeer(context.Background(), "mqtt-client", "", "", PeerCertificate{LeafDER: []byte{1}})
+	_, _, err := engine.AuthenticateWithPeer(context.Background(), testCertificateClientID, "", "", PeerCertificate{LeafDER: []byte{1}})
 	require.NoError(t, err)
+	_, committed := engine.CommitCertificateAuthentication(testCertificateClientID)
+	require.True(t, committed)
 
-	require.False(t, engine.CanPublish("mqtt-client", "$SYS/global/status"))
+	require.False(t, engine.CanPublish(testCertificateClientID, testCertificateGlobalTopic))
 	require.Equal(t, certificateAuth.identity.EntityID, authorizer.receivedClientID)
 }
 
 func TestAuthEngineCertificateIdentityCannotBeOverriddenByHook(t *testing.T) {
 	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
-		EntityID:     "8a0a5c59-4ea8-4fc1-badb-f96cf739b224",
-		CredentialID: "ca49950c-3ed2-41b4-a319-896085285686",
-		Fingerprint:  "abc123",
+		EntityID:     testCertificateEntityID,
+		CredentialID: testCertificateCredentialID,
+		Fingerprint:  testCertificateFingerprint,
 	}}
 	engine := NewAuthEngine(nil, nil, WithCertificateAuthentication(certificateAuth))
-	_, _, err := engine.AuthenticateWithPeer(context.Background(), "mqtt-client", "", "", PeerCertificate{LeafDER: []byte{1}})
+	_, _, err := engine.AuthenticateWithPeer(context.Background(), testCertificateClientID, "", "", PeerCertificate{LeafDER: []byte{1}})
 	require.NoError(t, err)
 
-	engine.SetExternalID("mqtt-client", "hook-chosen-identity")
-	require.Equal(t, certificateAuth.identity.EntityID, engine.ExternalID("mqtt-client"))
-	engine.Forget("mqtt-client")
+	engine.SetExternalID(testCertificateClientID, "hook-chosen-identity")
+	require.Equal(t, certificateAuth.identity.EntityID, engine.ExternalID(testCertificateClientID))
+	engine.Forget(testCertificateClientID)
 	require.Zero(t, engine.CertificateSessionCount())
 }
 
 func TestAuthEngineCertificateRotationRebindsClientBeforeNextOperation(t *testing.T) {
 	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
-		EntityID:     "8a0a5c59-4ea8-4fc1-badb-f96cf739b224",
-		CredentialID: "ca49950c-3ed2-41b4-a319-896085285686",
+		EntityID:     testCertificateEntityID,
+		CredentialID: testCertificateCredentialID,
 		Fingerprint:  "old-fingerprint",
 	}}
 	engine := NewAuthEngine(nil, nil, WithCertificateAuthentication(certificateAuth))
-	_, _, err := engine.AuthenticateWithPeer(context.Background(), "mqtt-client", "", "", PeerCertificate{LeafDER: []byte{1}})
+	_, _, err := engine.AuthenticateWithPeer(context.Background(), testCertificateClientID, "", "", PeerCertificate{LeafDER: []byte{1}})
 	require.NoError(t, err)
+	oldBinding, committed := engine.CommitCertificateAuthentication(testCertificateClientID)
+	require.True(t, committed)
 
 	certificateAuth.identity.CredentialID = "05119e28-6260-4a06-8742-f925bcfdccd4"
 	certificateAuth.identity.Fingerprint = "new-fingerprint"
-	_, _, err = engine.AuthenticateWithPeer(context.Background(), "mqtt-client", "", "", PeerCertificate{LeafDER: []byte{2}})
+	_, _, err = engine.AuthenticateWithPeer(context.Background(), testCertificateClientID, "", "", PeerCertificate{LeafDER: []byte{2}})
 	require.NoError(t, err)
-	require.True(t, engine.CanPublish("mqtt-client", "$SYS/global/status"))
+	newBinding, committed := engine.CommitCertificateAuthentication(testCertificateClientID)
+	require.True(t, committed)
+	require.NotEqual(t, oldBinding, newBinding)
+	engine.ForgetCertificateSession(testCertificateClientID, oldBinding)
+	require.True(t, engine.CanPublish(testCertificateClientID, testCertificateGlobalTopic))
 	require.Equal(t, "new-fingerprint", certificateAuth.lastAuthorizedIdentity.Fingerprint)
 	require.Equal(t, 1, engine.CertificateSessionCount())
 }
 
 func TestAuthEngineRejectsCrossEntityCertificateClientIDTakeover(t *testing.T) {
 	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
-		EntityID:     "8a0a5c59-4ea8-4fc1-badb-f96cf739b224",
-		CredentialID: "ca49950c-3ed2-41b4-a319-896085285686",
+		EntityID:     testCertificateEntityID,
+		CredentialID: testCertificateCredentialID,
 		Fingerprint:  "first-fingerprint",
 	}}
 	engine := NewAuthEngine(nil, nil, WithCertificateAuthentication(certificateAuth))
-	_, _, err := engine.AuthenticateWithPeer(context.Background(), "mqtt-client", "", "", PeerCertificate{LeafDER: []byte{1}})
+	_, _, err := engine.AuthenticateWithPeer(context.Background(), testCertificateClientID, "", "", PeerCertificate{LeafDER: []byte{1}})
 	require.NoError(t, err)
+	_, committed := engine.CommitCertificateAuthentication(testCertificateClientID)
+	require.True(t, committed)
 
 	certificateAuth.identity.EntityID = "ac47c9fd-1d4a-4270-bb11-ab6476a0bd3a"
 	certificateAuth.identity.CredentialID = "05119e28-6260-4a06-8742-f925bcfdccd4"
 	certificateAuth.identity.Fingerprint = "second-fingerprint"
-	_, _, err = engine.AuthenticateWithPeer(context.Background(), "mqtt-client", "", "", PeerCertificate{LeafDER: []byte{2}})
+	_, _, err = engine.AuthenticateWithPeer(context.Background(), testCertificateClientID, "", "", PeerCertificate{LeafDER: []byte{2}})
 	require.ErrorIs(t, err, ErrCertificateClientIdentityConflict)
-	require.Equal(t, "8a0a5c59-4ea8-4fc1-badb-f96cf739b224", engine.ExternalID("mqtt-client"))
+	require.Equal(t, testCertificateEntityID, engine.ExternalID(testCertificateClientID))
 	require.Equal(t, 1, engine.CertificateSessionCount())
 }
 
@@ -159,22 +181,71 @@ func TestAuthEngineNonCertificatePathUnchanged(t *testing.T) {
 
 func TestRejectedPlainTakeoverPreservesCertificateSession(t *testing.T) {
 	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
-		EntityID:     "8a0a5c59-4ea8-4fc1-badb-f96cf739b224",
-		CredentialID: "ca49950c-3ed2-41b4-a319-896085285686",
-		Fingerprint:  "abc123",
+		EntityID:     testCertificateEntityID,
+		CredentialID: testCertificateCredentialID,
+		Fingerprint:  testCertificateFingerprint,
 	}}
 	authn := &stubAuthenticator{result: &AuthnResult{Authenticated: false}}
 	engine := NewAuthEngine(authn, nil, WithCertificateAuthentication(certificateAuth))
-	_, _, err := engine.AuthenticateWithPeer(context.Background(), "mqtt-client", "", "", PeerCertificate{LeafDER: []byte{1}})
+	_, _, err := engine.AuthenticateWithPeer(context.Background(), testCertificateClientID, "", "", PeerCertificate{LeafDER: []byte{1}})
 	require.NoError(t, err)
+	_, committed := engine.CommitCertificateAuthentication(testCertificateClientID)
+	require.True(t, committed)
 
-	ok, _, err := engine.Authenticate("mqtt-client", "attacker", "wrong")
+	ok, _, err := engine.Authenticate(testCertificateClientID, "attacker", "wrong")
 	require.NoError(t, err)
 	require.False(t, ok)
 	require.Equal(t, 1, engine.CertificateSessionCount())
-	require.Equal(t, certificateAuth.identity.EntityID, engine.ExternalID("mqtt-client"))
-	require.True(t, engine.CanPublish("mqtt-client", "$SYS/global/status"))
+	require.Equal(t, certificateAuth.identity.EntityID, engine.ExternalID(testCertificateClientID))
+	require.True(t, engine.CanPublish(testCertificateClientID, testCertificateGlobalTopic))
 	require.Equal(t, 1, certificateAuth.authorizeCalls)
 }
 
-var ErrTenantMismatchForTest = errors.New("tenant mismatch")
+func TestAuthEngineSerializesConcurrentCertificateAuthentication(t *testing.T) {
+	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
+		EntityID:     testCertificateEntityID,
+		CredentialID: testCertificateCredentialID,
+		Fingerprint:  testCertificateFingerprint,
+	}}
+	engine := NewAuthEngine(nil, nil, WithCertificateAuthentication(certificateAuth))
+
+	_, _, err := engine.AuthenticateWithPeer(context.Background(), testCertificateClientID, "", "", PeerCertificate{LeafDER: []byte{1}})
+	require.NoError(t, err)
+	_, _, err = engine.AuthenticateWithPeer(context.Background(), testCertificateClientID, "", "", PeerCertificate{LeafDER: []byte{2}})
+	require.ErrorIs(t, err, ErrCertificateAuthenticationPending)
+
+	binding, committed := engine.CommitCertificateAuthentication(testCertificateClientID)
+	require.True(t, committed)
+	require.NotZero(t, binding)
+	require.Equal(t, 1, engine.CertificateSessionCount())
+}
+
+func TestAuthEngineRejectedReconnectPreservesCommittedCertificate(t *testing.T) {
+	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
+		EntityID:     testCertificateEntityID,
+		CredentialID: testCertificateCredentialID,
+		Fingerprint:  "old-fingerprint",
+	}}
+	engine := NewAuthEngine(nil, nil, WithCertificateAuthentication(certificateAuth))
+	_, _, err := engine.AuthenticateWithPeer(context.Background(), testCertificateClientID, "", "", PeerCertificate{LeafDER: []byte{1}})
+	require.NoError(t, err)
+	oldBinding, committed := engine.CommitCertificateAuthentication(testCertificateClientID)
+	require.True(t, committed)
+
+	certificateAuth.identity.CredentialID = "05119e28-6260-4a06-8742-f925bcfdccd4"
+	certificateAuth.identity.Fingerprint = "rejected-fingerprint"
+	_, _, err = engine.AuthenticateWithPeer(context.Background(), testCertificateClientID, "", "", PeerCertificate{LeafDER: []byte{2}})
+	require.NoError(t, err)
+	engine.Forget(testCertificateClientID)
+
+	currentBinding, current := engine.CertificateSessionBinding(testCertificateClientID)
+	require.True(t, current)
+	require.Equal(t, oldBinding, currentBinding)
+	require.Equal(t, testCertificateEntityID, engine.ExternalID(testCertificateClientID))
+	require.True(t, engine.CanPublish(testCertificateClientID, testCertificateGlobalTopic))
+	require.Equal(t, "old-fingerprint", certificateAuth.lastAuthorizedIdentity.Fingerprint)
+	_, committed = engine.CommitCertificateAuthentication(testCertificateClientID)
+	require.False(t, committed)
+}
+
+var errTenantMismatchForTest = errors.New("tenant mismatch")

--- a/broker/certificate_test.go
+++ b/broker/certificate_test.go
@@ -220,6 +220,32 @@ func TestAuthEngineSerializesConcurrentCertificateAuthentication(t *testing.T) {
 	require.Equal(t, 1, engine.CertificateSessionCount())
 }
 
+func TestAuthEngineBoundsPendingAndCommittedCertificateSessions(t *testing.T) {
+	const secondClientID = "client-2"
+	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
+		EntityID:     testCertificateEntityID,
+		CredentialID: testCertificateCredentialID,
+		Fingerprint:  testCertificateFingerprint,
+	}}
+	engine := NewAuthEngine(nil, nil,
+		WithIdentityCache(1, time.Hour),
+		WithCertificateAuthentication(certificateAuth),
+	)
+
+	_, _, err := engine.AuthenticateWithPeer(context.Background(), "client-1", "", "", PeerCertificate{LeafDER: []byte{1}})
+	require.NoError(t, err)
+	_, _, err = engine.AuthenticateWithPeer(context.Background(), secondClientID, "", "", PeerCertificate{LeafDER: []byte{2}})
+	require.ErrorIs(t, err, ErrCertificateSessionCapacity, "pending bindings count toward the bound")
+	binding, committed := engine.CommitCertificateAuthentication("client-1")
+	require.True(t, committed)
+	_, _, err = engine.AuthenticateWithPeer(context.Background(), secondClientID, "", "", PeerCertificate{LeafDER: []byte{2}})
+	require.ErrorIs(t, err, ErrCertificateSessionCapacity, "committed bindings count toward the bound")
+
+	engine.ForgetCertificateSession("client-1", binding)
+	_, _, err = engine.AuthenticateWithPeer(context.Background(), secondClientID, "", "", PeerCertificate{LeafDER: []byte{2}})
+	require.NoError(t, err)
+}
+
 func TestAuthEngineRejectedReconnectPreservesCommittedCertificate(t *testing.T) {
 	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
 		EntityID:     testCertificateEntityID,

--- a/broker/certificate_test.go
+++ b/broker/certificate_test.go
@@ -1,0 +1,180 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type certificateAuthenticatorStub struct {
+	identity               CertificateIdentity
+	authenticateErr        error
+	authorizeErr           error
+	authorizeCalls         int
+	lastAuthorizedIdentity CertificateIdentity
+}
+
+func (stub *certificateAuthenticatorStub) AuthenticateCertificate(_ context.Context, peer PeerCertificate) (CertificateIdentity, error) {
+	if len(peer.LeafDER) == 0 {
+		return CertificateIdentity{}, errors.New("missing leaf")
+	}
+	return stub.identity, stub.authenticateErr
+}
+
+func (stub *certificateAuthenticatorStub) AuthorizeCertificate(_ context.Context, identity CertificateIdentity, _ string) error {
+	stub.authorizeCalls++
+	stub.lastAuthorizedIdentity = identity
+	return stub.authorizeErr
+}
+
+func TestAuthEngineCertificateIdentityPrecedesNormalAuthorization(t *testing.T) {
+	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
+		EntityID:     "8a0a5c59-4ea8-4fc1-badb-f96cf739b224",
+		TenantID:     "d204f7df-8293-4194-963b-a47a65bc8f04",
+		CredentialID: "ca49950c-3ed2-41b4-a319-896085285686",
+		Fingerprint:  "abc123",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	}}
+	authorizer := &stubAuthorizer{allow: true}
+	engine := NewAuthEngine(nil, authorizer, WithCertificateAuthentication(certificateAuth))
+
+	ok, entityID, err := engine.AuthenticateWithPeer(
+		context.Background(),
+		"mqtt-client",
+		"ignored",
+		"ignored",
+		PeerCertificate{LeafDER: []byte{1, 2, 3}},
+	)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, certificateAuth.identity.EntityID, entityID)
+	require.True(t, engine.CanPublish("mqtt-client", "m/d204f7df-8293-4194-963b-a47a65bc8f04/c/channel"))
+	require.Equal(t, 1, certificateAuth.authorizeCalls)
+	require.Equal(t, certificateAuth.identity.EntityID, authorizer.receivedClientID)
+}
+
+func TestAuthEngineCertificateDenialStopsNormalAuthorization(t *testing.T) {
+	certificateAuth := &certificateAuthenticatorStub{
+		identity: CertificateIdentity{
+			EntityID:     "8a0a5c59-4ea8-4fc1-badb-f96cf739b224",
+			CredentialID: "ca49950c-3ed2-41b4-a319-896085285686",
+			Fingerprint:  "abc123",
+		},
+		authorizeErr: ErrTenantMismatchForTest,
+	}
+	authorizer := &stubAuthorizer{allow: true}
+	engine := NewAuthEngine(nil, authorizer, WithCertificateAuthentication(certificateAuth))
+	_, _, err := engine.AuthenticateWithPeer(context.Background(), "mqtt-client", "", "", PeerCertificate{LeafDER: []byte{1}})
+	require.NoError(t, err)
+
+	require.False(t, engine.CanSubscribe("mqtt-client", "m/other/#"))
+	require.Empty(t, authorizer.receivedClientID, "normal authorization must not run after tenant denial")
+}
+
+func TestAuthEngineNormalAuthorizationCanDenyCertificateIdentity(t *testing.T) {
+	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
+		EntityID:     "8a0a5c59-4ea8-4fc1-badb-f96cf739b224",
+		CredentialID: "ca49950c-3ed2-41b4-a319-896085285686",
+		Fingerprint:  "abc123",
+	}}
+	authorizer := &stubAuthorizer{allow: false}
+	engine := NewAuthEngine(nil, authorizer, WithCertificateAuthentication(certificateAuth))
+	_, _, err := engine.AuthenticateWithPeer(context.Background(), "mqtt-client", "", "", PeerCertificate{LeafDER: []byte{1}})
+	require.NoError(t, err)
+
+	require.False(t, engine.CanPublish("mqtt-client", "$SYS/global/status"))
+	require.Equal(t, certificateAuth.identity.EntityID, authorizer.receivedClientID)
+}
+
+func TestAuthEngineCertificateIdentityCannotBeOverriddenByHook(t *testing.T) {
+	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
+		EntityID:     "8a0a5c59-4ea8-4fc1-badb-f96cf739b224",
+		CredentialID: "ca49950c-3ed2-41b4-a319-896085285686",
+		Fingerprint:  "abc123",
+	}}
+	engine := NewAuthEngine(nil, nil, WithCertificateAuthentication(certificateAuth))
+	_, _, err := engine.AuthenticateWithPeer(context.Background(), "mqtt-client", "", "", PeerCertificate{LeafDER: []byte{1}})
+	require.NoError(t, err)
+
+	engine.SetExternalID("mqtt-client", "hook-chosen-identity")
+	require.Equal(t, certificateAuth.identity.EntityID, engine.ExternalID("mqtt-client"))
+	engine.Forget("mqtt-client")
+	require.Zero(t, engine.CertificateSessionCount())
+}
+
+func TestAuthEngineCertificateRotationRebindsClientBeforeNextOperation(t *testing.T) {
+	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
+		EntityID:     "8a0a5c59-4ea8-4fc1-badb-f96cf739b224",
+		CredentialID: "ca49950c-3ed2-41b4-a319-896085285686",
+		Fingerprint:  "old-fingerprint",
+	}}
+	engine := NewAuthEngine(nil, nil, WithCertificateAuthentication(certificateAuth))
+	_, _, err := engine.AuthenticateWithPeer(context.Background(), "mqtt-client", "", "", PeerCertificate{LeafDER: []byte{1}})
+	require.NoError(t, err)
+
+	certificateAuth.identity.CredentialID = "05119e28-6260-4a06-8742-f925bcfdccd4"
+	certificateAuth.identity.Fingerprint = "new-fingerprint"
+	_, _, err = engine.AuthenticateWithPeer(context.Background(), "mqtt-client", "", "", PeerCertificate{LeafDER: []byte{2}})
+	require.NoError(t, err)
+	require.True(t, engine.CanPublish("mqtt-client", "$SYS/global/status"))
+	require.Equal(t, "new-fingerprint", certificateAuth.lastAuthorizedIdentity.Fingerprint)
+	require.Equal(t, 1, engine.CertificateSessionCount())
+}
+
+func TestAuthEngineRejectsCrossEntityCertificateClientIDTakeover(t *testing.T) {
+	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
+		EntityID:     "8a0a5c59-4ea8-4fc1-badb-f96cf739b224",
+		CredentialID: "ca49950c-3ed2-41b4-a319-896085285686",
+		Fingerprint:  "first-fingerprint",
+	}}
+	engine := NewAuthEngine(nil, nil, WithCertificateAuthentication(certificateAuth))
+	_, _, err := engine.AuthenticateWithPeer(context.Background(), "mqtt-client", "", "", PeerCertificate{LeafDER: []byte{1}})
+	require.NoError(t, err)
+
+	certificateAuth.identity.EntityID = "ac47c9fd-1d4a-4270-bb11-ab6476a0bd3a"
+	certificateAuth.identity.CredentialID = "05119e28-6260-4a06-8742-f925bcfdccd4"
+	certificateAuth.identity.Fingerprint = "second-fingerprint"
+	_, _, err = engine.AuthenticateWithPeer(context.Background(), "mqtt-client", "", "", PeerCertificate{LeafDER: []byte{2}})
+	require.ErrorIs(t, err, ErrCertificateClientIdentityConflict)
+	require.Equal(t, "8a0a5c59-4ea8-4fc1-badb-f96cf739b224", engine.ExternalID("mqtt-client"))
+	require.Equal(t, 1, engine.CertificateSessionCount())
+}
+
+func TestAuthEngineNonCertificatePathUnchanged(t *testing.T) {
+	authn := &stubAuthenticator{result: &AuthnResult{Authenticated: true, ID: testExternalID}}
+	certificateAuth := &certificateAuthenticatorStub{authenticateErr: errors.New("must not be called")}
+	engine := NewAuthEngine(authn, nil, WithCertificateAuthentication(certificateAuth))
+
+	ok, externalID, err := engine.Authenticate("plain-client", "user", "password")
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, testExternalID, externalID)
+}
+
+func TestRejectedPlainTakeoverPreservesCertificateSession(t *testing.T) {
+	certificateAuth := &certificateAuthenticatorStub{identity: CertificateIdentity{
+		EntityID:     "8a0a5c59-4ea8-4fc1-badb-f96cf739b224",
+		CredentialID: "ca49950c-3ed2-41b4-a319-896085285686",
+		Fingerprint:  "abc123",
+	}}
+	authn := &stubAuthenticator{result: &AuthnResult{Authenticated: false}}
+	engine := NewAuthEngine(authn, nil, WithCertificateAuthentication(certificateAuth))
+	_, _, err := engine.AuthenticateWithPeer(context.Background(), "mqtt-client", "", "", PeerCertificate{LeafDER: []byte{1}})
+	require.NoError(t, err)
+
+	ok, _, err := engine.Authenticate("mqtt-client", "attacker", "wrong")
+	require.NoError(t, err)
+	require.False(t, ok)
+	require.Equal(t, 1, engine.CertificateSessionCount())
+	require.Equal(t, certificateAuth.identity.EntityID, engine.ExternalID("mqtt-client"))
+	require.True(t, engine.CanPublish("mqtt-client", "$SYS/global/status"))
+	require.Equal(t, 1, certificateAuth.authorizeCalls)
+}
+
+var ErrTenantMismatchForTest = errors.New("tenant mismatch")

--- a/broker/errors.go
+++ b/broker/errors.go
@@ -17,6 +17,10 @@ var ErrCertificateSessionCapacity = errors.New("certificate session capacity rea
 // client ID from being taken over by a different Atom entity.
 var ErrCertificateClientIdentityConflict = errors.New("certificate client ID is already bound to another entity")
 
+// ErrCertificateAuthenticationPending prevents concurrent certificate
+// takeovers for one protocol client ID from swapping each other's identity.
+var ErrCertificateAuthenticationPending = errors.New("certificate authentication is already pending for this client ID")
+
 // IsErrClientNotConnected reports whether err means a queue delivery target is
 // gone. Across the cluster RPC the signal is carried structurally (the
 // client_not_connected proto field, re-wrapped into ErrClientNotConnected by

--- a/broker/errors.go
+++ b/broker/errors.go
@@ -9,6 +9,14 @@ import "errors"
 // targets a client that no longer has a live connection.
 var ErrClientNotConnected = errors.New("client not connected")
 
+// ErrCertificateSessionCapacity prevents certificate-authenticated session
+// state from growing without a configured bound.
+var ErrCertificateSessionCapacity = errors.New("certificate session capacity reached")
+
+// ErrCertificateClientIdentityConflict prevents a live certificate-bound
+// client ID from being taken over by a different Atom entity.
+var ErrCertificateClientIdentityConflict = errors.New("certificate client ID is already bound to another entity")
+
 // IsErrClientNotConnected reports whether err means a queue delivery target is
 // gone. Across the cluster RPC the signal is carried structurally (the
 // client_not_connected proto field, re-wrapped into ErrClientNotConnected by

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1172,17 +1172,18 @@ func main() {
 		}
 
 		tcpCfg := tcp.Config{
-			Address:          slot.cfg.Addr,
-			TLSConfig:        tlsCfg,
-			ShutdownTimeout:  cfg.Server.ShutdownTimeout,
-			MaxConnections:   slot.cfg.MaxConnections,
-			ReadTimeout:      slot.cfg.ReadTimeout,
-			WriteTimeout:     slot.cfg.WriteTimeout,
-			SendQueueSize:    cfg.Session.MaxSendQueueSize,
-			DisconnectOnFull: cfg.Session.DisconnectOnFull,
-			ProtocolVersion:  protocolVersionForMode(slot.cfg.Protocol),
-			MaxPacketSize:    maxMQTTPacketSize(cfg.Broker.MaxMessageSize),
-			Logger:           logger,
+			Address:                   slot.cfg.Addr,
+			TLSConfig:                 tlsCfg,
+			ShutdownTimeout:           cfg.Server.ShutdownTimeout,
+			MaxConnections:            slot.cfg.MaxConnections,
+			ReadTimeout:               slot.cfg.ReadTimeout,
+			WriteTimeout:              slot.cfg.WriteTimeout,
+			SendQueueSize:             cfg.Session.MaxSendQueueSize,
+			DisconnectOnFull:          cfg.Session.DisconnectOnFull,
+			ProtocolVersion:           protocolVersionForMode(slot.cfg.Protocol),
+			CertificateAuthentication: certificateManager != nil && slot.name == listenerMTLS,
+			MaxPacketSize:             maxMQTTPacketSize(cfg.Broker.MaxMessageSize),
+			Logger:                    logger,
 		}
 		tcpCfg.IPRateLimiter = rateLimitManager
 		tcpServer := tcp.New(tcpCfg, b)
@@ -1226,16 +1227,17 @@ func main() {
 		}
 
 		wsCfg := websocket.Config{
-			Address:         slot.cfg.Addr,
-			Path:            slot.cfg.Path,
-			ShutdownTimeout: cfg.Server.ShutdownTimeout,
-			TLSConfig:       tlsCfg,
-			ProtocolVersion: protocolVersionForMode(slot.cfg.Protocol),
-			AllowedOrigins:  slot.cfg.AllowedOrigins,
-			MaxPacketSize:   maxMQTTPacketSize(cfg.Broker.MaxMessageSize),
-			ReadTimeout:     slot.cfg.ReadTimeout,
-			WriteTimeout:    slot.cfg.WriteTimeout,
-			MaxConnections:  slot.cfg.MaxConnections,
+			Address:                   slot.cfg.Addr,
+			Path:                      slot.cfg.Path,
+			ShutdownTimeout:           cfg.Server.ShutdownTimeout,
+			TLSConfig:                 tlsCfg,
+			ProtocolVersion:           protocolVersionForMode(slot.cfg.Protocol),
+			AllowedOrigins:            slot.cfg.AllowedOrigins,
+			MaxPacketSize:             maxMQTTPacketSize(cfg.Broker.MaxMessageSize),
+			ReadTimeout:               slot.cfg.ReadTimeout,
+			WriteTimeout:              slot.cfg.WriteTimeout,
+			MaxConnections:            slot.cfg.MaxConnections,
+			CertificateAuthentication: certificateManager != nil && slot.name == listenerMTLS,
 		}
 		wsCfg.IPRateLimiter = rateLimitManager
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -705,7 +705,10 @@ func main() {
 			CacheTTL:             cfg.Auth.Certificate.CacheTTL,
 			CacheSize:            cfg.Auth.Certificate.CacheSize,
 			TrustRefreshInterval: cfg.Auth.Certificate.TrustRefreshInterval,
-		}, pki.WithLogger(logger))
+		},
+			pki.WithLogger(logger),
+			pki.WithSessionInvalidator(b.DisconnectCertificateSessions),
+		)
 		if err != nil {
 			slog.Error("Failed to configure Atom certificate resolver", "error", err)
 			os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -34,6 +34,7 @@ import (
 	core "github.com/absmach/fluxmq/mqtt"
 	"github.com/absmach/fluxmq/mqtt/broker"
 	mqtttls "github.com/absmach/fluxmq/pkg/tls"
+	"github.com/absmach/fluxmq/pki"
 	"github.com/absmach/fluxmq/queue"
 	qraft "github.com/absmach/fluxmq/queue/raft"
 	queueStorage "github.com/absmach/fluxmq/queue/storage"
@@ -97,9 +98,11 @@ func maxMQTTPacketSize(maxMessageSize int) int {
 }
 
 type brokerDeliveryTarget struct {
-	mqtt    *broker.Broker
-	amqp    *amqp1broker.Broker
-	amqp091 *amqpbroker.Broker
+	mqtt                     *broker.Broker
+	amqp                     *amqp1broker.Broker
+	amqp091                  *amqpbroker.Broker
+	certificateManager       *pki.Manager
+	certificateEventClientID string
 }
 
 type localAMQPPolicy struct {
@@ -320,6 +323,15 @@ func localPrincipalPublishTargetContracts(principals []config.LocalPrincipalConf
 }
 
 func (t *brokerDeliveryTarget) Deliver(ctx context.Context, clientID string, msg *storage.Message) error {
+	if t.certificateManager != nil && clientID == t.certificateEventClientID {
+		if err := t.certificateManager.HandleEvent(msg.GetPayload(), msg.Properties); err != nil {
+			// Invalid events are acknowledged and dropped. Retrying an untrusted or
+			// malformed record would permanently block later revocations in the
+			// stream; the protected publisher contract prevents forgery at ingress.
+			slog.Warn("discarding invalid Atom lifecycle event", "error", err)
+		}
+		return nil
+	}
 	if amqp1broker.IsAMQPClient(clientID) {
 		return t.amqp.DeliverToClient(ctx, clientID, msg)
 	}
@@ -330,6 +342,9 @@ func (t *brokerDeliveryTarget) Deliver(ctx context.Context, clientID string, msg
 }
 
 func (t *brokerDeliveryTarget) HasDeliveryTarget(clientID string) bool {
+	if t.certificateManager != nil && clientID == t.certificateEventClientID {
+		return true
+	}
 	if amqp1broker.IsAMQPClient(clientID) {
 		return t.amqp != nil && t.amqp.IsClientConnected(clientID)
 	}
@@ -677,6 +692,45 @@ func main() {
 	// Create AMQP 0.9.1 broker (needs queue manager set later)
 	amqp091Broker := amqpbroker.New(nil, logger)
 	defer amqp091Broker.Close()
+
+	var certificateManager *pki.Manager
+	if cfg.Auth.Certificate.Enabled {
+		manager, err := pki.NewManager(pki.Config{
+			ResolverAddress:      cfg.Auth.Certificate.ResolverAddress,
+			ResolverInsecure:     cfg.Auth.Certificate.ResolverInsecure,
+			ServiceTokenFile:     cfg.Auth.Certificate.ServiceTokenFile,
+			TrustBundleURL:       cfg.Auth.Certificate.TrustBundleURL,
+			EventSourcePrincipal: cfg.Auth.Certificate.EventSourcePrincipal,
+			Timeout:              cfg.Auth.Certificate.ResolverTimeout,
+			CacheTTL:             cfg.Auth.Certificate.CacheTTL,
+			CacheSize:            cfg.Auth.Certificate.CacheSize,
+			TrustRefreshInterval: cfg.Auth.Certificate.TrustRefreshInterval,
+		}, pki.WithLogger(logger))
+		if err != nil {
+			slog.Error("Failed to configure Atom certificate resolver", "error", err)
+			os.Exit(1)
+		}
+		startTimeout := cfg.Auth.Certificate.ResolverTimeout
+		if startTimeout == 0 {
+			startTimeout = pki.DefaultResolverTimeout
+		}
+		startCtx, startCancel := context.WithTimeout(context.Background(), startTimeout)
+		err = manager.Start(startCtx)
+		startCancel()
+		if err != nil {
+			slog.Error("Failed to load Atom trust bundle", "error", err)
+			os.Exit(1)
+		}
+		certificateManager = manager
+		defer func() {
+			if err := manager.Close(); err != nil {
+				slog.Warn("Failed to close Atom certificate resolver", "error", err)
+			}
+		}()
+		slog.Info("Atom resolver-tier certificate authentication enabled",
+			"cache_ttl", cfg.Auth.Certificate.CacheTTL,
+			"cache_size", cfg.Auth.Certificate.CacheSize)
+	}
 	var (
 		amqp091ExternalAuth  *corebroker.AuthEngine
 		amqp091ExternalHooks *corebroker.BlockingHookEngine
@@ -718,6 +772,9 @@ func main() {
 		}
 		engineOpts := []corebroker.AuthEngineOption{
 			corebroker.WithIdentityCache(cacheSize, cacheTTL),
+		}
+		if certificateManager != nil {
+			engineOpts = append(engineOpts, corebroker.WithCertificateAuthentication(certificateManager))
 		}
 
 		if cfg.Auth.External.EnabledFor("mqtt") {
@@ -936,11 +993,17 @@ func main() {
 			amqp091Broker.CancelConsumers(queueName, groupID, consumerIDs)
 		}
 
+		certificateEventClientID := ""
+		if certificateManager != nil {
+			certificateEventClientID = "pki-events:" + cfg.Cluster.NodeID
+		}
 		// Delivery dispatcher: routes to AMQP or MQTT broker based on client ID prefix.
 		deliveryTarget := &brokerDeliveryTarget{
-			mqtt:    b,
-			amqp:    amqpBroker,
-			amqp091: amqp091Broker,
+			mqtt:                     b,
+			amqp:                     amqpBroker,
+			amqp091:                  amqp091Broker,
+			certificateManager:       certificateManager,
+			certificateEventClientID: certificateEventClientID,
 		}
 
 		// Create log-based queue manager with wildcard support
@@ -1001,6 +1064,25 @@ func main() {
 		// Set queue manager on AMQP broker
 		amqpBroker.SetQueueManager(qm)
 		amqp091Broker.SetQueueManager(qm)
+		if certificateManager != nil {
+			groupID := cfg.Auth.Certificate.EventConsumerGroupPrefix + "." + cfg.Cluster.NodeID
+			cursor := &queueTypes.CursorOption{
+				Position: queueTypes.CursorLatest,
+				Mode:     queueTypes.GroupModeStream,
+			}
+			if err := qm.SubscribeExistingWithCursor(
+				context.Background(),
+				cfg.Auth.Certificate.EventQueue,
+				"",
+				certificateEventClientID,
+				groupID,
+				"",
+				cursor,
+			); err != nil {
+				slog.Error("Failed to subscribe to Atom lifecycle events", "error", err)
+				os.Exit(1)
+			}
+		}
 
 		// Set queue handler on cluster for cross-node message routing
 		if etcdCluster != nil {
@@ -1078,6 +1160,13 @@ func main() {
 			slog.Error("Failed to build TCP TLS configuration", "listener", slot.name, "error", err)
 			os.Exit(1)
 		}
+		if certificateManager != nil && slot.name == listenerMTLS {
+			tlsCfg, err = certificateManager.WrapTLSConfig(tlsCfg)
+			if err != nil {
+				slog.Error("Failed to attach Atom trust bundle to TCP mTLS listener", "error", err)
+				os.Exit(1)
+			}
+		}
 
 		tcpCfg := tcp.Config{
 			Address:          slot.cfg.Addr,
@@ -1124,6 +1213,13 @@ func main() {
 		if err != nil {
 			slog.Error("Failed to build WebSocket TLS configuration", "listener", slot.name, "error", err)
 			os.Exit(1)
+		}
+		if certificateManager != nil && slot.name == listenerMTLS {
+			tlsCfg, err = certificateManager.WrapTLSConfig(tlsCfg)
+			if err != nil {
+				slog.Error("Failed to attach Atom trust bundle to WebSocket mTLS listener", "error", err)
+				os.Exit(1)
+			}
 		}
 
 		wsCfg := websocket.Config{
@@ -1428,6 +1524,9 @@ func main() {
 		if qm != nil && queueLogStore != nil {
 			apiServer := api.New(apiCfg, b, amqp091Broker, cl, qm, qm.QueueStore(), qm.GroupStore(), logger)
 			apiServer.SetReloadManager(reloadManager)
+			if certificateManager != nil {
+				apiServer.SetCertificateMetricsProvider(certificateManager)
+			}
 
 			wg.Add(1)
 			go func() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -711,7 +711,7 @@ func main() {
 		)
 		if err != nil {
 			slog.Error("Failed to configure Atom certificate resolver", "error", err)
-			os.Exit(1)
+			os.Exit(1) //nolint:gocritic // fatal initialization errors terminate immediately
 		}
 		startTimeout := cfg.Auth.Certificate.ResolverTimeout
 		if startTimeout == 0 {
@@ -722,7 +722,7 @@ func main() {
 		startCancel()
 		if err != nil {
 			slog.Error("Failed to load Atom trust bundle", "error", err)
-			os.Exit(1)
+			os.Exit(1) //nolint:gocritic // fatal initialization errors terminate immediately
 		}
 		certificateManager = manager
 		defer func() {

--- a/config/certificate_test.go
+++ b/config/certificate_test.go
@@ -91,6 +91,13 @@ func TestCertificateAuthenticationRejectsUnsafeCombinations(t *testing.T) {
 			match: "cache_ttl",
 		},
 		{
+			name: "unbounded active certificate bindings",
+			mutate: func(config *Config) {
+				config.Auth.External.IdentityCacheSize = -1
+			},
+			match: "bounded auth.external.identity_cache_size",
+		},
+		{
 			name: "events are not a durable stream contract",
 			mutate: func(config *Config) {
 				config.Queues[len(config.Queues)-1].Type = "classic"

--- a/config/certificate_test.go
+++ b/config/certificate_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func validCertificateConfig(t *testing.T) *Config {
+	t.Helper()
+	secretFile := filepath.Join(t.TempDir(), "secret")
+	require.NoError(t, os.WriteFile(secretFile, []byte("0123456789abcdef0123456789abcdef"), 0o600))
+	tokenFile := filepath.Join(t.TempDir(), "token")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("atom_service_token"), 0o600))
+
+	config := Default()
+	config.Cluster.Enabled = false
+	config.Auth.External.URL = "http://atom-auth:8181"
+	config.Auth.External.Protocols = map[string]bool{protocolMQTT: true}
+	config.Auth.Certificate = CertificateAuthConfig{
+		Enabled:                  true,
+		ResolverAddress:          "atom:8081",
+		ResolverInsecure:         true,
+		ServiceTokenFile:         tokenFile,
+		TrustBundleURL:           "http://atom:8080/certs/trust-bundle.pem",
+		ResolverTimeout:          time.Second,
+		CacheTTL:                 30 * time.Second,
+		CacheSize:                100,
+		TrustRefreshInterval:     time.Minute,
+		EventQueue:               "atom.events",
+		EventConsumerGroupPrefix: "fluxmq-pki",
+		EventSourcePrincipal:     "atom-events",
+	}
+	config.Server.TCP.MTLS = TCPListenerConfig{
+		Addr:           ":8883",
+		MaxConnections: 100,
+		ReadTimeout:    time.Second,
+		WriteTimeout:   time.Second,
+		Protocol:       ProtocolModeAuto,
+	}
+	config.Server.TCP.MTLS.TLS.CertFile = "server.pem"
+	config.Server.TCP.MTLS.TLS.KeyFile = "server.key"
+	config.Server.TCP.MTLS.TLS.ClientAuth = "require"
+	config.Queues = append(config.Queues, QueueConfig{
+		Name:     "atom.events",
+		Topics:   []string{"$queue/atom.events/#"},
+		Reserved: true,
+		Type:     "stream",
+	})
+	config.Auth.LocalPrincipals = []LocalPrincipalConfig{
+		{
+			Name:              "atom-events",
+			CertificateURISAN: "spiffe://example.test/atom/events",
+			CurrentSecretFile: secretFile,
+			Permissions: LocalPermissionsConfig{Publish: []LocalPublishPermission{
+				{Exchange: "", RoutingKey: "atom.events"},
+			}},
+		},
+	}
+	return config
+}
+
+func TestCertificateAuthenticationConfigurationContract(t *testing.T) {
+	require.NoError(t, validCertificateConfig(t).Validate())
+}
+
+func TestCertificateAuthenticationRejectsUnsafeCombinations(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+		match  string
+	}{
+		{
+			name: "normal Atom authorization missing",
+			mutate: func(config *Config) {
+				config.Auth.External.Protocols = map[string]bool{protocolMQTT: false}
+			},
+			match: "authorization for mqtt",
+		},
+		{
+			name: "unbounded revocation lag",
+			mutate: func(config *Config) {
+				config.Auth.Certificate.CacheTTL = certificateMaximumCacheTTL + time.Second
+			},
+			match: "cache_ttl",
+		},
+		{
+			name: "events are not a durable stream contract",
+			mutate: func(config *Config) {
+				config.Queues[len(config.Queues)-1].Type = "classic"
+			},
+			match: "reserved stream queue",
+		},
+		{
+			name: "publisher lacks exact protected target",
+			mutate: func(config *Config) {
+				config.Auth.LocalPrincipals[0].Permissions.Publish[0].RoutingKey = "other.events"
+			},
+			match: "exact default-exchange publish grant",
+		},
+		{
+			name: "no applicable MQTT mTLS transport",
+			mutate: func(config *Config) {
+				config.Server.TCP.MTLS = TCPListenerConfig{}
+				config.Server.WebSocket.MTLS = WSListenerConfig{}
+			},
+			match: "mTLS listener",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config := validCertificateConfig(t)
+			test.mutate(config)
+			require.ErrorContains(t, config.Validate(), test.match)
+		})
+	}
+}

--- a/config/certificate_test.go
+++ b/config/certificate_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testAtomEventQueue = "atom.events"
+
 func validCertificateConfig(t *testing.T) *Config {
 	t.Helper()
 	secretFile := filepath.Join(t.TempDir(), "secret")
@@ -33,7 +35,7 @@ func validCertificateConfig(t *testing.T) *Config {
 		CacheTTL:                 30 * time.Second,
 		CacheSize:                100,
 		TrustRefreshInterval:     time.Minute,
-		EventQueue:               "atom.events",
+		EventQueue:               testAtomEventQueue,
 		EventConsumerGroupPrefix: "fluxmq-pki",
 		EventSourcePrincipal:     "atom-events",
 	}
@@ -48,8 +50,8 @@ func validCertificateConfig(t *testing.T) *Config {
 	config.Server.TCP.MTLS.TLS.KeyFile = "server.key"
 	config.Server.TCP.MTLS.TLS.ClientAuth = "require"
 	config.Queues = append(config.Queues, QueueConfig{
-		Name:     "atom.events",
-		Topics:   []string{"$queue/atom.events/#"},
+		Name:     testAtomEventQueue,
+		Topics:   []string{"$queue/" + testAtomEventQueue + "/#"},
 		Reserved: true,
 		Type:     "stream",
 	})
@@ -59,7 +61,7 @@ func validCertificateConfig(t *testing.T) *Config {
 			CertificateURISAN: "spiffe://example.test/atom/events",
 			CurrentSecretFile: secretFile,
 			Permissions: LocalPermissionsConfig{Publish: []LocalPublishPermission{
-				{Exchange: "", RoutingKey: "atom.events"},
+				{Exchange: "", RoutingKey: testAtomEventQueue},
 			}},
 		},
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -2109,6 +2109,9 @@ func (c *Config) validateCertificateAuthentication() error {
 	if !c.Auth.External.EnabledFor(protocolMQTT) {
 		return fmt.Errorf("%senabled requires auth.external authorization for mqtt", path)
 	}
+	if c.Auth.External.IdentityCacheSize < 0 {
+		return fmt.Errorf("%senabled requires a bounded auth.external.identity_cache_size", path)
+	}
 	if !hasAddr(c.Server.TCP.MTLS.Addr) && !hasAddr(c.Server.WebSocket.MTLS.Addr) {
 		return fmt.Errorf("%senabled requires a configured MQTT TCP or WebSocket mTLS listener", path)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,7 @@ const (
 	authProtocolsField         = "protocols"
 	authIdentityCacheSizeField = "identity_cache_size"
 	authIdentityCacheTTLField  = "identity_cache_ttl"
+	certificateMaximumCacheTTL = 5 * time.Minute
 	clientAuthRequire          = "require"
 )
 
@@ -79,7 +80,26 @@ type Config struct {
 // AuthConfig configures external callouts and broker-local principals.
 type AuthConfig struct {
 	External        ExternalAuthConfig     `yaml:"external"`
+	Certificate     CertificateAuthConfig  `yaml:"certificate"`
 	LocalPrincipals []LocalPrincipalConfig `yaml:"local_principals"`
+}
+
+// CertificateAuthConfig enables Atom resolver-tier authentication on the MQTT
+// TCP and WebSocket mTLS listeners. Other listeners and non-certificate
+// authentication paths are intentionally unaffected.
+type CertificateAuthConfig struct {
+	Enabled                  bool          `yaml:"enabled"`
+	ResolverAddress          string        `yaml:"resolver_address"`
+	ResolverInsecure         bool          `yaml:"resolver_insecure"`
+	ServiceTokenFile         string        `yaml:"service_token_file"`
+	TrustBundleURL           string        `yaml:"trust_bundle_url"`
+	ResolverTimeout          time.Duration `yaml:"resolver_timeout"`
+	CacheTTL                 time.Duration `yaml:"cache_ttl"`
+	CacheSize                int           `yaml:"cache_size"`
+	TrustRefreshInterval     time.Duration `yaml:"trust_refresh_interval"`
+	EventQueue               string        `yaml:"event_queue"`
+	EventConsumerGroupPrefix string        `yaml:"event_consumer_group_prefix"`
+	EventSourcePrincipal     string        `yaml:"event_source_principal"`
 }
 
 // ExternalAuthConfig configures the external authentication/authorization callout.
@@ -298,6 +318,22 @@ func validateAuthYAML(node *yaml.Node) error {
 				authProtocolsField:         nil,
 				authIdentityCacheSizeField: nil,
 				authIdentityCacheTTLField:  nil,
+			})
+		},
+		"certificate": func(certificate *yaml.Node) error {
+			return validateYAMLMapping(certificate, "auth.certificate", map[string]func(*yaml.Node) error{
+				"enabled":                     nil,
+				"resolver_address":            nil,
+				"resolver_insecure":           nil,
+				"service_token_file":          nil,
+				"trust_bundle_url":            nil,
+				"resolver_timeout":            nil,
+				"cache_ttl":                   nil,
+				"cache_size":                  nil,
+				"trust_refresh_interval":      nil,
+				"event_queue":                 nil,
+				"event_consumer_group_prefix": nil,
+				"event_source_principal":      nil,
 			})
 		},
 		"local_principals": func(principals *yaml.Node) error {
@@ -1230,6 +1266,15 @@ func Default() *Config {
 				Burst:   10,
 			},
 		},
+		Auth: AuthConfig{
+			Certificate: CertificateAuthConfig{
+				ResolverTimeout:          3 * time.Second,
+				CacheTTL:                 30 * time.Second,
+				CacheSize:                10000,
+				TrustRefreshInterval:     time.Minute,
+				EventConsumerGroupPrefix: "fluxmq-pki",
+			},
+		},
 		QueueManager: QueueManagerConfig{
 			AutoCommitInterval: 5 * time.Second,
 		},
@@ -1402,7 +1447,8 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("server.tcp.%s.write_timeout cannot be negative", slot.name)
 		}
 		if slot.requireTLS {
-			if err := validateListenerTLS("server.tcp."+slot.name, slot.cfg.TLS, slot.requireClientAuth); err != nil {
+			requireStaticCA := slot.requireClientAuth && !(c.Auth.Certificate.Enabled && slot.name == listenerNameMTLS)
+			if err := validateListenerTLS("server.tcp."+slot.name, slot.cfg.TLS, requireStaticCA); err != nil {
 				return err
 			}
 		} else if tlsConfigured(slot.cfg.TLS) {
@@ -1436,7 +1482,8 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("server.websocket.%s.write_timeout cannot be negative", slot.name)
 		}
 		if slot.requireTLS {
-			if err := validateListenerTLS("server.websocket."+slot.name, slot.cfg.TLS, slot.requireClientAuth); err != nil {
+			requireStaticCA := slot.requireClientAuth && !(c.Auth.Certificate.Enabled && slot.name == listenerNameMTLS)
+			if err := validateListenerTLS("server.websocket."+slot.name, slot.cfg.TLS, requireStaticCA); err != nil {
 				return err
 			}
 		} else if tlsConfigured(slot.cfg.TLS) {
@@ -1580,6 +1627,9 @@ func (c *Config) Validate() error {
 		if !knownAuthProtocols[proto] {
 			return fmt.Errorf("auth.external.protocols: unknown protocol %q (valid: mqtt, amqp, amqp091, http, coap)", proto)
 		}
+	}
+	if err := c.validateCertificateAuthentication(); err != nil {
+		return err
 	}
 	if err := ValidateLocalPrincipals(c.Auth.LocalPrincipals); err != nil {
 		return err
@@ -2047,6 +2097,105 @@ func ValidateLocalPrincipals(principals []LocalPrincipalConfig) error {
 		}
 	}
 
+	return nil
+}
+
+func (c *Config) validateCertificateAuthentication() error {
+	certificate := c.Auth.Certificate
+	if !certificate.Enabled {
+		return nil
+	}
+	const path = "auth.certificate."
+	if !c.Auth.External.EnabledFor(protocolMQTT) {
+		return fmt.Errorf("%senabled requires auth.external authorization for mqtt", path)
+	}
+	if !hasAddr(c.Server.TCP.MTLS.Addr) && !hasAddr(c.Server.WebSocket.MTLS.Addr) {
+		return fmt.Errorf("%senabled requires a configured MQTT TCP or WebSocket mTLS listener", path)
+	}
+	if hasAddr(c.Server.TCP.MTLS.Addr) && strings.ToLower(strings.TrimSpace(c.Server.TCP.MTLS.TLS.ClientAuth)) != clientAuthRequire {
+		return fmt.Errorf("server.tcp.mtls.client_auth must be %q when %senabled is true", clientAuthRequire, path)
+	}
+	if hasAddr(c.Server.WebSocket.MTLS.Addr) && strings.ToLower(strings.TrimSpace(c.Server.WebSocket.MTLS.TLS.ClientAuth)) != clientAuthRequire {
+		return fmt.Errorf("server.websocket.mtls.client_auth must be %q when %senabled is true", clientAuthRequire, path)
+	}
+	if strings.TrimSpace(certificate.ResolverAddress) == "" {
+		return fmt.Errorf("%sresolver_address is required", path)
+	}
+	if strings.TrimSpace(certificate.ServiceTokenFile) == "" {
+		return fmt.Errorf("%sservice_token_file is required", path)
+	}
+	info, err := os.Stat(certificate.ServiceTokenFile)
+	if err != nil {
+		return fmt.Errorf("%sservice_token_file: %w", path, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%sservice_token_file must be a regular file", path)
+	}
+	parsedTrustURL, err := url.ParseRequestURI(certificate.TrustBundleURL)
+	if err != nil || parsedTrustURL.Host == "" || (parsedTrustURL.Scheme != "https" && parsedTrustURL.Scheme != "http") {
+		return fmt.Errorf("%strust_bundle_url must be an absolute HTTP(S) URL", path)
+	}
+	if parsedTrustURL.Scheme != "https" && !certificate.ResolverInsecure {
+		return fmt.Errorf("%strust_bundle_url must use HTTPS unless resolver_insecure is explicitly enabled", path)
+	}
+	if certificate.ResolverTimeout < 0 {
+		return fmt.Errorf("%sresolver_timeout cannot be negative", path)
+	}
+	if certificate.CacheTTL < 0 || certificate.CacheTTL > certificateMaximumCacheTTL {
+		return fmt.Errorf("%scache_ttl must not exceed %s", path, certificateMaximumCacheTTL)
+	}
+	if certificate.CacheSize < 0 {
+		return fmt.Errorf("%scache_size cannot be negative", path)
+	}
+	if certificate.TrustRefreshInterval < 0 {
+		return fmt.Errorf("%strust_refresh_interval cannot be negative", path)
+	}
+	if strings.TrimSpace(certificate.EventQueue) == "" {
+		return fmt.Errorf("%sevent_queue is required", path)
+	}
+	if strings.TrimSpace(certificate.EventConsumerGroupPrefix) == "" || containsWildcard(certificate.EventConsumerGroupPrefix) {
+		return fmt.Errorf("%sevent_consumer_group_prefix must be non-empty and contain no wildcard", path)
+	}
+	if strings.TrimSpace(certificate.EventSourcePrincipal) == "" {
+		return fmt.Errorf("%sevent_source_principal is required", path)
+	}
+
+	queueFound := false
+	for _, queue := range c.Queues {
+		if queue.Name != certificate.EventQueue {
+			continue
+		}
+		queueFound = true
+		if queue.Type != "stream" || !queue.Reserved {
+			return fmt.Errorf("%sevent_queue must name a reserved stream queue", path)
+		}
+		break
+	}
+	if !queueFound {
+		return fmt.Errorf("%sevent_queue must name an entry in queues", path)
+	}
+
+	principalFound := false
+	for _, principal := range c.Auth.LocalPrincipals {
+		if principal.Name != certificate.EventSourcePrincipal {
+			continue
+		}
+		principalFound = true
+		allowed := false
+		for _, permission := range principal.Permissions.Publish {
+			if permission.Exchange == "" && permission.RoutingKey == certificate.EventQueue && !permission.IsPrefix() {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return fmt.Errorf("%sevent_source_principal must have an exact default-exchange publish grant for event_queue", path)
+		}
+		break
+	}
+	if !principalFound {
+		return fmt.Errorf("%sevent_source_principal must name an auth.local_principals entry", path)
+	}
 	return nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,8 @@ const (
 	protocolMQTT    = "mqtt"
 	protocolAMQP    = "amqp"
 	protocolAMQP091 = "amqp091"
+	protocolHTTP    = "http"
+	protocolCoAP    = "coap"
 
 	defaultTCPV3Addr = ":1883"
 	defaultTCPV5Addr = ":1884"
@@ -470,7 +472,7 @@ type HooksConfig struct {
 
 // knownAuthProtocols is the set of valid protocol names for auth config.
 var knownAuthProtocols = map[string]bool{
-	protocolMQTT: true, protocolAMQP: true, protocolAMQP091: true, "http": true, "coap": true,
+	protocolMQTT: true, protocolAMQP: true, protocolAMQP091: true, protocolHTTP: true, protocolCoAP: true,
 }
 
 var knownBlockingHooks = map[string]bool{
@@ -1884,7 +1886,7 @@ func (c *Config) Validate() error {
 			if endpoint.Name == "" {
 				return fmt.Errorf("webhook.endpoints[%d].name cannot be empty", i)
 			}
-			if endpoint.Type != "http" {
+			if endpoint.Type != protocolHTTP {
 				return fmt.Errorf("webhook.endpoints[%d].type must be 'http' (grpc not yet supported)", i)
 			}
 			if endpoint.URL == "" {
@@ -2135,7 +2137,7 @@ func (c *Config) validateCertificateAuthentication() error {
 		return fmt.Errorf("%sservice_token_file must be a regular file", path)
 	}
 	parsedTrustURL, err := url.ParseRequestURI(certificate.TrustBundleURL)
-	if err != nil || parsedTrustURL.Host == "" || (parsedTrustURL.Scheme != "https" && parsedTrustURL.Scheme != "http") {
+	if err != nil || parsedTrustURL.Host == "" || (parsedTrustURL.Scheme != "https" && parsedTrustURL.Scheme != protocolHTTP) {
 		return fmt.Errorf("%strust_bundle_url must be an absolute HTTP(S) URL", path)
 	}
 	if parsedTrustURL.Scheme != "https" && !certificate.ResolverInsecure {

--- a/docs/content/docs/configuration/atom-certificate-authentication.md
+++ b/docs/content/docs/configuration/atom-certificate-authentication.md
@@ -1,0 +1,184 @@
+---
+title: Atom Certificate Authentication
+description: Resolver-tier MQTT mTLS identity, tenant binding, revocation, and trust refresh
+---
+
+# Atom Certificate Authentication
+
+FluxMQ's Atom integration is a **resolver verification tier** for MQTT over the
+TCP and WebSocket mTLS listeners. It is intended for standard- and long-lived
+device certificates, where authoritative revocation and owner lifecycle state
+matter more than removing Atom from the connection path. Plain MQTT, TLS
+without client certificates, HTTP, CoAP, and AMQP authentication are unchanged.
+
+At each MQTT CONNECT, FluxMQ copies the verified peer leaf and issuer DER from
+the TLS termination path and derives the leaf SHA-256 fingerprint and serial.
+It calls Atom's `atom.v1.CertificateService/ResolveCertificateV2` with those
+selectors. FluxMQ never reads identity or tenant scope from the certificate
+subject. Atom's response is the only certificate-to-entity mapping.
+
+For every publish and subscribe, FluxMQ:
+
+1. extracts the canonical tenant UUID from a Magistrala `m/<tenant>/...` or
+   `hc/<tenant>` topic;
+2. compares it with Atom's resolved tenant, rejecting cross-tenant and global
+   to tenant escalation;
+3. revalidates the certificate lifecycle fact from the bounded cache; and
+4. invokes the existing MQTT external authorizer with Atom's entity UUID and
+   the original operation.
+
+The tenant check always precedes normal authorization. Certificate
+authentication does not change topic design or existing authorization policy.
+
+## Failure and cache policy
+
+The default resolver cache TTL is 30 seconds and configuration rejects any TTL
+over five minutes. Entries are also capped by the certificate's own expiry and
+by `cache_size` (default 10,000, LRU eviction). A valid cache hit may be used
+during an Atom outage until that bound expires. A cache miss or expired entry
+fails closed. Concurrent connections presenting the same leaf share one
+resolver request.
+
+The operational recovery objective is therefore to restore Atom before the
+configured cache TTL elapses. After that point, new connections and the next
+operation on an existing certificate session are denied until Atom recovers.
+Set alerts on `resolver_failures`, `resolver_timeouts`, and a sustained fall in
+cache hits. Do not increase the TTL to mask availability problems: it is also
+the maximum fallback revocation lag if event consumption is interrupted.
+
+Atom lifecycle events normally make revocation faster than the TTL. Atom
+publishes its outbox to a protected `atom.events` stream. FluxMQ authenticates
+the exact local publisher principal, validates the Atom v1 envelope, and
+idempotently evicts entries by credential, entity, tenant, or issuer. A revoked
+live session is not killed asynchronously; its next publish or subscribe
+re-resolves and is denied. An idle revoked socket may remain connected but has
+no usable messaging authority. Certificate rotation on a reconnect replaces
+the client ID's old binding; the new certificate must resolve independently.
+
+This reference event topology uses an exact, crash-durable local-principal
+publish target and is consequently a single-node deployment contract. FluxMQ
+already rejects exact local-principal targets while clustering is enabled. A
+future clustered deployment must provide an equivalent fan-out stream in which
+every broker node receives every Atom invalidation event; it must not put all
+nodes in one competing-consumer group.
+
+## Trust bundle behavior
+
+FluxMQ fetches `/certs/trust-bundle.pem` from Atom before exposing an MQTT mTLS
+listener. Startup fails if the first fetch or PEM validation fails. The pool is
+refreshed with ETag revalidation on the configured interval and immediately
+after a `pki.authority.*` event. A failed refresh retains the last known-good
+pool. Each new handshake obtains the current pool atomically, so a newly
+provisioned tenant CA becomes usable without restarting FluxMQ.
+
+No legacy certificate service or serial-only resolver is called. Migrated
+deployments need only Atom's V2 resolver, published trust endpoint, normal
+external authorizer, and outbox event stream.
+
+## Configuration
+
+The Atom event publisher connects to `server.amqp091.local` with the declared
+URI SAN, username, and secret. Its exact default-exchange routing key must match
+the reserved stream below. `service_token_file` contains the bearer token used
+only on the resolver gRPC call and is reread for rotation.
+
+```yaml
+cluster:
+  enabled: false
+  node_id: broker-1
+
+server:
+  tcp:
+    mtls:
+      addr: ":8883"
+      protocol: auto
+      max_connections: 10000
+      read_timeout: 10s
+      write_timeout: 10s
+      cert_file: /run/secrets/fluxmq-server.pem
+      key_file: /run/secrets/fluxmq-server-key.pem
+      client_auth: require
+      min_version: TLS1.2
+  websocket:
+    mtls:
+      addr: ":8085"
+      path: /mqtt
+      protocol: auto
+      max_connections: 10000
+      read_timeout: 10s
+      write_timeout: 10s
+      cert_file: /run/secrets/fluxmq-server.pem
+      key_file: /run/secrets/fluxmq-server-key.pem
+      client_auth: require
+      min_version: TLS1.2
+  amqp091:
+    local:
+      addr: ":5683"
+      max_connections: 8
+      cert_file: /run/secrets/fluxmq-server.pem
+      key_file: /run/secrets/fluxmq-server-key.pem
+      ca_file: /run/secrets/service-client-ca.pem
+      client_auth: require
+      min_version: TLS1.2
+
+auth:
+  external:
+    url: https://magistrala-auth.internal:8181
+    transport: grpc
+    timeout: 2s
+    protocols:
+      mqtt: true
+
+  certificate:
+    enabled: true
+    resolver_address: atom.internal:8081
+    resolver_insecure: false
+    service_token_file: /run/secrets/fluxmq-atom-token
+    trust_bundle_url: https://atom.internal/certs/trust-bundle.pem
+    resolver_timeout: 3s
+    cache_ttl: 30s
+    cache_size: 10000
+    trust_refresh_interval: 1m
+    event_queue: atom.events
+    event_consumer_group_prefix: fluxmq-pki
+    event_source_principal: atom-events
+
+  local_principals:
+    - name: atom-events
+      certificate_uri_san: spiffe://example.org/atom/events
+      role: publisher
+      current_secret_file: /run/secrets/atom-events-secret
+      permissions:
+        publish:
+          - exchange: ""
+            routing_key: atom.events
+        subscribe: []
+
+queues:
+  - name: atom.events
+    topics: ["$queue/atom.events/#"]
+    reserved: true
+    type: stream
+    primary_group: fluxmq-pki
+    retention:
+      max_age: 24h
+      max_length_bytes: 67108864
+      max_length_messages: 100000
+    limits:
+      max_message_size: 1048576
+      max_depth: 100000
+```
+
+`resolver_insecure: true` permits both plaintext resolver gRPC and an HTTP
+trust URL and is for a loopback or already protected service-mesh hop only.
+Without it, the resolver uses system-trust TLS and `trust_bundle_url` must be
+HTTPS. The MQTT mTLS listeners do not need a static `ca_file` when this
+integration is enabled; Atom's published bundle is their client trust source.
+
+## Metrics
+
+`GET /api/v1/stats` includes a `certificates` object with active session and
+cache counts plus resolver requests/failures/timeouts, cache hits/misses/
+evictions, accepted/rejected events, invalidations, tenant denials, and trust
+refresh successes/failures. Counters have no entity, tenant, credential,
+fingerprint, or issuer labels.

--- a/docs/content/docs/configuration/atom-certificate-authentication.md
+++ b/docs/content/docs/configuration/atom-certificate-authentication.md
@@ -49,11 +49,12 @@ the maximum fallback revocation lag if event consumption is interrupted.
 Atom lifecycle events normally make revocation faster than the TTL. Atom
 publishes its outbox to a protected `atom.events` stream. FluxMQ authenticates
 the exact local publisher principal, validates the Atom v1 envelope, and
-idempotently evicts entries by credential, entity, tenant, or issuer. A revoked
-live session is not killed asynchronously; its next publish or subscribe
-re-resolves and is denied. An idle revoked socket may remain connected but has
-no usable messaging authority. Certificate rotation on a reconnect replaces
-the client ID's old binding; the new certificate must resolve independently.
+idempotently evicts entries by credential, entity, tenant, or issuer. Revocation,
+bulk entity revocation, inactive/deleted entities, and frozen/inactive/deleted
+tenants also remove matching certificate bindings and disconnect their live MQTT
+sessions. A reconnect must resolve authoritatively again. Certificate rotation
+replaces the client ID's old binding only for the same entity; the new
+certificate must resolve independently.
 
 This reference event topology uses an exact, crash-durable local-principal
 publish target and is consequently a single-node deployment contract. FluxMQ
@@ -179,6 +180,6 @@ integration is enabled; Atom's published bundle is their client trust source.
 
 `GET /api/v1/stats` includes a `certificates` object with active session and
 cache counts plus resolver requests/failures/timeouts, cache hits/misses/
-evictions, accepted/rejected events, invalidations, tenant denials, and trust
-refresh successes/failures. Counters have no entity, tenant, credential,
-fingerprint, or issuer labels.
+evictions, accepted/rejected events, invalidations, lifecycle-disconnected
+sessions, tenant denials, and trust refresh successes/failures. Counters have no
+entity, tenant, credential, fingerprint, or issuer labels.

--- a/docs/content/docs/configuration/meta.json
+++ b/docs/content/docs/configuration/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Configuration",
-  "pages": ["server", "storage", "clustering", "security", "hot-reload"]
+  "pages": ["server", "storage", "clustering", "security", "atom-certificate-authentication", "hot-reload"]
 }

--- a/docs/content/docs/configuration/meta.json
+++ b/docs/content/docs/configuration/meta.json
@@ -1,4 +1,11 @@
 {
   "title": "Configuration",
-  "pages": ["server", "storage", "clustering", "security", "atom-certificate-authentication", "hot-reload"]
+  "pages": [
+    "server",
+    "storage",
+    "clustering",
+    "security",
+    "atom-certificate-authentication",
+    "hot-reload"
+  ]
 }

--- a/docs/content/docs/configuration/security.md
+++ b/docs/content/docs/configuration/security.md
@@ -170,6 +170,16 @@ See [Internal AMQP Local Principals](/deployment/internal-amqp-local-principals)
 for the complete production configuration, rotation process, tests, and
 rollout contract.
 
+## Atom Certificate Authentication
+
+MQTT TCP and WebSocket mTLS listeners can use Atom's authoritative certificate
+resolver while retaining the existing external authorizer. This resolver tier
+binds certificate identities to canonical tenant UUIDs before authorization,
+uses a bounded cache with outbox-event invalidation, and refreshes client trust
+from Atom's published bundle. See
+[Atom Certificate Authentication](/configuration/atom-certificate-authentication)
+for its failure policy and complete deployment contract.
+
 ## Reserved Message Properties
 
 Message property names beginning with `_flux.` are reserved for broker-internal

--- a/docs/content/docs/reference/configuration-reference.md
+++ b/docs/content/docs/reference/configuration-reference.md
@@ -748,6 +748,20 @@ auth:
     identity_cache_size: 50000
     identity_cache_ttl: "1h"
 
+  certificate:
+    enabled: true
+    resolver_address: "atom.internal:8081"
+    resolver_insecure: false
+    service_token_file: "/run/secrets/fluxmq-atom-token"
+    trust_bundle_url: "https://atom.internal/certs/trust-bundle.pem"
+    resolver_timeout: "3s"
+    cache_ttl: "30s"
+    cache_size: 10000
+    trust_refresh_interval: "1m"
+    event_queue: "atom.events"
+    event_consumer_group_prefix: "fluxmq-pki"
+    event_source_principal: "atom-events"
+
   local_principals:
     - name: "audit-publisher"
       certificate_uri_san: "spiffe://example.org/audit-publisher"
@@ -769,6 +783,18 @@ auth:
 | `external.protocols`                            | `{}`    | External-auth protocol toggle. Empty means every protocol. |
 | `external.identity_cache_size`                  | `0`     | Maximum cached external identities; zero selects the broker default (`10000`), while a negative value disables size eviction. |
 | `external.identity_cache_ttl`                   | `0`     | External identity cache TTL; zero selects the broker default (`24h`), while a negative value disables TTL eviction. |
+| `certificate.enabled`                           | `false` | Enables Atom resolver-tier authentication on MQTT TCP and WebSocket mTLS listeners. Requires normal MQTT external authorization. |
+| `certificate.resolver_address`                  | —       | Atom gRPC address for `ResolveCertificateV2`. |
+| `certificate.resolver_insecure`                 | `false` | Explicitly permits plaintext resolver gRPC and an HTTP trust URL on a separately protected hop. |
+| `certificate.service_token_file`                | —       | File containing the resolver bearer token; reread on every cache-miss call for rotation. |
+| `certificate.trust_bundle_url`                  | —       | Atom `/certs/trust-bundle.pem` URL. Initial load is fail-closed; later refreshes retain the last known-good pool. |
+| `certificate.resolver_timeout`                  | `3s`    | Per-resolver-call and trust-refresh timeout. |
+| `certificate.cache_ttl`                         | `30s`   | Reviewed outage/revocation cache window. Must be positive and at most `5m`. |
+| `certificate.cache_size`                        | `10000` | Maximum LRU resolver entries. Must be positive. |
+| `certificate.trust_refresh_interval`            | `1m`    | ETag-based trust refresh interval; authority events also trigger refresh. |
+| `certificate.event_queue`                       | —       | Reserved stream carrying Atom outbox events. |
+| `certificate.event_consumer_group_prefix`       | `fluxmq-pki` | Prefix combined with the node ID so each node has its own invalidation group. |
+| `certificate.event_source_principal`            | —       | Exact local-principal name Atom must authenticate as when publishing events. |
 | `local_principals[].name`                       | —       | Unique SASL username for the local principal. |
 | `local_principals[].certificate_uri_san`        | —       | Exact URI SAN required on a CA-verified client certificate. |
 | `local_principals[].role`                       | `publisher` | Capability of the principal on every local listener: `publisher` may only publish; `service` may also consume and relay an origin identity. |
@@ -781,7 +807,9 @@ Valid `external.protocols` keys: `mqtt`, `amqp`, `amqp091`, `http`, `coap`.
 The old flat `auth.url`, `auth.transport`, `auth.timeout`, `auth.protocols`, and
 cache fields are invalid.
 
-See [Security configuration](/configuration/security) for detailed examples.
+See [Security configuration](/configuration/security) and
+[Atom Certificate Authentication](/configuration/atom-certificate-authentication)
+for detailed examples.
 
 ## Logging
 

--- a/mqtt/broker/broker.go
+++ b/mqtt/broker/broker.go
@@ -130,6 +130,7 @@ type Broker struct {
 	cfg       brokerConfig
 
 	sessionLocks  keyLock
+	connectLocks  keyLock
 	globalMu      sync.Mutex // protects lifecycle (Close, transferActiveSessions, expireSessions)
 	wg            sync.WaitGroup
 	sessionsMap   session.Cache

--- a/mqtt/broker/broker.go
+++ b/mqtt/broker/broker.go
@@ -260,28 +260,43 @@ func (b *Broker) SetAuthEngine(auth *broker.AuthEngine) {
 // resolved external identity (empty when no authenticator is configured or
 // when the authenticator did not return one).
 func (b *Broker) Authenticate(clientID, username, password string) (bool, string, error) {
+	return b.AuthenticateContext(context.Background(), clientID, username, password)
+}
+
+// AuthenticateContext validates credentials using the caller's context.
+func (b *Broker) AuthenticateContext(ctx context.Context, clientID, username, password string) (bool, string, error) {
 	if b.auth == nil {
 		return true, "", nil
 	}
-	return b.auth.Authenticate(clientID, username, password)
+	return b.auth.AuthenticateContext(ctx, clientID, username, password)
 }
 
 // CanPublish checks publish authorization for a client/topic pair.
 // Returns true when authz is not configured.
 func (b *Broker) CanPublish(clientID, topic string) bool {
+	return b.CanPublishContext(context.Background(), clientID, topic)
+}
+
+// CanPublishContext checks publish authorization using the caller's context.
+func (b *Broker) CanPublishContext(ctx context.Context, clientID, topic string) bool {
 	if b.auth == nil {
 		return true
 	}
-	return b.auth.CanPublish(clientID, topic)
+	return b.auth.CanPublishContext(ctx, clientID, topic)
 }
 
 // CanSubscribe checks subscribe authorization for a client/filter pair.
 // Returns true when authz is not configured.
 func (b *Broker) CanSubscribe(clientID, filter string) bool {
+	return b.CanSubscribeContext(context.Background(), clientID, filter)
+}
+
+// CanSubscribeContext checks subscribe authorization using the caller's context.
+func (b *Broker) CanSubscribeContext(ctx context.Context, clientID, filter string) bool {
 	if b.auth == nil {
 		return true
 	}
-	return b.auth.CanSubscribe(clientID, filter)
+	return b.auth.CanSubscribeContext(ctx, clientID, filter)
 }
 
 // ApplyRegisterHooks runs the optional auth_on_register hook.

--- a/mqtt/broker/broker.go
+++ b/mqtt/broker/broker.go
@@ -298,6 +298,7 @@ func (b *Broker) ApplyRegisterHooks(ctx context.Context, clientID, externalID, u
 			b.auth.Forget(clientID)
 		} else {
 			b.auth.SetExternalID(clientID, req.ExternalID)
+			req.ExternalID = b.auth.ExternalID(clientID)
 		}
 	}
 	return req.ExternalID, ok
@@ -347,6 +348,15 @@ func (b *Broker) ExternalID(clientID string) string {
 		return ""
 	}
 	return b.auth.ExternalID(clientID)
+}
+
+// CertificateSessionCount returns the number of bounded certificate identity
+// bindings currently retained by the authentication engine.
+func (b *Broker) CertificateSessionCount() int {
+	if b.auth == nil {
+		return 0
+	}
+	return b.auth.CertificateSessionCount()
 }
 
 // SetClientRateLimiter sets the client rate limiter for publish/subscribe rate limiting.

--- a/mqtt/broker/broker_test.go
+++ b/mqtt/broker/broker_test.go
@@ -95,7 +95,7 @@ func TestBroker_HandleV5Connect(t *testing.T) {
 		FixedHeader: packets.FixedHeader{
 			PacketType: packets.ConnectType,
 		},
-		ProtocolName:    "MQTT",
+		ProtocolName:    protocolNameMQTT,
 		ProtocolVersion: 5,
 		ClientID:        "test-client",
 		CleanStart:      true,

--- a/mqtt/broker/certificate.go
+++ b/mqtt/broker/certificate.go
@@ -1,0 +1,32 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	corebroker "github.com/absmach/fluxmq/broker"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
+)
+
+// DisconnectCertificateSessions revokes matching certificate bindings and
+// closes their live MQTT connections. Persistent session data is retained, but
+// a client must present and resolve a valid certificate before reconnecting.
+func (b *Broker) DisconnectCertificateSessions(match func(corebroker.CertificateIdentity) bool) int {
+	if b.auth == nil {
+		return 0
+	}
+	clientIDs := b.auth.InvalidateCertificateSessions(match)
+	disconnected := 0
+	for _, clientID := range clientIDs {
+		s := b.Get(clientID)
+		if s == nil || !s.IsConnected() {
+			continue
+		}
+		// Treat lifecycle revocation as graceful for Will purposes: a revoked
+		// credential must not publish one final message while being removed.
+		if err := s.Disconnect(true, v5.DisconnectAdministrativeAction); err == nil {
+			disconnected++
+		}
+	}
+	return disconnected
+}

--- a/mqtt/broker/external_identity_test.go
+++ b/mqtt/broker/external_identity_test.go
@@ -7,9 +7,12 @@ import (
 	"context"
 	"io"
 	"testing"
+	"time"
 
 	corebroker "github.com/absmach/fluxmq/broker"
+	core "github.com/absmach/fluxmq/mqtt"
 	"github.com/absmach/fluxmq/mqtt/packets"
+	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
 	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/mqtt/session"
 	"github.com/absmach/fluxmq/storage"
@@ -20,6 +23,39 @@ import (
 type externalIDAuthenticator struct {
 	result *corebroker.AuthnResult
 	err    error
+}
+
+type certificateResolverAuthenticator struct {
+	calls int
+}
+
+func (auth *certificateResolverAuthenticator) AuthenticateCertificate(_ context.Context, peer corebroker.PeerCertificate) (corebroker.CertificateIdentity, error) {
+	auth.calls++
+	return corebroker.CertificateIdentity{
+		EntityID:     "8a0a5c59-4ea8-4fc1-badb-f96cf739b224",
+		TenantID:     "d204f7df-8293-4194-963b-a47a65bc8f04",
+		CredentialID: "ca49950c-3ed2-41b4-a319-896085285686",
+		Fingerprint:  "certificate-fingerprint",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	}, nil
+}
+
+func (auth *certificateResolverAuthenticator) AuthorizeCertificate(context.Context, corebroker.CertificateIdentity, string) error {
+	return nil
+}
+
+type certificateMockConnection struct {
+	mockConnection
+	leafDER   []byte
+	issuerDER []byte
+}
+
+func (connection *certificateMockConnection) PeerCertificateDER() []byte {
+	return append([]byte(nil), connection.leafDER...)
+}
+
+func (connection *certificateMockConnection) PeerIssuerCertificateDER() []byte {
+	return append([]byte(nil), connection.issuerDER...)
 }
 
 func (a *externalIDAuthenticator) Authenticate(clientID, username, secret string) (*corebroker.AuthnResult, error) {
@@ -104,6 +140,64 @@ func TestV5ConnectStoresExternalIDOnSession(t *testing.T) {
 	s := b.Get("test-client")
 	require.NotNil(t, s)
 	require.Equal(t, "ext-123", s.ExternalID)
+}
+
+func TestCertificateAuthenticationRunsForMQTTV3AndV5(t *testing.T) {
+	tests := []struct {
+		name    string
+		connect func(clientID string) packets.ControlPacket
+		handle  func(*Broker, core.Connection, packets.ControlPacket) error
+	}{
+		{
+			name: "v3 over mTLS transport",
+			connect: func(clientID string) packets.ControlPacket {
+				return &v3.Connect{
+					FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
+					ProtocolName:    "MQTT",
+					ProtocolVersion: 4,
+					ClientID:        clientID,
+					CleanSession:    true,
+					KeepAlive:       60,
+				}
+			},
+			handle: func(broker *Broker, connection core.Connection, packet packets.ControlPacket) error {
+				return newV3Handler(broker).HandleConnect(connection, packet)
+			},
+		},
+		{
+			name: "v5 over mTLS transport",
+			connect: func(clientID string) packets.ControlPacket {
+				return &v5.Connect{
+					FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
+					ProtocolName:    "MQTT",
+					ProtocolVersion: 5,
+					ClientID:        clientID,
+					CleanStart:      true,
+					KeepAlive:       60,
+				}
+			},
+			handle: func(broker *Broker, connection core.Connection, packet packets.ControlPacket) error {
+				return newV5Handler(broker).HandleConnect(connection, packet)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b := NewBroker(memory.New(), nil)
+			defer b.Close()
+			resolver := &certificateResolverAuthenticator{}
+			b.SetAuthEngine(corebroker.NewAuthEngine(nil, nil, corebroker.WithCertificateAuthentication(resolver)))
+			connection := &certificateMockConnection{leafDER: []byte{1, 2, 3}, issuerDER: []byte{4, 5, 6}}
+			clientID := "certificate-client"
+
+			err := test.handle(b, connection, test.connect(clientID))
+			require.True(t, err == nil || err == io.EOF, "unexpected connect error: %v", err)
+			require.Equal(t, 1, resolver.calls)
+			session := b.Get(clientID)
+			require.NotNil(t, session)
+			require.Equal(t, "8a0a5c59-4ea8-4fc1-badb-f96cf739b224", session.ExternalID)
+		})
+	}
 }
 
 func TestRegisterHookExternalIDOverridesAuthzIdentity(t *testing.T) {

--- a/mqtt/broker/external_identity_test.go
+++ b/mqtt/broker/external_identity_test.go
@@ -26,18 +26,22 @@ type externalIDAuthenticator struct {
 }
 
 type certificateResolverAuthenticator struct {
-	calls int
+	calls    int
+	identity corebroker.CertificateIdentity
 }
 
 func (auth *certificateResolverAuthenticator) AuthenticateCertificate(_ context.Context, peer corebroker.PeerCertificate) (corebroker.CertificateIdentity, error) {
 	auth.calls++
-	return corebroker.CertificateIdentity{
-		EntityID:     "8a0a5c59-4ea8-4fc1-badb-f96cf739b224",
-		TenantID:     "d204f7df-8293-4194-963b-a47a65bc8f04",
-		CredentialID: "ca49950c-3ed2-41b4-a319-896085285686",
-		Fingerprint:  "certificate-fingerprint",
-		ExpiresAt:    time.Now().Add(time.Hour),
-	}, nil
+	if auth.identity.EntityID == "" {
+		auth.identity = corebroker.CertificateIdentity{
+			EntityID:     "8a0a5c59-4ea8-4fc1-badb-f96cf739b224",
+			TenantID:     "d204f7df-8293-4194-963b-a47a65bc8f04",
+			CredentialID: "ca49950c-3ed2-41b4-a319-896085285686",
+			Fingerprint:  "certificate-fingerprint",
+			ExpiresAt:    time.Now().Add(time.Hour),
+		}
+	}
+	return auth.identity, nil
 }
 
 func (auth *certificateResolverAuthenticator) AuthorizeCertificate(context.Context, corebroker.CertificateIdentity, string) error {
@@ -198,6 +202,96 @@ func TestCertificateAuthenticationRunsForMQTTV3AndV5(t *testing.T) {
 			require.Equal(t, "8a0a5c59-4ea8-4fc1-badb-f96cf739b224", session.ExternalID)
 		})
 	}
+}
+
+func TestRejectedCertificateConnectCleansPendingIdentity(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+	resolver := &certificateResolverAuthenticator{}
+	auth := corebroker.NewAuthEngine(nil, nil, corebroker.WithCertificateAuthentication(resolver))
+	b.SetAuthEngine(auth)
+	connection := &certificateMockConnection{leafDER: []byte{1, 2, 3}, issuerDER: []byte{4, 5, 6}}
+	connect := &v5.Connect{
+		FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
+		ProtocolName:    "MQTT",
+		ProtocolVersion: 5,
+		ClientID:        "rejected-certificate-client",
+		CleanStart:      true,
+		KeepAlive:       60,
+		WillFlag:        true,
+		WillTopic:       "invalid/#",
+	}
+
+	require.ErrorIs(t, newV5Handler(b).HandleConnect(connection, connect), ErrTopicInvalid)
+	require.Zero(t, auth.CertificateSessionCount())
+	require.Empty(t, auth.ExternalID(connect.ClientID))
+}
+
+func TestCertificateLifecycleInvalidationDisconnectsLiveSession(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+	resolver := &certificateResolverAuthenticator{}
+	auth := corebroker.NewAuthEngine(nil, nil, corebroker.WithCertificateAuthentication(resolver))
+	b.SetAuthEngine(auth)
+	clientID := "revoked-certificate-client"
+	_, _, err := auth.AuthenticateWithPeer(context.Background(), clientID, "", "", corebroker.PeerCertificate{LeafDER: []byte{1}})
+	require.NoError(t, err)
+	binding, committed := auth.CommitCertificateAuthentication(clientID)
+	require.True(t, committed)
+	s, _, err := b.CreateSession(clientID, 5, session.Options{
+		CleanStart: true,
+		Will: &storage.WillMessage{
+			ClientID: clientID,
+			Topic:    "m/d204f7df-8293-4194-963b-a47a65bc8f04/c/will",
+			Payload:  []byte("must-not-publish"),
+		},
+	})
+	require.NoError(t, err)
+	_, _ = s.ConnectWithOptions(&mockConnection{}, session.ConnectOptions{
+		Version:            5,
+		CertificateBinding: binding,
+	})
+
+	disconnected := b.DisconnectCertificateSessions(func(identity corebroker.CertificateIdentity) bool {
+		return identity.CredentialID == "ca49950c-3ed2-41b4-a319-896085285686"
+	})
+	require.Equal(t, 1, disconnected)
+	require.False(t, s.IsConnected())
+	require.Nil(t, s.Will, "revocation must suppress the certificate session's Will")
+	require.Zero(t, auth.CertificateSessionCount())
+}
+
+func TestCertificateAuthenticationRejectsPersistentSessionOwnershipTakeover(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+	clientID := "owned-persistent-client"
+	victimEntityID := "8a0a5c59-4ea8-4fc1-badb-f96cf739b224"
+	s, _, err := b.CreateSession(clientID, 5, session.Options{CleanStart: false, ExpiryInterval: 300})
+	require.NoError(t, err)
+	s.ExternalID = victimEntityID
+
+	resolver := &certificateResolverAuthenticator{identity: corebroker.CertificateIdentity{
+		EntityID:     "ac47c9fd-1d4a-4270-bb11-ab6476a0bd3a",
+		TenantID:     "88b65e71-e41d-4f12-9800-6c621133af9b",
+		CredentialID: "05119e28-6260-4a06-8742-f925bcfdccd4",
+		Fingerprint:  "attacker-certificate",
+		ExpiresAt:    time.Now().Add(time.Hour),
+	}}
+	auth := corebroker.NewAuthEngine(nil, nil, corebroker.WithCertificateAuthentication(resolver))
+	b.SetAuthEngine(auth)
+	connection := &certificateMockConnection{leafDER: []byte{1, 2, 3}}
+	connect := &v5.Connect{
+		FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
+		ProtocolName:    "MQTT",
+		ProtocolVersion: 5,
+		ClientID:        clientID,
+		CleanStart:      false,
+		KeepAlive:       60,
+	}
+
+	require.ErrorIs(t, newV5Handler(b).HandleConnect(connection, connect), ErrNotAuthorized)
+	require.Equal(t, victimEntityID, s.ExternalID)
+	require.Zero(t, auth.CertificateSessionCount())
 }
 
 func TestRegisterHookExternalIDOverridesAuthzIdentity(t *testing.T) {

--- a/mqtt/broker/external_identity_test.go
+++ b/mqtt/broker/external_identity_test.go
@@ -52,8 +52,9 @@ func (auth *certificateResolverAuthenticator) AuthorizeCertificate(context.Conte
 
 type certificateMockConnection struct {
 	mockConnection
-	leafDER   []byte
-	issuerDER []byte
+	leafDER                   []byte
+	issuerDER                 []byte
+	certificateAuthentication bool
 }
 
 func (connection *certificateMockConnection) PeerCertificateDER() []byte {
@@ -62,6 +63,10 @@ func (connection *certificateMockConnection) PeerCertificateDER() []byte {
 
 func (connection *certificateMockConnection) PeerIssuerCertificateDER() []byte {
 	return append([]byte(nil), connection.issuerDER...)
+}
+
+func (connection *certificateMockConnection) CertificateAuthenticationEnabled() bool {
+	return connection.certificateAuthentication
 }
 
 func (a *externalIDAuthenticator) Authenticate(clientID, username, secret string) (*corebroker.AuthnResult, error) {
@@ -193,7 +198,11 @@ func TestCertificateAuthenticationRunsForMQTTV3AndV5(t *testing.T) {
 			defer b.Close()
 			resolver := &certificateResolverAuthenticator{}
 			b.SetAuthEngine(corebroker.NewAuthEngine(nil, nil, corebroker.WithCertificateAuthentication(resolver)))
-			connection := &certificateMockConnection{leafDER: []byte{1, 2, 3}, issuerDER: []byte{4, 5, 6}}
+			connection := &certificateMockConnection{
+				leafDER:                   []byte{1, 2, 3},
+				issuerDER:                 []byte{4, 5, 6},
+				certificateAuthentication: true,
+			}
 			clientID := "certificate-client"
 
 			err := test.handle(b, connection, test.connect(clientID))
@@ -206,13 +215,85 @@ func TestCertificateAuthenticationRunsForMQTTV3AndV5(t *testing.T) {
 	}
 }
 
+func TestVerifiedCertificateOnOrdinaryTLSListenerUsesExistingAuthentication(t *testing.T) {
+	tests := []struct {
+		name    string
+		connect func(clientID string) packets.ControlPacket
+		handle  func(*Broker, core.Connection, packets.ControlPacket) error
+	}{
+		{
+			name: "mqtt v3",
+			connect: func(clientID string) packets.ControlPacket {
+				return &v3.Connect{
+					FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
+					ProtocolName:    protocolNameMQTT,
+					ProtocolVersion: 4,
+					ClientID:        clientID,
+					CleanSession:    true,
+					KeepAlive:       60,
+					UsernameFlag:    true,
+					PasswordFlag:    true,
+					Username:        "ordinary-user",
+					Password:        []byte("ordinary-password"),
+				}
+			},
+			handle: func(broker *Broker, connection core.Connection, packet packets.ControlPacket) error {
+				return newV3Handler(broker).HandleConnect(connection, packet)
+			},
+		},
+		{
+			name: "mqtt v5",
+			connect: func(clientID string) packets.ControlPacket {
+				return &v5.Connect{
+					FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
+					ProtocolName:    protocolNameMQTT,
+					ProtocolVersion: 5,
+					ClientID:        clientID,
+					CleanStart:      true,
+					KeepAlive:       60,
+					UsernameFlag:    true,
+					PasswordFlag:    true,
+					Username:        "ordinary-user",
+					Password:        []byte("ordinary-password"),
+				}
+			},
+			handle: func(broker *Broker, connection core.Connection, packet packets.ControlPacket) error {
+				return newV5Handler(broker).HandleConnect(connection, packet)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			broker := NewBroker(memory.New(), nil)
+			defer broker.Close()
+			resolver := &certificateResolverAuthenticator{}
+			broker.SetAuthEngine(corebroker.NewAuthEngine(&externalIDAuthenticator{
+				result: &corebroker.AuthnResult{Authenticated: true, ID: "ordinary-identity"},
+			}, nil, corebroker.WithCertificateAuthentication(resolver)))
+			connection := &certificateMockConnection{
+				leafDER:                   []byte{1, 2, 3},
+				issuerDER:                 []byte{4, 5, 6},
+				certificateAuthentication: false,
+			}
+			clientID := "ordinary-tls-client"
+
+			err := test.handle(broker, connection, test.connect(clientID))
+			require.True(t, err == nil || err == io.EOF, "unexpected connect error: %v", err)
+			require.Zero(t, resolver.calls)
+			session := broker.Get(clientID)
+			require.NotNil(t, session)
+			require.Equal(t, "ordinary-identity", session.ExternalID)
+		})
+	}
+}
+
 func TestRejectedCertificateConnectCleansPendingIdentity(t *testing.T) {
 	b := NewBroker(memory.New(), nil)
 	defer b.Close()
 	resolver := &certificateResolverAuthenticator{}
 	auth := corebroker.NewAuthEngine(nil, nil, corebroker.WithCertificateAuthentication(resolver))
 	b.SetAuthEngine(auth)
-	connection := &certificateMockConnection{leafDER: []byte{1, 2, 3}, issuerDER: []byte{4, 5, 6}}
+	connection := &certificateMockConnection{leafDER: []byte{1, 2, 3}, issuerDER: []byte{4, 5, 6}, certificateAuthentication: true}
 	connect := &v5.Connect{
 		FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
 		ProtocolName:    protocolNameMQTT,
@@ -273,7 +354,7 @@ func TestCertificateAuthenticationRejectsUnauthorizedWillBeforeSession(t *testin
 			resolver := &certificateResolverAuthenticator{authorizeErr: errors.New("cross-tenant Will")}
 			auth := corebroker.NewAuthEngine(nil, nil, corebroker.WithCertificateAuthentication(resolver))
 			b.SetAuthEngine(auth)
-			connection := &certificateMockConnection{leafDER: []byte{1, 2, 3}}
+			connection := &certificateMockConnection{leafDER: []byte{1, 2, 3}, certificateAuthentication: true}
 
 			require.ErrorIs(t, test.handle(b, connection, test.connect), ErrNotAuthorized)
 			require.Zero(t, auth.CertificateSessionCount())
@@ -333,7 +414,7 @@ func TestCertificateAuthenticationRejectsPersistentSessionOwnershipTakeover(t *t
 	}}
 	auth := corebroker.NewAuthEngine(nil, nil, corebroker.WithCertificateAuthentication(resolver))
 	b.SetAuthEngine(auth)
-	connection := &certificateMockConnection{leafDER: []byte{1, 2, 3}}
+	connection := &certificateMockConnection{leafDER: []byte{1, 2, 3}, certificateAuthentication: true}
 	connect := &v5.Connect{
 		FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
 		ProtocolName:    protocolNameMQTT,

--- a/mqtt/broker/external_identity_test.go
+++ b/mqtt/broker/external_identity_test.go
@@ -5,6 +5,7 @@ package broker
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 	"time"
@@ -26,8 +27,9 @@ type externalIDAuthenticator struct {
 }
 
 type certificateResolverAuthenticator struct {
-	calls    int
-	identity corebroker.CertificateIdentity
+	calls        int
+	identity     corebroker.CertificateIdentity
+	authorizeErr error
 }
 
 func (auth *certificateResolverAuthenticator) AuthenticateCertificate(_ context.Context, peer corebroker.PeerCertificate) (corebroker.CertificateIdentity, error) {
@@ -45,7 +47,7 @@ func (auth *certificateResolverAuthenticator) AuthenticateCertificate(_ context.
 }
 
 func (auth *certificateResolverAuthenticator) AuthorizeCertificate(context.Context, corebroker.CertificateIdentity, string) error {
-	return nil
+	return auth.authorizeErr
 }
 
 type certificateMockConnection struct {
@@ -225,6 +227,58 @@ func TestRejectedCertificateConnectCleansPendingIdentity(t *testing.T) {
 	require.ErrorIs(t, newV5Handler(b).HandleConnect(connection, connect), ErrTopicInvalid)
 	require.Zero(t, auth.CertificateSessionCount())
 	require.Empty(t, auth.ExternalID(connect.ClientID))
+}
+
+func TestCertificateAuthenticationRejectsUnauthorizedWillBeforeSession(t *testing.T) {
+	tests := []struct {
+		name    string
+		connect packets.ControlPacket
+		handle  func(*Broker, core.Connection, packets.ControlPacket) error
+	}{
+		{
+			name: "mqtt v3",
+			connect: &v3.Connect{
+				FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
+				ProtocolName:    "MQTT",
+				ProtocolVersion: 4,
+				ClientID:        "certificate-will-v3",
+				CleanSession:    true,
+				WillFlag:        true,
+				WillTopic:       "m/88b65e71-e41d-4f12-9800-6c621133af9b/c/will",
+			},
+			handle: func(broker *Broker, connection core.Connection, packet packets.ControlPacket) error {
+				return newV3Handler(broker).HandleConnect(connection, packet)
+			},
+		},
+		{
+			name: "mqtt v5",
+			connect: &v5.Connect{
+				FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
+				ProtocolName:    "MQTT",
+				ProtocolVersion: 5,
+				ClientID:        "certificate-will-v5",
+				CleanStart:      true,
+				WillFlag:        true,
+				WillTopic:       "m/88b65e71-e41d-4f12-9800-6c621133af9b/c/will",
+			},
+			handle: func(broker *Broker, connection core.Connection, packet packets.ControlPacket) error {
+				return newV5Handler(broker).HandleConnect(connection, packet)
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b := NewBroker(memory.New(), nil)
+			defer b.Close()
+			resolver := &certificateResolverAuthenticator{authorizeErr: errors.New("cross-tenant Will")}
+			auth := corebroker.NewAuthEngine(nil, nil, corebroker.WithCertificateAuthentication(resolver))
+			b.SetAuthEngine(auth)
+			connection := &certificateMockConnection{leafDER: []byte{1, 2, 3}}
+
+			require.ErrorIs(t, test.handle(b, connection, test.connect), ErrNotAuthorized)
+			require.Zero(t, auth.CertificateSessionCount())
+		})
+	}
 }
 
 func TestCertificateLifecycleInvalidationDisconnectsLiveSession(t *testing.T) {

--- a/mqtt/broker/external_identity_test.go
+++ b/mqtt/broker/external_identity_test.go
@@ -129,7 +129,7 @@ func TestV5ConnectStoresExternalIDOnSession(t *testing.T) {
 	handler := newV5Handler(b)
 	connect := &v5.Connect{
 		FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
-		ProtocolName:    "MQTT",
+		ProtocolName:    protocolNameMQTT,
 		ProtocolVersion: 5,
 		ClientID:        "test-client",
 		CleanStart:      true,
@@ -159,7 +159,7 @@ func TestCertificateAuthenticationRunsForMQTTV3AndV5(t *testing.T) {
 			connect: func(clientID string) packets.ControlPacket {
 				return &v3.Connect{
 					FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
-					ProtocolName:    "MQTT",
+					ProtocolName:    protocolNameMQTT,
 					ProtocolVersion: 4,
 					ClientID:        clientID,
 					CleanSession:    true,
@@ -175,7 +175,7 @@ func TestCertificateAuthenticationRunsForMQTTV3AndV5(t *testing.T) {
 			connect: func(clientID string) packets.ControlPacket {
 				return &v5.Connect{
 					FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
-					ProtocolName:    "MQTT",
+					ProtocolName:    protocolNameMQTT,
 					ProtocolVersion: 5,
 					ClientID:        clientID,
 					CleanStart:      true,
@@ -215,7 +215,7 @@ func TestRejectedCertificateConnectCleansPendingIdentity(t *testing.T) {
 	connection := &certificateMockConnection{leafDER: []byte{1, 2, 3}, issuerDER: []byte{4, 5, 6}}
 	connect := &v5.Connect{
 		FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
-		ProtocolName:    "MQTT",
+		ProtocolName:    protocolNameMQTT,
 		ProtocolVersion: 5,
 		ClientID:        "rejected-certificate-client",
 		CleanStart:      true,
@@ -239,7 +239,7 @@ func TestCertificateAuthenticationRejectsUnauthorizedWillBeforeSession(t *testin
 			name: "mqtt v3",
 			connect: &v3.Connect{
 				FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
-				ProtocolName:    "MQTT",
+				ProtocolName:    protocolNameMQTT,
 				ProtocolVersion: 4,
 				ClientID:        "certificate-will-v3",
 				CleanSession:    true,
@@ -254,7 +254,7 @@ func TestCertificateAuthenticationRejectsUnauthorizedWillBeforeSession(t *testin
 			name: "mqtt v5",
 			connect: &v5.Connect{
 				FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
-				ProtocolName:    "MQTT",
+				ProtocolName:    protocolNameMQTT,
 				ProtocolVersion: 5,
 				ClientID:        "certificate-will-v5",
 				CleanStart:      true,
@@ -336,7 +336,7 @@ func TestCertificateAuthenticationRejectsPersistentSessionOwnershipTakeover(t *t
 	connection := &certificateMockConnection{leafDER: []byte{1, 2, 3}}
 	connect := &v5.Connect{
 		FixedHeader:     packets.FixedHeader{PacketType: packets.ConnectType},
-		ProtocolName:    "MQTT",
+		ProtocolName:    protocolNameMQTT,
 		ProtocolVersion: 5,
 		ClientID:        clientID,
 		CleanStart:      false,

--- a/mqtt/broker/session.go
+++ b/mqtt/broker/session.go
@@ -165,8 +165,8 @@ func (b *Broker) CreateSession(clientID string, version byte, opts session.Optio
 		return nil, false, err
 	}
 
-	s.SetOnDisconnect(func(s *session.Session, graceful bool) {
-		b.handleDisconnect(s, graceful)
+	s.SetOnBoundDisconnect(func(s *session.Session, graceful bool, certificateBinding uint64) {
+		b.handleDisconnect(s, graceful, certificateBinding)
 	})
 
 	b.sessionsMap.Set(clientID, s)
@@ -260,9 +260,13 @@ func (b *Broker) destroySessionLocked(ctx context.Context, s *session.Session) e
 }
 
 // handleDisconnect handles session disconnect.
-func (b *Broker) handleDisconnect(s *session.Session, graceful bool) {
+func (b *Broker) handleDisconnect(s *session.Session, graceful bool, certificateBinding uint64) {
 	if b.auth != nil {
-		b.auth.Forget(s.ID)
+		if certificateBinding != 0 {
+			b.auth.ForgetCertificateSession(s.ID, certificateBinding)
+		} else {
+			b.auth.Forget(s.ID)
+		}
 	}
 
 	// Webhook: client disconnected

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -131,6 +131,12 @@ func (h *v3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 			conn.Close()
 			return ErrTopicInvalid
 		}
+		if certificateAuthentication && !h.broker.auth.CanPublishPendingCertificate(clientID, p.WillTopic) {
+			h.broker.telemetry.stats.IncrementAuthErrors()
+			sendV3ConnAck(conn, false, v3.ConnAckNotAuthorized) //nolint:errcheck // best-effort rejection reply before closing
+			conn.Close()
+			return ErrNotAuthorized
+		}
 		// Note: Will payload is stored as []byte in storage.WillMessage
 		//nolint:godox // TODO: Consider zero-copy for will messages in future
 		will = &storage.WillMessage{

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -83,7 +83,12 @@ func (h *v3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 		username := p.Username
 		password := string(p.Password)
 
-		authenticated, resolvedID, err := h.broker.auth.Authenticate(clientID, username, password)
+		var peerCertificate corebroker.PeerCertificate
+		if peer, ok := conn.(corebroker.PeerCertificateSource); ok {
+			peerCertificate.LeafDER = peer.PeerCertificateDER()
+			peerCertificate.IssuerDER = peer.PeerIssuerCertificateDER()
+		}
+		authenticated, resolvedID, err := h.broker.auth.AuthenticateWithPeer(context.Background(), clientID, username, password, peerCertificate)
 		if err != nil || !authenticated {
 			h.broker.telemetry.stats.IncrementAuthErrors()
 			sendV3ConnAck(conn, false, v3.ConnAckBadUsernameOrPassword) //nolint:errcheck // best-effort rejection reply before closing

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -77,8 +77,22 @@ func (h *v3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 			return ErrClientIDRequired
 		}
 	}
+	h.broker.connectLocks.Lock(clientID)
+	connectLocked := true
+	defer func() {
+		if connectLocked {
+			h.broker.connectLocks.Unlock(clientID)
+		}
+	}()
+	authenticationPending := false
+	defer func() {
+		if authenticationPending && h.broker.auth != nil {
+			h.broker.auth.Forget(clientID)
+		}
+	}()
 
 	externalID := ""
+	certificateAuthentication := false
 	if h.broker.auth != nil {
 		username := p.Username
 		password := string(p.Password)
@@ -88,6 +102,7 @@ func (h *v3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 			peerCertificate.LeafDER = peer.PeerCertificateDER()
 			peerCertificate.IssuerDER = peer.PeerIssuerCertificateDER()
 		}
+		certificateAuthentication = len(peerCertificate.LeafDER) != 0 && h.broker.auth.CertificateAuthenticationEnabled()
 		authenticated, resolvedID, err := h.broker.auth.AuthenticateWithPeer(context.Background(), clientID, username, password, peerCertificate)
 		if err != nil || !authenticated {
 			h.broker.telemetry.stats.IncrementAuthErrors()
@@ -96,9 +111,11 @@ func (h *v3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 			return ErrNotAuthorized
 		}
 		externalID = resolvedID
+		authenticationPending = true
 	}
 	hookExternalID, ok := h.broker.ApplyRegisterHooks(context.Background(), clientID, externalID, p.Username, string(p.Password), corebroker.HookProtocolMQTT)
 	if !ok {
+		authenticationPending = false
 		h.broker.telemetry.stats.IncrementAuthErrors()
 		sendV3ConnAck(conn, false, v3.ConnAckNotAuthorized) //nolint:errcheck // best-effort rejection reply before closing
 		conn.Close()
@@ -140,6 +157,23 @@ func (h *v3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 		conn.Close()
 		return err
 	}
+	if certificateAuthentication && s.ExternalID != "" && s.ExternalID != externalID {
+		h.broker.telemetry.stats.IncrementAuthErrors()
+		sendV3ConnAck(conn, false, v3.ConnAckNotAuthorized) //nolint:errcheck // best-effort rejection reply before closing
+		conn.Close()
+		return ErrNotAuthorized
+	}
+	certificateBinding := uint64(0)
+	if certificateAuthentication {
+		var committed bool
+		certificateBinding, committed = h.broker.auth.CommitCertificateAuthentication(clientID)
+		if !committed {
+			h.broker.telemetry.stats.IncrementAuthErrors()
+			sendV3ConnAck(conn, false, v3.ConnAckNotAuthorized) //nolint:errcheck // best-effort rejection reply before closing
+			conn.Close()
+			return ErrNotAuthorized
+		}
+	}
 
 	s.ExternalID = externalID
 
@@ -151,12 +185,21 @@ func (h *v3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 	// 3.1.1 cannot advertise the value, so a client has no way to learn about a
 	// later change.
 	epoch, superseded := s.ConnectWithOptions(conn, session.ConnectOptions{
-		Version:        p.ProtocolVersion,
-		KeepAlive:      time.Duration(p.KeepAlive) * time.Second,
-		Will:           will,
-		ReceiveMaximum: maxReceived,
-		MaxQoS:         h.broker.MaxQoS(),
+		Version:            p.ProtocolVersion,
+		KeepAlive:          time.Duration(p.KeepAlive) * time.Second,
+		Will:               will,
+		ReceiveMaximum:     maxReceived,
+		MaxQoS:             h.broker.MaxQoS(),
+		CertificateBinding: certificateBinding,
 	})
+	authenticationPending = false
+	if certificateAuthentication {
+		currentBinding, current := h.broker.auth.CertificateSessionBinding(clientID)
+		if !current || currentBinding != certificateBinding {
+			s.DisconnectIf(true, epoch, v5.DisconnectAdministrativeAction) //nolint:errcheck // lifecycle invalidation raced connection establishment
+			return ErrNotAuthorized
+		}
+	}
 	if superseded != nil {
 		go h.broker.drainSuperseded(context.WithoutCancel(context.Background()), superseded)
 	}
@@ -179,6 +222,8 @@ func (h *v3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	h.deliverOfflineMessages(s)
 
+	h.broker.connectLocks.Unlock(clientID)
+	connectLocked = false
 	return h.broker.runSession(h, s, conn, epoch, time.Duration(p.KeepAlive)*time.Second)
 }
 

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -98,7 +98,7 @@ func (h *v3Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 		password := string(p.Password)
 
 		var peerCertificate corebroker.PeerCertificate
-		if peer, ok := conn.(corebroker.PeerCertificateSource); ok {
+		if peer, ok := conn.(corebroker.CertificateAuthenticationSource); ok && peer.CertificateAuthenticationEnabled() {
 			peerCertificate.LeafDER = peer.PeerCertificateDER()
 			peerCertificate.IssuerDER = peer.PeerIssuerCertificateDER()
 		}

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -84,7 +84,12 @@ func (h *v5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 		username := p.Username
 		password := string(p.Password)
 
-		authenticated, resolvedID, err := h.broker.auth.Authenticate(clientID, username, password)
+		var peerCertificate corebroker.PeerCertificate
+		if peer, ok := conn.(corebroker.PeerCertificateSource); ok {
+			peerCertificate.LeafDER = peer.PeerCertificateDER()
+			peerCertificate.IssuerDER = peer.PeerIssuerCertificateDER()
+		}
+		authenticated, resolvedID, err := h.broker.auth.AuthenticateWithPeer(context.Background(), clientID, username, password, peerCertificate)
 		if err != nil || !authenticated {
 			h.broker.telemetry.stats.IncrementAuthErrors()
 			sendV5ConnAck(conn, false, v5.ConnAckBadUsernameOrPassword, nil) //nolint:errcheck // best-effort rejection reply before closing

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -132,6 +132,12 @@ func (h *v5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 			conn.Close()
 			return ErrTopicInvalid
 		}
+		if certificateAuthentication && !h.broker.auth.CanPublishPendingCertificate(clientID, p.WillTopic) {
+			h.broker.telemetry.stats.IncrementAuthErrors()
+			sendV5ConnAck(conn, false, v5.ConnAckNotAuthorized, nil) //nolint:errcheck // best-effort rejection reply before closing
+			conn.Close()
+			return ErrNotAuthorized
+		}
 		// Note: Will payload is stored as []byte in storage.WillMessage
 		//nolint:godox // TODO: Consider zero-copy for will messages in future
 		will = &storage.WillMessage{

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -78,8 +78,22 @@ func (h *v5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 			return ErrClientIDRequired
 		}
 	}
+	h.broker.connectLocks.Lock(clientID)
+	connectLocked := true
+	defer func() {
+		if connectLocked {
+			h.broker.connectLocks.Unlock(clientID)
+		}
+	}()
+	authenticationPending := false
+	defer func() {
+		if authenticationPending && h.broker.auth != nil {
+			h.broker.auth.Forget(clientID)
+		}
+	}()
 
 	externalID := ""
+	certificateAuthentication := false
 	if h.broker.auth != nil {
 		username := p.Username
 		password := string(p.Password)
@@ -89,6 +103,7 @@ func (h *v5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 			peerCertificate.LeafDER = peer.PeerCertificateDER()
 			peerCertificate.IssuerDER = peer.PeerIssuerCertificateDER()
 		}
+		certificateAuthentication = len(peerCertificate.LeafDER) != 0 && h.broker.auth.CertificateAuthenticationEnabled()
 		authenticated, resolvedID, err := h.broker.auth.AuthenticateWithPeer(context.Background(), clientID, username, password, peerCertificate)
 		if err != nil || !authenticated {
 			h.broker.telemetry.stats.IncrementAuthErrors()
@@ -97,9 +112,11 @@ func (h *v5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 			return ErrNotAuthorized
 		}
 		externalID = resolvedID
+		authenticationPending = true
 	}
 	hookExternalID, ok := h.broker.ApplyRegisterHooks(context.Background(), clientID, externalID, p.Username, string(p.Password), corebroker.HookProtocolMQTT)
 	if !ok {
+		authenticationPending = false
 		h.broker.telemetry.stats.IncrementAuthErrors()
 		sendV5ConnAck(conn, false, v5.ConnAckNotAuthorized, nil) //nolint:errcheck // best-effort rejection reply before closing
 		conn.Close()
@@ -165,6 +182,23 @@ func (h *v5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 		conn.Close()
 		return err
 	}
+	if certificateAuthentication && s.ExternalID != "" && s.ExternalID != externalID {
+		h.broker.telemetry.stats.IncrementAuthErrors()
+		sendV5ConnAck(conn, false, v5.ConnAckNotAuthorized, nil) //nolint:errcheck // best-effort rejection reply before closing
+		conn.Close()
+		return ErrNotAuthorized
+	}
+	certificateBinding := uint64(0)
+	if certificateAuthentication {
+		var committed bool
+		certificateBinding, committed = h.broker.auth.CommitCertificateAuthentication(clientID)
+		if !committed {
+			h.broker.telemetry.stats.IncrementAuthErrors()
+			sendV5ConnAck(conn, false, v5.ConnAckNotAuthorized, nil) //nolint:errcheck // best-effort rejection reply before closing
+			conn.Close()
+			return ErrNotAuthorized
+		}
+	}
 
 	s.ExternalID = externalID
 
@@ -176,13 +210,22 @@ func (h *v5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 	// than the one its CONNACK announced.
 	sessionMaxQoS := h.broker.MaxQoS()
 	epoch, superseded := s.ConnectWithOptions(conn, session.ConnectOptions{
-		Version:        p.ProtocolVersion,
-		KeepAlive:      time.Duration(p.KeepAlive) * time.Second,
-		Will:           will,
-		ReceiveMaximum: receiveMax,
-		TopicAliasMax:  topicAliasMax,
-		MaxQoS:         sessionMaxQoS,
+		Version:            p.ProtocolVersion,
+		KeepAlive:          time.Duration(p.KeepAlive) * time.Second,
+		Will:               will,
+		ReceiveMaximum:     receiveMax,
+		TopicAliasMax:      topicAliasMax,
+		MaxQoS:             sessionMaxQoS,
+		CertificateBinding: certificateBinding,
 	})
+	authenticationPending = false
+	if certificateAuthentication {
+		currentBinding, current := h.broker.auth.CertificateSessionBinding(clientID)
+		if !current || currentBinding != certificateBinding {
+			s.DisconnectIf(true, epoch, v5.DisconnectAdministrativeAction) //nolint:errcheck // lifecycle invalidation raced connection establishment
+			return ErrNotAuthorized
+		}
+	}
 	// Session expiry is applied verbatim on reconnect so a new value of 0
 	// (expire on disconnect) replaces a previous positive one. A new session's
 	// expiry, including the server default policy, was already set in
@@ -212,6 +255,8 @@ func (h *v5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 
 	h.deliverOfflineMessages(s)
 
+	h.broker.connectLocks.Unlock(clientID)
+	connectLocked = false
 	return h.broker.runSession(h, s, conn, epoch, time.Duration(p.KeepAlive)*time.Second)
 }
 

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -99,7 +99,7 @@ func (h *v5Handler) HandleConnect(conn core.Connection, pkt packets.ControlPacke
 		password := string(p.Password)
 
 		var peerCertificate corebroker.PeerCertificate
-		if peer, ok := conn.(corebroker.PeerCertificateSource); ok {
+		if peer, ok := conn.(corebroker.CertificateAuthenticationSource); ok && peer.CertificateAuthenticationEnabled() {
 			peerCertificate.LeafDER = peer.PeerCertificateDER()
 			peerCertificate.IssuerDER = peer.PeerIssuerCertificateDER()
 		}

--- a/mqtt/connection.go
+++ b/mqtt/connection.go
@@ -92,16 +92,17 @@ type connection struct {
 
 	mu sync.RWMutex
 
-	sendMu           sync.Mutex
-	controlCh        chan sendItem
-	dataCh           chan sendItem
-	closeCh          chan struct{}
-	closeOnce        sync.Once
-	sendWg           sync.WaitGroup
-	writeTimeout     time.Duration // 0 = no write deadline
-	maxPacketSize    int           // 0 = unlimited
-	disconnectOnFull bool
-	closed           atomic.Bool
+	sendMu                    sync.Mutex
+	controlCh                 chan sendItem
+	dataCh                    chan sendItem
+	closeCh                   chan struct{}
+	closeOnce                 sync.Once
+	sendWg                    sync.WaitGroup
+	writeTimeout              time.Duration // 0 = no write deadline
+	maxPacketSize             int           // 0 = unlimited
+	disconnectOnFull          bool
+	certificateAuthentication bool
+	closed                    atomic.Bool
 
 	lastActivity atomic.Int64 // UnixNano timestamp; updated lock-free by Touch()
 
@@ -130,6 +131,14 @@ func WithWriteTimeout(d time.Duration) ConnOption {
 		if d > 0 {
 			c.writeTimeout = d
 		}
+	}
+}
+
+// WithCertificateAuthentication marks a connection as belonging to a listener
+// that explicitly authenticates verified peer certificates through Atom.
+func WithCertificateAuthentication(enabled bool) ConnOption {
+	return func(c *connection) {
+		c.certificateAuthentication = enabled
 	}
 }
 
@@ -211,6 +220,12 @@ func (c *connection) PeerIssuerCertificateDER() []byte {
 		return nil
 	}
 	return append([]byte(nil), state.VerifiedChains[0][1].Raw...)
+}
+
+// CertificateAuthenticationEnabled reports whether this connection belongs to
+// the explicitly configured certificate-authentication listener.
+func (c *connection) CertificateAuthenticationEnabled() bool {
+	return c.certificateAuthentication
 }
 
 // ReadPacket reads the next MQTT packet from the connection.

--- a/mqtt/connection.go
+++ b/mqtt/connection.go
@@ -5,6 +5,7 @@ package mqtt
 
 import (
 	"bufio"
+	"crypto/tls"
 	"errors"
 	"io"
 	"net"
@@ -184,6 +185,32 @@ func NewConnectionWithVersion(conn net.Conn, queueSize int, disconnectOnFull boo
 	}
 
 	return c
+}
+
+// PeerCertificateDER returns a copy of the verified TLS peer leaf.
+func (c *connection) PeerCertificateDER() []byte {
+	tlsConn, ok := c.conn.(*tls.Conn)
+	if !ok {
+		return nil
+	}
+	state := tlsConn.ConnectionState()
+	if len(state.VerifiedChains) == 0 || len(state.VerifiedChains[0]) == 0 {
+		return nil
+	}
+	return append([]byte(nil), state.VerifiedChains[0][0].Raw...)
+}
+
+// PeerIssuerCertificateDER returns a copy of the verified leaf issuer.
+func (c *connection) PeerIssuerCertificateDER() []byte {
+	tlsConn, ok := c.conn.(*tls.Conn)
+	if !ok {
+		return nil
+	}
+	state := tlsConn.ConnectionState()
+	if len(state.VerifiedChains) == 0 || len(state.VerifiedChains[0]) < 2 {
+		return nil
+	}
+	return append([]byte(nil), state.VerifiedChains[0][1].Raw...)
 }
 
 // ReadPacket reads the next MQTT packet from the connection.

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -61,6 +61,7 @@ type Session struct {
 	ExternalID          string
 	authMethod          string
 	authState           any
+	certificateBinding  uint64
 	conn                core.Connection
 	msgHandler          *msgHandler
 	Will                *storage.WillMessage
@@ -68,6 +69,7 @@ type Session struct {
 	subscriptionAliases map[string]string
 	subscriptionIDs     map[string][]uint32
 	onDisconnect        func(s *Session, graceful bool)
+	onBoundDisconnect   func(s *Session, graceful bool, certificateBinding uint64)
 	KeepAlive           time.Duration
 	state               State
 	// epoch is bumped on every Connect. It identifies the current connection
@@ -218,6 +220,9 @@ type ConnectOptions struct {
 	Will           *storage.WillMessage
 	ReceiveMaximum uint16
 	TopicAliasMax  uint16
+	// CertificateBinding scopes authentication cleanup to this connection
+	// generation. Zero denotes a non-certificate connection.
+	CertificateBinding uint64
 	// MaxQoS is the maximum QoS advertised to this connection. It is applied
 	// with the epoch bump so a superseded CONNECT cannot overwrite the value a
 	// replacement connection was granted.
@@ -273,6 +278,7 @@ func (s *Session) attach(c core.Connection, opts ConnectOptions, applyOpts bool)
 		s.Will = opts.Will
 		s.TopicAliasMax = opts.TopicAliasMax
 		s.maxQoS = opts.MaxQoS
+		s.certificateBinding = opts.CertificateBinding
 	}
 
 	// Topic alias mappings are scoped to a single network connection and must
@@ -563,8 +569,13 @@ func (s *Session) disconnectLocked(graceful bool, reasonCode byte) error {
 	s.msgHandler.ClearAliases()
 
 	callback := s.onDisconnect
+	boundCallback := s.onBoundDisconnect
+	certificateBinding := s.certificateBinding
 	if callback != nil {
 		go callback(s, graceful)
+	}
+	if boundCallback != nil {
+		go boundCallback(s, graceful, certificateBinding)
 	}
 
 	return nil
@@ -738,6 +749,14 @@ func (s *Session) SetOnDisconnect(fn func(*Session, bool)) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.onDisconnect = fn
+}
+
+// SetOnBoundDisconnect sets a callback that receives the authentication
+// binding captured from the connection generation being disconnected.
+func (s *Session) SetOnBoundDisconnect(fn func(*Session, bool, uint64)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onBoundDisconnect = fn
 }
 
 // AddSubscription adds a subscription to the cache.

--- a/mqtt/session/takeover_test.go
+++ b/mqtt/session/takeover_test.go
@@ -194,6 +194,37 @@ func TestConnectWithOptions_AppliesNewOptionsOnReconnect(t *testing.T) {
 	require.Equal(t, byte(4), superseded.Version, "superseded carries the old version")
 }
 
+func TestDisconnectCallbackCapturesCertificateBindingGeneration(t *testing.T) {
+	s := newTakeoverSession(t)
+	callbackStarted := make(chan struct{})
+	releaseCallback := make(chan struct{})
+	capturedBinding := make(chan uint64, 1)
+	s.SetOnBoundDisconnect(func(_ *Session, _ bool, certificateBinding uint64) {
+		close(callbackStarted)
+		<-releaseCallback
+		capturedBinding <- certificateBinding
+	})
+
+	oldConn := &recordingConn{}
+	oldEpoch, _ := s.ConnectWithOptions(oldConn, ConnectOptions{
+		Version:            5,
+		CertificateBinding: 41,
+	})
+	require.NoError(t, s.DisconnectIf(false, oldEpoch, v5.DisconnectUnspecifiedError))
+	<-callbackStarted
+
+	newConn := &recordingConn{}
+	_, _ = s.ConnectWithOptions(newConn, ConnectOptions{
+		Version:            5,
+		CertificateBinding: 42,
+	})
+	close(releaseCallback)
+
+	require.Equal(t, uint64(41), <-capturedBinding,
+		"delayed cleanup from the old connection must retain its old binding")
+	require.Equal(t, uint64(42), s.certificateBinding)
+}
+
 // TestSetExpiryInterval_ZeroReplacesPositive guards finding #3: a reconnect
 // carrying session expiry 0 (expire on disconnect) must replace a previous
 // positive value, not be ignored.

--- a/pki/cache.go
+++ b/pki/cache.go
@@ -1,0 +1,114 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package pki
+
+import (
+	"container/list"
+	"sync"
+	"time"
+
+	corebroker "github.com/absmach/fluxmq/broker"
+)
+
+type resolutionCache struct {
+	mu       sync.Mutex
+	capacity int
+	ttl      time.Duration
+	clock    func() time.Time
+	entries  map[string]*list.Element
+	order    *list.List
+}
+
+type resolutionEntry struct {
+	fingerprint string
+	identity    corebroker.CertificateIdentity
+	expiresAt   time.Time
+}
+
+func newResolutionCache(capacity int, ttl time.Duration) *resolutionCache {
+	return &resolutionCache{
+		capacity: capacity,
+		ttl:      ttl,
+		clock:    time.Now,
+		entries:  make(map[string]*list.Element),
+		order:    list.New(),
+	}
+}
+
+func (c *resolutionCache) get(fingerprint string) (corebroker.CertificateIdentity, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	elem, ok := c.entries[fingerprint]
+	if !ok {
+		return corebroker.CertificateIdentity{}, false
+	}
+	entry := elem.Value.(*resolutionEntry)
+	if !entry.expiresAt.After(c.clock()) {
+		c.remove(elem)
+		return corebroker.CertificateIdentity{}, false
+	}
+	c.order.MoveToFront(elem)
+	return entry.identity, true
+}
+
+func (c *resolutionCache) put(identity corebroker.CertificateIdentity) (evicted bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	expiresAt := c.clock().Add(c.ttl)
+	if identity.ExpiresAt.Before(expiresAt) {
+		expiresAt = identity.ExpiresAt
+	}
+	if elem, ok := c.entries[identity.Fingerprint]; ok {
+		entry := elem.Value.(*resolutionEntry)
+		entry.identity = identity
+		entry.expiresAt = expiresAt
+		c.order.MoveToFront(elem)
+		return false
+	}
+
+	entry := &resolutionEntry{
+		fingerprint: identity.Fingerprint,
+		identity:    identity,
+		expiresAt:   expiresAt,
+	}
+	c.entries[identity.Fingerprint] = c.order.PushFront(entry)
+	if c.capacity > 0 && c.order.Len() > c.capacity {
+		c.remove(c.order.Back())
+		return true
+	}
+	return false
+}
+
+func (c *resolutionCache) invalidate(match func(corebroker.CertificateIdentity) bool) int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	removed := 0
+	for elem := c.order.Back(); elem != nil; {
+		previous := elem.Prev()
+		if match(elem.Value.(*resolutionEntry).identity) {
+			c.remove(elem)
+			removed++
+		}
+		elem = previous
+	}
+	return removed
+}
+
+func (c *resolutionCache) len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.order.Len()
+}
+
+func (c *resolutionCache) remove(elem *list.Element) {
+	if elem == nil {
+		return
+	}
+	entry := elem.Value.(*resolutionEntry)
+	delete(c.entries, entry.fingerprint)
+	c.order.Remove(elem)
+}

--- a/pki/events.go
+++ b/pki/events.go
@@ -15,7 +15,10 @@ import (
 	"github.com/google/uuid"
 )
 
-const maximumEventBytes = 1024 * 1024
+const (
+	maximumEventBytes = 1024 * 1024
+	issuerIDDetail    = "issuer_id"
+)
 
 var ErrUntrustedEvent = errors.New("untrusted Atom certificate lifecycle event")
 
@@ -139,6 +142,19 @@ func sessionDisconnectionKeys(event domainEvent) (invalidationKeys, bool) {
 			keys.add(keys.tenants, *event.TenantID)
 		}
 		keys.addDetail(keys.tenants, event.Details["tenant_id"])
+	case "pki.authority.revoke", "pki.authority.revoked",
+		"pki.authority.expire", "pki.authority.expired",
+		"pki.authority.fail", "pki.authority.failed",
+		"pki.authority.disable", "pki.authority.disabled",
+		"pki.authority.delete", "pki.authority.deleted",
+		"pki.authority.remove", "pki.authority.removed",
+		"pki.authority.purge", "pki.authority.purged":
+		if event.TargetID != nil {
+			keys.add(keys.issuers, *event.TargetID)
+		}
+		for _, field := range []string{issuerIDDetail, "old_issuer_id"} {
+			keys.addDetail(keys.issuers, event.Details[field])
+		}
 	default:
 		return keys, false
 	}
@@ -179,7 +195,7 @@ func (keys invalidationKeys) addEnvelope(event domainEvent) {
 	for _, field := range []string{"entity_id"} {
 		keys.addDetail(keys.entities, event.Details[field])
 	}
-	for _, field := range []string{"issuer_id", "old_issuer_id", "new_issuer_id"} {
+	for _, field := range []string{issuerIDDetail, "old_issuer_id", "new_issuer_id"} {
 		keys.addDetail(keys.issuers, event.Details[field])
 	}
 	keys.addDetail(keys.issuers, event.Details["issuer_ids"])

--- a/pki/events.go
+++ b/pki/events.go
@@ -1,0 +1,162 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package pki
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	corebroker "github.com/absmach/fluxmq/broker"
+	"github.com/google/uuid"
+)
+
+const maximumEventBytes = 1024 * 1024
+
+var ErrUntrustedEvent = errors.New("untrusted Atom certificate lifecycle event")
+
+type domainEvent struct {
+	SchemaVersion uint32         `json:"schema_version"`
+	EventID       string         `json:"event_id"`
+	Event         string         `json:"event"`
+	Source        string         `json:"source"`
+	TenantID      *string        `json:"tenant_id"`
+	TargetKind    *string        `json:"target_kind"`
+	TargetID      *string        `json:"target_id"`
+	Outcome       string         `json:"outcome"`
+	Details       map[string]any `json:"details"`
+}
+
+type invalidationKeys struct {
+	credentials map[string]struct{}
+	entities    map[string]struct{}
+	issuers     map[string]struct{}
+	tenants     map[string]struct{}
+}
+
+// HandleEvent authenticates the broker-stamped publisher identity and Atom's
+// envelope before idempotently evicting affected resolver entries. It is safe
+// under at-least-once delivery.
+func (m *Manager) HandleEvent(payload []byte, properties map[string]string) error {
+	if corebroker.ExternalIDFromProperties(properties) != m.config.EventSourcePrincipal {
+		m.metrics.eventsRejected.Add(1)
+		return ErrUntrustedEvent
+	}
+	if len(payload) == 0 || len(payload) > maximumEventBytes {
+		m.metrics.eventsRejected.Add(1)
+		return fmt.Errorf("%w: invalid payload size", ErrUntrustedEvent)
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(payload)))
+	decoder.UseNumber()
+	var event domainEvent
+	if err := decoder.Decode(&event); err != nil {
+		m.metrics.eventsRejected.Add(1)
+		return fmt.Errorf("%w: invalid JSON", ErrUntrustedEvent)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		m.metrics.eventsRejected.Add(1)
+		return fmt.Errorf("%w: trailing JSON value", ErrUntrustedEvent)
+	}
+	if event.SchemaVersion != 1 || event.Source != "atom" || event.Outcome != "allow" || event.Event == "" {
+		m.metrics.eventsRejected.Add(1)
+		return fmt.Errorf("%w: invalid envelope", ErrUntrustedEvent)
+	}
+	if _, err := uuid.Parse(event.EventID); err != nil {
+		m.metrics.eventsRejected.Add(1)
+		return fmt.Errorf("%w: invalid event ID", ErrUntrustedEvent)
+	}
+
+	m.metrics.eventsReceived.Add(1)
+	keys := newInvalidationKeys()
+	keys.addEnvelope(event)
+	removed := m.cache.invalidate(func(identity corebroker.CertificateIdentity) bool {
+		return keys.matches(identity)
+	})
+	if removed != 0 {
+		m.metrics.cacheInvalidations.Add(uint64(removed))
+	}
+	if strings.HasPrefix(event.Event, "pki.authority.") {
+		m.requestTrustRefresh()
+	}
+	return nil
+}
+
+func newInvalidationKeys() invalidationKeys {
+	return invalidationKeys{
+		credentials: make(map[string]struct{}),
+		entities:    make(map[string]struct{}),
+		issuers:     make(map[string]struct{}),
+		tenants:     make(map[string]struct{}),
+	}
+}
+
+func (keys invalidationKeys) addEnvelope(event domainEvent) {
+	if event.TenantID != nil && strings.HasPrefix(event.Event, "tenant.") {
+		keys.add(keys.tenants, *event.TenantID)
+	}
+	if event.TargetKind != nil && event.TargetID != nil {
+		switch *event.TargetKind {
+		case "credential":
+			keys.add(keys.credentials, *event.TargetID)
+		case "entity":
+			if strings.HasPrefix(event.Event, "entity.") || event.Event == "certificate.revoke_entity" {
+				keys.add(keys.entities, *event.TargetID)
+			}
+		case "authority", "issuer", "pki_authority":
+			keys.add(keys.issuers, *event.TargetID)
+		case "tenant":
+			keys.add(keys.tenants, *event.TargetID)
+		}
+	}
+	for _, field := range []string{"credential_id", "old_credential_id", "new_credential_id"} {
+		keys.addDetail(keys.credentials, event.Details[field])
+	}
+	keys.addDetail(keys.credentials, event.Details["credential_ids"])
+	for _, field := range []string{"entity_id"} {
+		keys.addDetail(keys.entities, event.Details[field])
+	}
+	for _, field := range []string{"issuer_id", "old_issuer_id", "new_issuer_id"} {
+		keys.addDetail(keys.issuers, event.Details[field])
+	}
+	keys.addDetail(keys.issuers, event.Details["issuer_ids"])
+	keys.addDetail(keys.tenants, event.Details["tenant_id"])
+}
+
+func (keys invalidationKeys) addDetail(target map[string]struct{}, value any) {
+	switch typed := value.(type) {
+	case string:
+		keys.add(target, typed)
+	case []any:
+		for _, item := range typed {
+			if text, ok := item.(string); ok {
+				keys.add(target, text)
+			}
+		}
+	}
+}
+
+func (keys invalidationKeys) add(target map[string]struct{}, value string) {
+	parsed, err := uuid.Parse(value)
+	if err == nil {
+		target[parsed.String()] = struct{}{}
+	}
+}
+
+func (keys invalidationKeys) matches(identity corebroker.CertificateIdentity) bool {
+	if _, ok := keys.credentials[identity.CredentialID]; ok {
+		return true
+	}
+	if _, ok := keys.entities[identity.EntityID]; ok {
+		return true
+	}
+	if _, ok := keys.issuers[identity.IssuerID]; ok {
+		return true
+	}
+	if _, ok := keys.tenants[identity.TenantID]; ok {
+		return true
+	}
+	return false
+}

--- a/pki/events.go
+++ b/pki/events.go
@@ -4,6 +4,7 @@
 package pki
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -49,7 +50,7 @@ func (m *Manager) HandleEvent(payload []byte, properties map[string]string) erro
 		m.metrics.eventsRejected.Add(1)
 		return fmt.Errorf("%w: invalid payload size", ErrUntrustedEvent)
 	}
-	decoder := json.NewDecoder(strings.NewReader(string(payload)))
+	decoder := json.NewDecoder(bytes.NewReader(payload))
 	decoder.UseNumber()
 	var event domainEvent
 	if err := decoder.Decode(&event); err != nil {
@@ -70,18 +71,78 @@ func (m *Manager) HandleEvent(payload []byte, properties map[string]string) erro
 	}
 
 	m.metrics.eventsReceived.Add(1)
+	if !eventAffectsCertificates(event.Event) {
+		return nil
+	}
 	keys := newInvalidationKeys()
 	keys.addEnvelope(event)
+	if keys.empty() {
+		m.metrics.eventsRejected.Add(1)
+		return fmt.Errorf("%w: lifecycle event has no valid invalidation target", ErrUntrustedEvent)
+	}
+	m.lifecycle.Lock()
+	m.generation++
 	removed := m.cache.invalidate(func(identity corebroker.CertificateIdentity) bool {
 		return keys.matches(identity)
 	})
+	m.lifecycle.Unlock()
 	if removed != 0 {
 		m.metrics.cacheInvalidations.Add(uint64(removed))
+	}
+	disconnectKeys, disconnectSessions := sessionDisconnectionKeys(event)
+	if m.sessions != nil && disconnectSessions {
+		disconnected := m.sessions(disconnectKeys.matches)
+		if disconnected > 0 {
+			m.metrics.sessionsDisconnected.Add(uint64(disconnected))
+		}
 	}
 	if strings.HasPrefix(event.Event, "pki.authority.") {
 		m.requestTrustRefresh()
 	}
 	return nil
+}
+
+func eventAffectsCertificates(event string) bool {
+	return strings.HasPrefix(event, "certificate.") ||
+		strings.HasPrefix(event, "entity.") ||
+		strings.HasPrefix(event, "tenant.") ||
+		strings.HasPrefix(event, "pki.authority.")
+}
+
+func sessionDisconnectionKeys(event domainEvent) (invalidationKeys, bool) {
+	keys := newInvalidationKeys()
+	switch event.Event {
+	case "certificate.revoke":
+		if event.TargetID != nil {
+			keys.add(keys.credentials, *event.TargetID)
+		}
+		keys.addDetail(keys.credentials, event.Details["credential_id"])
+	case "certificate.renew":
+		revokeOld, _ := event.Details["revoke_old"].(bool)
+		if !revokeOld {
+			return keys, false
+		}
+		if event.TargetID != nil {
+			keys.add(keys.credentials, *event.TargetID)
+		}
+		keys.addDetail(keys.credentials, event.Details["old_credential_id"])
+	case "certificate.revoke_entity", "entity.disable", "entity.suspend", "entity.delete", "entity.purge":
+		if event.TargetID != nil {
+			keys.add(keys.entities, *event.TargetID)
+		}
+		keys.addDetail(keys.entities, event.Details["entity_id"])
+	case "tenant.disable", "tenant.freeze", "tenant.delete", "tenant.purge":
+		if event.TargetID != nil {
+			keys.add(keys.tenants, *event.TargetID)
+		}
+		if event.TenantID != nil {
+			keys.add(keys.tenants, *event.TenantID)
+		}
+		keys.addDetail(keys.tenants, event.Details["tenant_id"])
+	default:
+		return keys, false
+	}
+	return keys, true
 }
 
 func newInvalidationKeys() invalidationKeys {
@@ -159,4 +220,8 @@ func (keys invalidationKeys) matches(identity corebroker.CertificateIdentity) bo
 		return true
 	}
 	return false
+}
+
+func (keys invalidationKeys) empty() bool {
+	return len(keys.credentials) == 0 && len(keys.entities) == 0 && len(keys.issuers) == 0 && len(keys.tenants) == 0
 }

--- a/pki/grpc_resolver.go
+++ b/pki/grpc_resolver.go
@@ -1,0 +1,184 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package pki
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"unicode"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+const (
+	resolveCertificateV2Method = "/atom.v1.CertificateService/ResolveCertificateV2"
+	maximumServiceTokenBytes   = 64 * 1024
+)
+
+type grpcResolver struct {
+	connection       *grpc.ClientConn
+	serviceTokenFile string
+	request          protoreflect.MessageDescriptor
+	response         protoreflect.MessageDescriptor
+}
+
+func newGRPCResolver(config Config) (*grpcResolver, error) {
+	if _, err := readServiceToken(config.ServiceTokenFile); err != nil {
+		return nil, err
+	}
+	request, response, err := certificateMessageDescriptors()
+	if err != nil {
+		return nil, err
+	}
+	var transport credentials.TransportCredentials
+	if config.ResolverInsecure {
+		transport = insecure.NewCredentials()
+	} else {
+		transport = credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
+	}
+	connection, err := grpc.NewClient(
+		config.ResolverAddress,
+		grpc.WithTransportCredentials(transport),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create Atom certificate resolver client: %w", err)
+	}
+	return &grpcResolver{
+		connection:       connection,
+		serviceTokenFile: config.ServiceTokenFile,
+		request:          request,
+		response:         response,
+	}, nil
+}
+
+func (r *grpcResolver) ResolveCertificateV2(ctx context.Context, request ResolverRequest) (ResolverResult, error) {
+	token, err := readServiceToken(r.serviceTokenFile)
+	if err != nil {
+		return ResolverResult{}, err
+	}
+	ctx = metadata.AppendToOutgoingContext(ctx, "authorization", "Bearer "+token)
+
+	input := dynamicpb.NewMessage(r.request)
+	setBytes(input, "certificate_der", request.CertificateDER)
+	setString(input, "fingerprint_sha256", request.FingerprintSHA256)
+	setString(input, "issuer_fingerprint_sha256", request.IssuerFingerprintSHA256)
+	setString(input, "serial_number", request.SerialNumber)
+	setString(input, "expected_tenant_id", request.ExpectedTenantID)
+	output := dynamicpb.NewMessage(r.response)
+	if err := r.connection.Invoke(
+		ctx,
+		resolveCertificateV2Method,
+		input,
+		output,
+		grpc.MaxCallRecvMsgSize(64*1024),
+	); err != nil {
+		return ResolverResult{}, fmt.Errorf("Atom ResolveCertificateV2: %w", err)
+	}
+	return ResolverResult{
+		EntityID:     getString(output, "entity_id"),
+		TenantID:     getString(output, "tenant_id"),
+		CredentialID: getString(output, "credential_id"),
+		IssuerID:     getString(output, "issuer_id"),
+		ExpiresAt:    getString(output, "expires_at"),
+		Status:       getString(output, "status"),
+	}, nil
+}
+
+func (r *grpcResolver) Close() error {
+	return r.connection.Close()
+}
+
+func readServiceToken(filename string) (string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return "", fmt.Errorf("open Atom resolver service token: %w", err)
+	}
+	defer file.Close()
+	data, err := io.ReadAll(io.LimitReader(file, maximumServiceTokenBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("read Atom resolver service token: %w", err)
+	}
+	if len(data) == 0 || len(data) > maximumServiceTokenBytes {
+		return "", fmt.Errorf("Atom resolver service token is empty or exceeds %d bytes", maximumServiceTokenBytes)
+	}
+	token := strings.TrimSpace(string(data))
+	if token == "" || strings.IndexFunc(token, unicode.IsSpace) >= 0 {
+		return "", fmt.Errorf("Atom resolver service token must be one non-empty value")
+	}
+	return token, nil
+}
+
+func certificateMessageDescriptors() (protoreflect.MessageDescriptor, protoreflect.MessageDescriptor, error) {
+	optional := descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL
+	bytesType := descriptorpb.FieldDescriptorProto_TYPE_BYTES
+	stringType := descriptorpb.FieldDescriptorProto_TYPE_STRING
+	file, err := protodesc.NewFile(&descriptorpb.FileDescriptorProto{
+		Name:    proto.String("atom_certificate_v2_runtime.proto"),
+		Package: proto.String("atom.v1"),
+		Syntax:  proto.String("proto3"),
+		MessageType: []*descriptorpb.DescriptorProto{
+			{
+				Name: proto.String("ResolveCertificateV2Request"),
+				Field: []*descriptorpb.FieldDescriptorProto{
+					{Name: proto.String("certificate_der"), Number: proto.Int32(1), Label: &optional, Type: &bytesType},
+					{Name: proto.String("fingerprint_sha256"), Number: proto.Int32(2), Label: &optional, Type: &stringType},
+					{Name: proto.String("issuer_fingerprint_sha256"), Number: proto.Int32(3), Label: &optional, Type: &stringType},
+					{Name: proto.String("serial_number"), Number: proto.Int32(4), Label: &optional, Type: &stringType},
+					{Name: proto.String("expected_tenant_id"), Number: proto.Int32(5), Label: &optional, Type: &stringType},
+				},
+			},
+			{
+				Name: proto.String("ResolveCertificateV2Response"),
+				Field: []*descriptorpb.FieldDescriptorProto{
+					{Name: proto.String("entity_id"), Number: proto.Int32(1), Label: &optional, Type: &stringType},
+					{Name: proto.String("tenant_id"), Number: proto.Int32(2), Label: &optional, Type: &stringType},
+					{Name: proto.String("credential_id"), Number: proto.Int32(3), Label: &optional, Type: &stringType},
+					{Name: proto.String("issuer_id"), Number: proto.Int32(4), Label: &optional, Type: &stringType},
+					{Name: proto.String("expires_at"), Number: proto.Int32(5), Label: &optional, Type: &stringType},
+					{Name: proto.String("status"), Number: proto.Int32(6), Label: &optional, Type: &stringType},
+				},
+			},
+		},
+	}, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build Atom certificate resolver protobuf descriptors: %w", err)
+	}
+	messages := file.Messages()
+	return messages.ByName("ResolveCertificateV2Request"), messages.ByName("ResolveCertificateV2Response"), nil
+}
+
+func setBytes(message *dynamicpb.Message, name protoreflect.Name, value []byte) {
+	if len(value) == 0 {
+		return
+	}
+	field := message.Descriptor().Fields().ByName(name)
+	message.Set(field, protoreflect.ValueOfBytes(value))
+}
+
+func setString(message *dynamicpb.Message, name protoreflect.Name, value string) {
+	if value == "" {
+		return
+	}
+	field := message.Descriptor().Fields().ByName(name)
+	message.Set(field, protoreflect.ValueOfString(value))
+}
+
+func getString(message *dynamicpb.Message, name protoreflect.Name) string {
+	field := message.Descriptor().Fields().ByName(name)
+	return message.Get(field).String()
+}
+
+var _ Resolver = (*grpcResolver)(nil)

--- a/pki/manager.go
+++ b/pki/manager.go
@@ -1,0 +1,457 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+// Package pki implements FluxMQ's resolver verification tier for MQTT mTLS.
+// Atom is authoritative for certificate lifecycle state. Successful results
+// may be reused only from the bounded cache configured here; cache misses and
+// expired entries fail closed when Atom is unavailable.
+package pki
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	corebroker "github.com/absmach/fluxmq/broker"
+	"github.com/google/uuid"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	DefaultResolverTimeout     = 3 * time.Second
+	DefaultCacheTTL            = 30 * time.Second
+	MaximumCacheTTL            = 5 * time.Minute
+	DefaultCacheSize           = 10000
+	DefaultTrustRefresh        = time.Minute
+	maximumCertificateDERBytes = 64 * 1024
+	maximumTrustBundleBytes    = 4 * 1024 * 1024
+)
+
+var (
+	ErrInvalidPeerCertificate = errors.New("invalid peer certificate")
+	ErrResolverIdentity       = errors.New("invalid certificate resolver identity")
+	ErrTenantMismatch         = errors.New("certificate tenant does not match requested scope")
+	ErrTenantScopeUnknown     = errors.New("tenant-scoped topic has no canonical tenant UUID")
+)
+
+// Config configures resolver-tier certificate authentication. The cache TTL is
+// the maximum reviewed outage/revocation window and may not exceed five minutes.
+type Config struct {
+	ResolverAddress      string
+	ResolverInsecure     bool
+	ServiceTokenFile     string
+	TrustBundleURL       string
+	EventSourcePrincipal string
+	Timeout              time.Duration
+	CacheTTL             time.Duration
+	CacheSize            int
+	TrustRefreshInterval time.Duration
+}
+
+// ResolverRequest contains every selector extracted from the verified TLS
+// chain. ExpectedTenantID is set when revalidating an operation scope.
+type ResolverRequest struct {
+	CertificateDER          []byte
+	FingerprintSHA256       string
+	IssuerFingerprintSHA256 string
+	SerialNumber            string
+	ExpectedTenantID        string
+}
+
+// ResolverResult mirrors Atom ResolveCertificateV2's identity contract.
+type ResolverResult struct {
+	EntityID     string
+	TenantID     string
+	CredentialID string
+	IssuerID     string
+	ExpiresAt    string
+	Status       string
+}
+
+// Resolver is injectable so lifecycle and outage behavior can be tested
+// without weakening the production gRPC path.
+type Resolver interface {
+	ResolveCertificateV2(ctx context.Context, request ResolverRequest) (ResolverResult, error)
+}
+
+type managerMetrics struct {
+	resolverRequests     atomic.Uint64
+	resolverFailures     atomic.Uint64
+	resolverTimeouts     atomic.Uint64
+	cacheHits            atomic.Uint64
+	cacheMisses          atomic.Uint64
+	cacheEvictions       atomic.Uint64
+	eventsReceived       atomic.Uint64
+	eventsRejected       atomic.Uint64
+	cacheInvalidations   atomic.Uint64
+	tenantDenials        atomic.Uint64
+	trustRefreshSuccess  atomic.Uint64
+	trustRefreshFailures atomic.Uint64
+}
+
+// Manager resolves certificate identities, owns the bounded cache, consumes
+// invalidation events, and maintains an atomically refreshed trust bundle.
+type Manager struct {
+	config     Config
+	resolver   Resolver
+	httpClient *http.Client
+	logger     *slog.Logger
+	cache      *resolutionCache
+	metrics    managerMetrics
+	requests   singleflight.Group
+	clock      func() time.Time
+
+	trustMu   sync.RWMutex
+	trustPool *x509.CertPool
+	trustETag string
+	refreshCh chan struct{}
+	stopCh    chan struct{}
+	stopOnce  sync.Once
+	wg        sync.WaitGroup
+}
+
+type managerOptions struct {
+	resolver   Resolver
+	httpClient *http.Client
+	logger     *slog.Logger
+	clock      func() time.Time
+}
+
+// Option customizes a Manager.
+type Option func(*managerOptions)
+
+func WithResolver(resolver Resolver) Option {
+	return func(options *managerOptions) { options.resolver = resolver }
+}
+
+func WithHTTPClient(client *http.Client) Option {
+	return func(options *managerOptions) { options.httpClient = client }
+}
+
+func WithLogger(logger *slog.Logger) Option {
+	return func(options *managerOptions) { options.logger = logger }
+}
+
+func withClock(clock func() time.Time) Option {
+	return func(options *managerOptions) { options.clock = clock }
+}
+
+// NewManager constructs the resolver tier. Start must complete before any mTLS
+// listener is exposed so no connection uses a stale file-based trust source.
+func NewManager(config Config, opts ...Option) (*Manager, error) {
+	applyConfigDefaults(&config)
+	if err := validateConfig(config); err != nil {
+		return nil, err
+	}
+
+	options := managerOptions{
+		httpClient: &http.Client{Timeout: config.Timeout},
+		logger:     slog.Default(),
+		clock:      time.Now,
+	}
+	for _, option := range opts {
+		option(&options)
+	}
+	if options.httpClient == nil {
+		return nil, fmt.Errorf("certificate trust HTTP client is nil")
+	}
+	if options.logger == nil {
+		options.logger = slog.Default()
+	}
+	if options.clock == nil {
+		options.clock = time.Now
+	}
+
+	resolver := options.resolver
+	if resolver == nil {
+		var err error
+		resolver, err = newGRPCResolver(config)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	cache := newResolutionCache(config.CacheSize, config.CacheTTL)
+	cache.clock = options.clock
+	return &Manager{
+		config:     config,
+		resolver:   resolver,
+		httpClient: options.httpClient,
+		logger:     options.logger,
+		cache:      cache,
+		clock:      options.clock,
+		refreshCh:  make(chan struct{}, 1),
+		stopCh:     make(chan struct{}),
+	}, nil
+}
+
+func applyConfigDefaults(config *Config) {
+	if config.Timeout == 0 {
+		config.Timeout = DefaultResolverTimeout
+	}
+	if config.CacheTTL == 0 {
+		config.CacheTTL = DefaultCacheTTL
+	}
+	if config.CacheSize == 0 {
+		config.CacheSize = DefaultCacheSize
+	}
+	if config.TrustRefreshInterval == 0 {
+		config.TrustRefreshInterval = DefaultTrustRefresh
+	}
+}
+
+func validateConfig(config Config) error {
+	if strings.TrimSpace(config.ResolverAddress) == "" {
+		return fmt.Errorf("certificate resolver address is required")
+	}
+	if strings.TrimSpace(config.ServiceTokenFile) == "" {
+		return fmt.Errorf("certificate resolver service token file is required")
+	}
+	if strings.TrimSpace(config.TrustBundleURL) == "" {
+		return fmt.Errorf("Atom trust bundle URL is required")
+	}
+	if strings.TrimSpace(config.EventSourcePrincipal) == "" {
+		return fmt.Errorf("Atom event source principal is required")
+	}
+	if config.Timeout <= 0 {
+		return fmt.Errorf("certificate resolver timeout must be positive")
+	}
+	if config.CacheTTL <= 0 || config.CacheTTL > MaximumCacheTTL {
+		return fmt.Errorf("certificate resolver cache TTL must be positive and no greater than %s", MaximumCacheTTL)
+	}
+	if config.CacheSize <= 0 {
+		return fmt.Errorf("certificate resolver cache size must be positive")
+	}
+	if config.TrustRefreshInterval <= 0 {
+		return fmt.Errorf("certificate trust refresh interval must be positive")
+	}
+	return nil
+}
+
+// Start loads Atom's published trust bundle synchronously, then begins periodic
+// and event-triggered refresh. Initial failure is fatal and therefore closed.
+func (m *Manager) Start(ctx context.Context) error {
+	if err := m.RefreshTrustBundle(ctx); err != nil {
+		return err
+	}
+	m.wg.Add(1)
+	go m.trustRefreshLoop()
+	return nil
+}
+
+// Close stops background refresh and closes the owned resolver connection.
+func (m *Manager) Close() error {
+	m.stopOnce.Do(func() { close(m.stopCh) })
+	m.wg.Wait()
+	if closer, ok := m.resolver.(interface{ Close() error }); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+// AuthenticateCertificate authoritatively resolves the peer, using a valid
+// bounded cache entry when present. On a miss, any Atom error fails closed.
+func (m *Manager) AuthenticateCertificate(ctx context.Context, peer corebroker.PeerCertificate) (corebroker.CertificateIdentity, error) {
+	request, err := selectorsFromPeer(peer)
+	if err != nil {
+		return corebroker.CertificateIdentity{}, err
+	}
+	return m.resolve(ctx, request)
+}
+
+// AuthorizeCertificate revalidates lifecycle state from the bounded cache (or
+// Atom after expiry/invalidation), then compares the requested tenant before
+// FluxMQ calls its existing external authorizer.
+func (m *Manager) AuthorizeCertificate(ctx context.Context, identity corebroker.CertificateIdentity, topic string) error {
+	tenantID, scoped, err := topicTenant(topic)
+	if err != nil {
+		m.metrics.tenantDenials.Add(1)
+		return err
+	}
+	if scoped && identity.TenantID != tenantID {
+		m.metrics.tenantDenials.Add(1)
+		return ErrTenantMismatch
+	}
+
+	current, err := m.resolve(ctx, ResolverRequest{
+		FingerprintSHA256: identity.Fingerprint,
+		ExpectedTenantID:  tenantID,
+	})
+	if err != nil {
+		return err
+	}
+	if current.EntityID != identity.EntityID || current.TenantID != identity.TenantID || current.CredentialID != identity.CredentialID {
+		return ErrResolverIdentity
+	}
+	return nil
+}
+
+func (m *Manager) resolve(ctx context.Context, request ResolverRequest) (corebroker.CertificateIdentity, error) {
+	if request.FingerprintSHA256 == "" {
+		return corebroker.CertificateIdentity{}, ErrInvalidPeerCertificate
+	}
+	if cached, ok := m.cache.get(request.FingerprintSHA256); ok {
+		m.metrics.cacheHits.Add(1)
+		if request.ExpectedTenantID != "" && cached.TenantID != request.ExpectedTenantID {
+			m.metrics.tenantDenials.Add(1)
+			return corebroker.CertificateIdentity{}, ErrTenantMismatch
+		}
+		return cached, nil
+	}
+	m.metrics.cacheMisses.Add(1)
+
+	value, err, _ := m.requests.Do(request.FingerprintSHA256, func() (any, error) {
+		if cached, ok := m.cache.get(request.FingerprintSHA256); ok {
+			m.metrics.cacheHits.Add(1)
+			return cached, nil
+		}
+		m.metrics.resolverRequests.Add(1)
+		callCtx, cancel := context.WithTimeout(ctx, m.config.Timeout)
+		defer cancel()
+		result, err := m.resolver.ResolveCertificateV2(callCtx, request)
+		if err != nil {
+			m.metrics.resolverFailures.Add(1)
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(callCtx.Err(), context.DeadlineExceeded) {
+				m.metrics.resolverTimeouts.Add(1)
+			}
+			return corebroker.CertificateIdentity{}, err
+		}
+		identity, err := validateResolverResult(result, request.FingerprintSHA256, m.clock())
+		if err != nil {
+			m.metrics.resolverFailures.Add(1)
+			return corebroker.CertificateIdentity{}, err
+		}
+		if request.ExpectedTenantID != "" && identity.TenantID != request.ExpectedTenantID {
+			m.metrics.tenantDenials.Add(1)
+			return corebroker.CertificateIdentity{}, ErrTenantMismatch
+		}
+		if m.cache.put(identity) {
+			m.metrics.cacheEvictions.Add(1)
+		}
+		return identity, nil
+	})
+	if err != nil {
+		return corebroker.CertificateIdentity{}, err
+	}
+	identity := value.(corebroker.CertificateIdentity)
+	if request.ExpectedTenantID != "" && identity.TenantID != request.ExpectedTenantID {
+		m.metrics.tenantDenials.Add(1)
+		return corebroker.CertificateIdentity{}, ErrTenantMismatch
+	}
+	return identity, nil
+}
+
+func selectorsFromPeer(peer corebroker.PeerCertificate) (ResolverRequest, error) {
+	if len(peer.LeafDER) == 0 || len(peer.LeafDER) > maximumCertificateDERBytes {
+		return ResolverRequest{}, ErrInvalidPeerCertificate
+	}
+	certificate, err := x509.ParseCertificate(peer.LeafDER)
+	if err != nil || certificate.SerialNumber == nil || certificate.SerialNumber.Sign() < 0 {
+		return ResolverRequest{}, ErrInvalidPeerCertificate
+	}
+	leafDigest := sha256.Sum256(peer.LeafDER)
+	request := ResolverRequest{
+		CertificateDER:    append([]byte(nil), peer.LeafDER...),
+		FingerprintSHA256: hex.EncodeToString(leafDigest[:]),
+		SerialNumber:      normalizeSerial(certificate.SerialNumber),
+	}
+	if len(peer.IssuerDER) != 0 {
+		if _, err := x509.ParseCertificate(peer.IssuerDER); err != nil {
+			return ResolverRequest{}, ErrInvalidPeerCertificate
+		}
+		issuerDigest := sha256.Sum256(peer.IssuerDER)
+		request.IssuerFingerprintSHA256 = hex.EncodeToString(issuerDigest[:])
+	}
+	return request, nil
+}
+
+func normalizeSerial(serial *big.Int) string {
+	value := strings.TrimLeft(strings.ToLower(serial.Text(16)), "0")
+	if value == "" {
+		return "0"
+	}
+	return value
+}
+
+func validateResolverResult(result ResolverResult, fingerprint string, now time.Time) (corebroker.CertificateIdentity, error) {
+	if result.Status != "active" {
+		return corebroker.CertificateIdentity{}, ErrResolverIdentity
+	}
+	if _, err := uuid.Parse(result.EntityID); err != nil {
+		return corebroker.CertificateIdentity{}, ErrResolverIdentity
+	}
+	if result.TenantID != "" {
+		if _, err := uuid.Parse(result.TenantID); err != nil {
+			return corebroker.CertificateIdentity{}, ErrResolverIdentity
+		}
+	}
+	if _, err := uuid.Parse(result.CredentialID); err != nil {
+		return corebroker.CertificateIdentity{}, ErrResolverIdentity
+	}
+	if result.IssuerID != "" {
+		if _, err := uuid.Parse(result.IssuerID); err != nil {
+			return corebroker.CertificateIdentity{}, ErrResolverIdentity
+		}
+	}
+	expiresAt, err := time.Parse(time.RFC3339, result.ExpiresAt)
+	if err != nil || !expiresAt.After(now) {
+		return corebroker.CertificateIdentity{}, ErrResolverIdentity
+	}
+	return corebroker.CertificateIdentity{
+		EntityID:     result.EntityID,
+		TenantID:     result.TenantID,
+		CredentialID: result.CredentialID,
+		IssuerID:     result.IssuerID,
+		Fingerprint:  strings.ToLower(fingerprint),
+		ExpiresAt:    expiresAt,
+	}, nil
+}
+
+func topicTenant(topic string) (string, bool, error) {
+	parts := strings.Split(topic, "/")
+	if len(parts) == 0 || (parts[0] != "m" && parts[0] != "hc") {
+		return "", false, nil
+	}
+	if len(parts) < 2 || strings.ContainsAny(parts[1], "+#") {
+		return "", true, ErrTenantScopeUnknown
+	}
+	parsed, err := uuid.Parse(parts[1])
+	if err != nil {
+		return "", true, ErrTenantScopeUnknown
+	}
+	return parsed.String(), true, nil
+}
+
+// CertificateMetrics returns a label-free operational snapshot.
+func (m *Manager) CertificateMetrics() corebroker.CertificateMetrics {
+	return corebroker.CertificateMetrics{
+		ResolverRequests:     m.metrics.resolverRequests.Load(),
+		ResolverFailures:     m.metrics.resolverFailures.Load(),
+		ResolverTimeouts:     m.metrics.resolverTimeouts.Load(),
+		CacheHits:            m.metrics.cacheHits.Load(),
+		CacheMisses:          m.metrics.cacheMisses.Load(),
+		CacheEvictions:       m.metrics.cacheEvictions.Load(),
+		CacheEntries:         m.cache.len(),
+		EventsReceived:       m.metrics.eventsReceived.Load(),
+		EventsRejected:       m.metrics.eventsRejected.Load(),
+		CacheInvalidations:   m.metrics.cacheInvalidations.Load(),
+		TenantDenials:        m.metrics.tenantDenials.Load(),
+		TrustRefreshSuccess:  m.metrics.trustRefreshSuccess.Load(),
+		TrustRefreshFailures: m.metrics.trustRefreshFailures.Load(),
+	}
+}
+
+var (
+	_ corebroker.CertificateAuthenticator   = (*Manager)(nil)
+	_ corebroker.CertificateMetricsProvider = (*Manager)(nil)
+)

--- a/pki/manager.go
+++ b/pki/manager.go
@@ -17,6 +17,7 @@ import (
 	"log/slog"
 	"math/big"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -232,8 +233,12 @@ func validateConfig(config Config) error {
 	if strings.TrimSpace(config.ServiceTokenFile) == "" {
 		return fmt.Errorf("certificate resolver service token file is required")
 	}
-	if strings.TrimSpace(config.TrustBundleURL) == "" {
-		return fmt.Errorf("Atom trust bundle URL is required")
+	trustURL, err := url.ParseRequestURI(config.TrustBundleURL)
+	if err != nil || trustURL.Host == "" || (trustURL.Scheme != "https" && trustURL.Scheme != "http") {
+		return fmt.Errorf("Atom trust bundle URL must be an absolute HTTP(S) URL")
+	}
+	if trustURL.Scheme != "https" && !config.ResolverInsecure {
+		return fmt.Errorf("Atom trust bundle URL must use HTTPS unless resolver insecure mode is enabled")
 	}
 	if strings.TrimSpace(config.EventSourcePrincipal) == "" {
 		return fmt.Errorf("Atom event source principal is required")

--- a/pki/manager.go
+++ b/pki/manager.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	corebroker "github.com/absmach/fluxmq/broker"
+	"github.com/absmach/fluxmq/topics"
 	"github.com/google/uuid"
 	"golang.org/x/sync/singleflight"
 )
@@ -40,6 +41,7 @@ const (
 var (
 	ErrInvalidPeerCertificate = errors.New("invalid peer certificate")
 	ErrResolverIdentity       = errors.New("invalid certificate resolver identity")
+	ErrResolutionInvalidated  = errors.New("certificate resolution invalidated by a lifecycle event")
 	ErrTenantMismatch         = errors.New("certificate tenant does not match requested scope")
 	ErrTenantScopeUnknown     = errors.New("tenant-scoped topic has no canonical tenant UUID")
 )
@@ -94,6 +96,7 @@ type managerMetrics struct {
 	eventsReceived       atomic.Uint64
 	eventsRejected       atomic.Uint64
 	cacheInvalidations   atomic.Uint64
+	sessionsDisconnected atomic.Uint64
 	tenantDenials        atomic.Uint64
 	trustRefreshSuccess  atomic.Uint64
 	trustRefreshFailures atomic.Uint64
@@ -110,6 +113,9 @@ type Manager struct {
 	metrics    managerMetrics
 	requests   singleflight.Group
 	clock      func() time.Time
+	sessions   func(func(corebroker.CertificateIdentity) bool) int
+	lifecycle  sync.RWMutex
+	generation uint64
 
 	trustMu   sync.RWMutex
 	trustPool *x509.CertPool
@@ -125,6 +131,7 @@ type managerOptions struct {
 	httpClient *http.Client
 	logger     *slog.Logger
 	clock      func() time.Time
+	sessions   func(func(corebroker.CertificateIdentity) bool) int
 }
 
 // Option customizes a Manager.
@@ -140,6 +147,13 @@ func WithHTTPClient(client *http.Client) Option {
 
 func WithLogger(logger *slog.Logger) Option {
 	return func(options *managerOptions) { options.logger = logger }
+}
+
+// WithSessionInvalidator installs the consuming broker's live-session
+// revoker. It is invoked only for lifecycle events that make an existing
+// credential, entity, or tenant unusable.
+func WithSessionInvalidator(invalidate func(func(corebroker.CertificateIdentity) bool) int) Option {
+	return func(options *managerOptions) { options.sessions = invalidate }
 }
 
 func withClock(clock func() time.Time) Option {
@@ -188,6 +202,7 @@ func NewManager(config Config, opts ...Option) (*Manager, error) {
 		resolver:   resolver,
 		httpClient: options.httpClient,
 		logger:     options.logger,
+		sessions:   options.sessions,
 		cache:      cache,
 		clock:      options.clock,
 		refreshCh:  make(chan struct{}, 1),
@@ -300,7 +315,7 @@ func (m *Manager) resolve(ctx context.Context, request ResolverRequest) (corebro
 	if request.FingerprintSHA256 == "" {
 		return corebroker.CertificateIdentity{}, ErrInvalidPeerCertificate
 	}
-	if cached, ok := m.cache.get(request.FingerprintSHA256); ok {
+	if cached, ok := m.cachedResolution(request.FingerprintSHA256); ok {
 		m.metrics.cacheHits.Add(1)
 		if request.ExpectedTenantID != "" && cached.TenantID != request.ExpectedTenantID {
 			m.metrics.tenantDenials.Add(1)
@@ -311,10 +326,13 @@ func (m *Manager) resolve(ctx context.Context, request ResolverRequest) (corebro
 	m.metrics.cacheMisses.Add(1)
 
 	value, err, _ := m.requests.Do(request.FingerprintSHA256, func() (any, error) {
-		if cached, ok := m.cache.get(request.FingerprintSHA256); ok {
+		if cached, ok := m.cachedResolution(request.FingerprintSHA256); ok {
 			m.metrics.cacheHits.Add(1)
 			return cached, nil
 		}
+		m.lifecycle.RLock()
+		generation := m.generation
+		m.lifecycle.RUnlock()
 		m.metrics.resolverRequests.Add(1)
 		callCtx, cancel := context.WithTimeout(ctx, m.config.Timeout)
 		defer cancel()
@@ -335,7 +353,14 @@ func (m *Manager) resolve(ctx context.Context, request ResolverRequest) (corebro
 			m.metrics.tenantDenials.Add(1)
 			return corebroker.CertificateIdentity{}, ErrTenantMismatch
 		}
-		if m.cache.put(identity) {
+		m.lifecycle.RLock()
+		if generation != m.generation {
+			m.lifecycle.RUnlock()
+			return corebroker.CertificateIdentity{}, ErrResolutionInvalidated
+		}
+		evicted := m.cache.put(identity)
+		m.lifecycle.RUnlock()
+		if evicted {
 			m.metrics.cacheEvictions.Add(1)
 		}
 		return identity, nil
@@ -349,6 +374,12 @@ func (m *Manager) resolve(ctx context.Context, request ResolverRequest) (corebro
 		return corebroker.CertificateIdentity{}, ErrTenantMismatch
 	}
 	return identity, nil
+}
+
+func (m *Manager) cachedResolution(fingerprint string) (corebroker.CertificateIdentity, bool) {
+	m.lifecycle.RLock()
+	defer m.lifecycle.RUnlock()
+	return m.cache.get(fingerprint)
 }
 
 func selectorsFromPeer(peer corebroker.PeerCertificate) (ResolverRequest, error) {
@@ -418,6 +449,9 @@ func validateResolverResult(result ResolverResult, fingerprint string, now time.
 }
 
 func topicTenant(topic string) (string, bool, error) {
+	if _, sharedFilter, shared := topics.ParseShared(topic); shared {
+		topic = sharedFilter
+	}
 	parts := strings.Split(topic, "/")
 	if len(parts) == 0 || (parts[0] != "m" && parts[0] != "hc") {
 		return "", false, nil
@@ -445,6 +479,7 @@ func (m *Manager) CertificateMetrics() corebroker.CertificateMetrics {
 		EventsReceived:       m.metrics.eventsReceived.Load(),
 		EventsRejected:       m.metrics.eventsRejected.Load(),
 		CacheInvalidations:   m.metrics.cacheInvalidations.Load(),
+		SessionsDisconnected: m.metrics.sessionsDisconnected.Load(),
 		TenantDenials:        m.metrics.tenantDenials.Load(),
 		TrustRefreshSuccess:  m.metrics.trustRefreshSuccess.Load(),
 		TrustRefreshFailures: m.metrics.trustRefreshFailures.Load(),

--- a/pki/manager.go
+++ b/pki/manager.go
@@ -303,12 +303,26 @@ func (m *Manager) AuthorizeCertificate(ctx context.Context, identity corebroker.
 		ExpectedTenantID:  tenantID,
 	})
 	if err != nil {
+		m.disconnectResolvedSession(identity)
 		return err
 	}
 	if current.EntityID != identity.EntityID || current.TenantID != identity.TenantID || current.CredentialID != identity.CredentialID {
+		m.disconnectResolvedSession(identity)
 		return ErrResolverIdentity
 	}
 	return nil
+}
+
+func (m *Manager) disconnectResolvedSession(identity corebroker.CertificateIdentity) {
+	if m.sessions == nil {
+		return
+	}
+	disconnected := m.sessions(func(candidate corebroker.CertificateIdentity) bool {
+		return candidate.CredentialID == identity.CredentialID && candidate.Fingerprint == identity.Fingerprint
+	})
+	if disconnected > 0 {
+		m.metrics.sessionsDisconnected.Add(uint64(disconnected))
+	}
 }
 
 func (m *Manager) resolve(ctx context.Context, request ResolverRequest) (corebroker.CertificateIdentity, error) {

--- a/pki/manager.go
+++ b/pki/manager.go
@@ -37,6 +37,8 @@ const (
 	DefaultTrustRefresh        = time.Minute
 	maximumCertificateDERBytes = 64 * 1024
 	maximumTrustBundleBytes    = 4 * 1024 * 1024
+	httpsScheme                = "https"
+	certificatePEMType         = "CERTIFICATE"
 )
 
 var (
@@ -234,10 +236,10 @@ func validateConfig(config Config) error {
 		return fmt.Errorf("certificate resolver service token file is required")
 	}
 	trustURL, err := url.ParseRequestURI(config.TrustBundleURL)
-	if err != nil || trustURL.Host == "" || (trustURL.Scheme != "https" && trustURL.Scheme != "http") {
+	if err != nil || trustURL.Host == "" || (trustURL.Scheme != httpsScheme && trustURL.Scheme != "http") {
 		return fmt.Errorf("Atom trust bundle URL must be an absolute HTTP(S) URL")
 	}
-	if trustURL.Scheme != "https" && !config.ResolverInsecure {
+	if trustURL.Scheme != httpsScheme && !config.ResolverInsecure {
 		return fmt.Errorf("Atom trust bundle URL must use HTTPS unless resolver insecure mode is enabled")
 	}
 	if strings.TrimSpace(config.EventSourcePrincipal) == "" {

--- a/pki/manager.go
+++ b/pki/manager.go
@@ -265,7 +265,9 @@ func (m *Manager) Start(ctx context.Context) error {
 		return err
 	}
 	m.wg.Add(1)
-	go m.trustRefreshLoop()
+	// Startup callers commonly use a short-lived timeout context. Preserve its
+	// values for refresh requests while leaving shutdown ownership with Close.
+	go m.trustRefreshLoop(context.WithoutCancel(ctx))
 	return nil
 }
 

--- a/pki/manager_test.go
+++ b/pki/manager_test.go
@@ -498,7 +498,7 @@ func TestTrustBundleRefreshAfterAuthorityProvisioningEvent(t *testing.T) {
 
 func TestTrustBundleRejectsNonCA(t *testing.T) {
 	peer, _ := makePeerCertificate(t, 14)
-	leafPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: peer.LeafDER})
+	leafPEM := pem.EncodeToMemory(&pem.Block{Type: certificatePEMType, Bytes: peer.LeafDER})
 	_, err := parseTrustBundle(leafPEM)
 	require.ErrorContains(t, err, "cannot sign certificates")
 }
@@ -570,5 +570,5 @@ func makePeerCertificate(t *testing.T, serial int64) (corebroker.PeerCertificate
 	}
 	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, issuerTemplate, &leafKey.PublicKey, issuerKey)
 	require.NoError(t, err)
-	return corebroker.PeerCertificate{LeafDER: leafDER, IssuerDER: issuerDER}, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: issuerDER})
+	return corebroker.PeerCertificate{LeafDER: leafDER, IssuerDER: issuerDER}, pem.EncodeToMemory(&pem.Block{Type: certificatePEMType, Bytes: issuerDER})
 }

--- a/pki/manager_test.go
+++ b/pki/manager_test.go
@@ -1,0 +1,433 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package pki
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	corebroker "github.com/absmach/fluxmq/broker"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testEntityID       = "8a0a5c59-4ea8-4fc1-badb-f96cf739b224"
+	testTenantID       = "d204f7df-8293-4194-963b-a47a65bc8f04"
+	testOtherTenantID  = "88b65e71-e41d-4f12-9800-6c621133af9b"
+	testCredentialID   = "ca49950c-3ed2-41b4-a319-896085285686"
+	testIssuerID       = "95bdde91-c07a-4fc2-bf7f-cec505475449"
+	testEventPrincipal = "atom-events"
+)
+
+type resolverStub struct {
+	mu       sync.Mutex
+	calls    int
+	requests []ResolverRequest
+	result   ResolverResult
+	results  map[string]ResolverResult
+	err      error
+	wait     bool
+	delay    time.Duration
+}
+
+func (stub *resolverStub) ResolveCertificateV2(ctx context.Context, request ResolverRequest) (ResolverResult, error) {
+	stub.mu.Lock()
+	stub.calls++
+	request.CertificateDER = append([]byte(nil), request.CertificateDER...)
+	stub.requests = append(stub.requests, request)
+	result := stub.result
+	if selected, ok := stub.results[request.FingerprintSHA256]; ok {
+		result = selected
+	}
+	err := stub.err
+	wait := stub.wait
+	delay := stub.delay
+	stub.mu.Unlock()
+
+	if wait {
+		<-ctx.Done()
+		return ResolverResult{}, ctx.Err()
+	}
+	if delay > 0 {
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return ResolverResult{}, ctx.Err()
+		}
+	}
+	return result, err
+}
+
+func (stub *resolverStub) setError(err error) {
+	stub.mu.Lock()
+	stub.err = err
+	stub.mu.Unlock()
+}
+
+func (stub *resolverStub) callCount() int {
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	return stub.calls
+}
+
+func (stub *resolverStub) lastRequest() ResolverRequest {
+	stub.mu.Lock()
+	defer stub.mu.Unlock()
+	return stub.requests[len(stub.requests)-1]
+}
+
+func activeResolverResult(now time.Time) ResolverResult {
+	return ResolverResult{
+		EntityID:     testEntityID,
+		TenantID:     testTenantID,
+		CredentialID: testCredentialID,
+		IssuerID:     testIssuerID,
+		ExpiresAt:    now.Add(time.Hour).Format(time.RFC3339),
+		Status:       "active",
+	}
+}
+
+func newTestManager(t *testing.T, resolver Resolver, now *time.Time, options ...Option) *Manager {
+	t.Helper()
+	opts := []Option{WithResolver(resolver)}
+	if now != nil {
+		opts = append(opts, withClock(func() time.Time { return *now }))
+	}
+	opts = append(opts, options...)
+	manager, err := NewManager(Config{
+		ResolverAddress:      "atom.invalid:8081",
+		ServiceTokenFile:     "unused-by-test-resolver",
+		TrustBundleURL:       "https://atom.invalid/certs/trust-bundle.pem",
+		EventSourcePrincipal: testEventPrincipal,
+		Timeout:              100 * time.Millisecond,
+		CacheTTL:             30 * time.Second,
+		CacheSize:            64,
+		TrustRefreshInterval: time.Hour,
+	}, opts...)
+	require.NoError(t, err)
+	return manager
+}
+
+func TestResolverAuthenticationExtractsAllTLSSelectorsAndMapsEntity(t *testing.T) {
+	now := time.Now().UTC()
+	peer, _ := makePeerCertificate(t, 0x1af)
+	resolver := &resolverStub{result: activeResolverResult(now)}
+	manager := newTestManager(t, resolver, &now)
+
+	identity, err := manager.AuthenticateCertificate(context.Background(), peer)
+	require.NoError(t, err)
+	require.Equal(t, testEntityID, identity.EntityID)
+	require.Equal(t, testTenantID, identity.TenantID)
+	require.Equal(t, testCredentialID, identity.CredentialID)
+	require.Equal(t, testIssuerID, identity.IssuerID)
+
+	request := resolver.lastRequest()
+	require.Equal(t, peer.LeafDER, request.CertificateDER)
+	require.Len(t, request.FingerprintSHA256, 64)
+	require.Len(t, request.IssuerFingerprintSHA256, 64)
+	require.Equal(t, "1af", request.SerialNumber)
+	require.Empty(t, request.ExpectedTenantID)
+}
+
+func TestTenantBindingRejectsCrossTenantAndGlobalEscalation(t *testing.T) {
+	now := time.Now().UTC()
+	peer, _ := makePeerCertificate(t, 1)
+	resolver := &resolverStub{result: activeResolverResult(now)}
+	manager := newTestManager(t, resolver, &now)
+	identity, err := manager.AuthenticateCertificate(context.Background(), peer)
+	require.NoError(t, err)
+
+	err = manager.AuthorizeCertificate(context.Background(), identity, "m/"+testOtherTenantID+"/c/channel/messages")
+	require.ErrorIs(t, err, ErrTenantMismatch)
+	require.Equal(t, 1, resolver.callCount(), "cross-tenant denial must happen before authorization lookup")
+
+	globalResolver := &resolverStub{result: activeResolverResult(now)}
+	globalResolver.result.TenantID = ""
+	globalManager := newTestManager(t, globalResolver, &now)
+	globalIdentity, err := globalManager.AuthenticateCertificate(context.Background(), peer)
+	require.NoError(t, err)
+	require.Empty(t, globalIdentity.TenantID)
+	require.ErrorIs(t, globalManager.AuthorizeCertificate(context.Background(), globalIdentity, "m/"+testTenantID+"/c/channel"), ErrTenantMismatch)
+	require.NoError(t, globalManager.AuthorizeCertificate(context.Background(), globalIdentity, "$SYS/global/status"))
+}
+
+func TestResolverLifecycleDenialsOccurBeforeSession(t *testing.T) {
+	now := time.Now().UTC()
+	peer, _ := makePeerCertificate(t, 2)
+	tests := []struct {
+		name   string
+		result ResolverResult
+		err    error
+	}{
+		{name: "unknown", result: activeResolverResult(now), err: errors.New("not found")},
+		{name: "revoked", result: func() ResolverResult { value := activeResolverResult(now); value.Status = "revoked"; return value }()},
+		{name: "expired", result: func() ResolverResult {
+			value := activeResolverResult(now)
+			value.ExpiresAt = now.Add(-time.Second).Format(time.RFC3339)
+			return value
+		}()},
+		{name: "inactive entity", result: activeResolverResult(now), err: errors.New("inactive entity")},
+		{name: "frozen tenant", result: activeResolverResult(now), err: errors.New("frozen tenant")},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			resolver := &resolverStub{result: test.result, err: test.err}
+			manager := newTestManager(t, resolver, &now)
+			_, err := manager.AuthenticateCertificate(context.Background(), peer)
+			require.Error(t, err)
+			require.Zero(t, manager.CertificateMetrics().CacheEntries)
+		})
+	}
+}
+
+func TestResolverTimeoutFailsClosed(t *testing.T) {
+	now := time.Now().UTC()
+	peer, _ := makePeerCertificate(t, 3)
+	resolver := &resolverStub{result: activeResolverResult(now), wait: true}
+	manager := newTestManager(t, resolver, &now)
+	manager.config.Timeout = 5 * time.Millisecond
+
+	_, err := manager.AuthenticateCertificate(context.Background(), peer)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	metrics := manager.CertificateMetrics()
+	require.Equal(t, uint64(1), metrics.ResolverFailures)
+	require.Equal(t, uint64(1), metrics.ResolverTimeouts)
+}
+
+func TestReviewedCacheAllowsBoundedOutageThenFailsClosed(t *testing.T) {
+	now := time.Now().UTC()
+	peer, _ := makePeerCertificate(t, 4)
+	resolver := &resolverStub{result: activeResolverResult(now)}
+	manager := newTestManager(t, resolver, &now)
+	manager.config.CacheTTL = 10 * time.Second
+	manager.cache.ttl = 10 * time.Second
+
+	first, err := manager.AuthenticateCertificate(context.Background(), peer)
+	require.NoError(t, err)
+	resolver.setError(errors.New("Atom unavailable"))
+	second, err := manager.AuthenticateCertificate(context.Background(), peer)
+	require.NoError(t, err)
+	require.Equal(t, first, second)
+
+	now = now.Add(11 * time.Second)
+	_, err = manager.AuthenticateCertificate(context.Background(), peer)
+	require.ErrorContains(t, err, "Atom unavailable")
+	require.Equal(t, 2, resolver.callCount())
+}
+
+func TestLifecycleEventEvictsRevokedSessionAndDuplicateIsIdempotent(t *testing.T) {
+	now := time.Now().UTC()
+	peer, _ := makePeerCertificate(t, 5)
+	resolver := &resolverStub{result: activeResolverResult(now)}
+	manager := newTestManager(t, resolver, &now)
+	identity, err := manager.AuthenticateCertificate(context.Background(), peer)
+	require.NoError(t, err)
+
+	event := lifecycleEvent(t, "certificate.revoke", "credential", testCredentialID, map[string]any{
+		"credential_id": testCredentialID,
+	})
+	properties := map[string]string{corebroker.ExternalIDProperty: testEventPrincipal}
+	require.NoError(t, manager.HandleEvent(event, properties))
+	require.NoError(t, manager.HandleEvent(event, properties))
+	require.Zero(t, manager.CertificateMetrics().CacheEntries)
+
+	revoked := activeResolverResult(now)
+	revoked.Status = "revoked"
+	resolver.mu.Lock()
+	resolver.result = revoked
+	resolver.mu.Unlock()
+	require.Error(t, manager.AuthorizeCertificate(context.Background(), identity, "$SYS/global/status"))
+	require.Equal(t, uint64(1), manager.CertificateMetrics().CacheInvalidations)
+}
+
+func TestCertificateRotationRebindsSameEntity(t *testing.T) {
+	now := time.Now().UTC()
+	oldPeer, _ := makePeerCertificate(t, 6)
+	newPeer, _ := makePeerCertificate(t, 7)
+	oldRequest, err := selectorsFromPeer(oldPeer)
+	require.NoError(t, err)
+	newRequest, err := selectorsFromPeer(newPeer)
+	require.NoError(t, err)
+	oldResult := activeResolverResult(now)
+	newResult := activeResolverResult(now)
+	newResult.CredentialID = "05119e28-6260-4a06-8742-f925bcfdccd4"
+	resolver := &resolverStub{results: map[string]ResolverResult{
+		oldRequest.FingerprintSHA256: oldResult,
+		newRequest.FingerprintSHA256: newResult,
+	}}
+	manager := newTestManager(t, resolver, &now)
+
+	oldIdentity, err := manager.AuthenticateCertificate(context.Background(), oldPeer)
+	require.NoError(t, err)
+	newIdentity, err := manager.AuthenticateCertificate(context.Background(), newPeer)
+	require.NoError(t, err)
+	require.Equal(t, oldIdentity.EntityID, newIdentity.EntityID)
+	require.NotEqual(t, oldIdentity.CredentialID, newIdentity.CredentialID)
+	require.NoError(t, manager.AuthorizeCertificate(context.Background(), newIdentity, "m/"+testTenantID+"/c/channel"))
+}
+
+func TestResolverLoadCollapsesConcurrentConnections(t *testing.T) {
+	now := time.Now().UTC()
+	peer, _ := makePeerCertificate(t, 8)
+	resolver := &resolverStub{result: activeResolverResult(now), delay: 20 * time.Millisecond}
+	manager := newTestManager(t, resolver, &now)
+
+	const connections = 250
+	start := make(chan struct{})
+	errs := make(chan error, connections)
+	var workers sync.WaitGroup
+	workers.Add(connections)
+	for range connections {
+		go func() {
+			defer workers.Done()
+			<-start
+			_, err := manager.AuthenticateCertificate(context.Background(), peer)
+			errs <- err
+		}()
+	}
+	close(start)
+	workers.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, 1, resolver.callCount())
+	require.Equal(t, 1, manager.CertificateMetrics().CacheEntries)
+}
+
+func TestTrustBundleRefreshAfterAuthorityProvisioningEvent(t *testing.T) {
+	now := time.Now().UTC()
+	_, firstPEM := makePeerCertificate(t, 9)
+	_, secondPEM := makePeerCertificate(t, 10)
+
+	var bundleMu sync.RWMutex
+	bundle := firstPEM
+	etag := "\"v1\""
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		bundleMu.RLock()
+		defer bundleMu.RUnlock()
+		if request.Header.Get("If-None-Match") == etag {
+			writer.WriteHeader(http.StatusNotModified)
+			return
+		}
+		writer.Header().Set("ETag", etag)
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write(bundle)
+	}))
+	defer server.Close()
+
+	resolver := &resolverStub{result: activeResolverResult(now)}
+	manager, err := NewManager(Config{
+		ResolverAddress:      "atom.invalid:8081",
+		ServiceTokenFile:     "unused-by-test-resolver",
+		TrustBundleURL:       server.URL,
+		EventSourcePrincipal: testEventPrincipal,
+		Timeout:              time.Second,
+		CacheTTL:             30 * time.Second,
+		CacheSize:            64,
+		TrustRefreshInterval: time.Hour,
+	}, WithResolver(resolver), WithHTTPClient(server.Client()))
+	require.NoError(t, err)
+	require.NoError(t, manager.Start(context.Background()))
+	t.Cleanup(func() { require.NoError(t, manager.Close()) })
+	require.Len(t, manager.trustPool.Subjects(), 1)
+
+	bundleMu.Lock()
+	bundle = append(append([]byte(nil), firstPEM...), secondPEM...)
+	etag = "\"v2\""
+	bundleMu.Unlock()
+	event := lifecycleEvent(t, "pki.authority.provisioned_automatically", "pki_authority", testIssuerID, nil)
+	require.NoError(t, manager.HandleEvent(event, map[string]string{corebroker.ExternalIDProperty: testEventPrincipal}))
+	require.Eventually(t, func() bool {
+		manager.trustMu.RLock()
+		defer manager.trustMu.RUnlock()
+		return manager.trustPool != nil && len(manager.trustPool.Subjects()) == 2
+	}, time.Second, 10*time.Millisecond)
+
+	wrapped, err := manager.WrapTLSConfig(&tls.Config{ClientAuth: tls.RequireAndVerifyClientCert})
+	require.NoError(t, err)
+	current, err := wrapped.GetConfigForClient(nil)
+	require.NoError(t, err)
+	require.Len(t, current.ClientCAs.Subjects(), 2)
+}
+
+func TestUntrustedEventCannotInvalidateCache(t *testing.T) {
+	now := time.Now().UTC()
+	peer, _ := makePeerCertificate(t, 11)
+	resolver := &resolverStub{result: activeResolverResult(now)}
+	manager := newTestManager(t, resolver, &now)
+	_, err := manager.AuthenticateCertificate(context.Background(), peer)
+	require.NoError(t, err)
+
+	event := lifecycleEvent(t, "certificate.revoke", "credential", testCredentialID, nil)
+	require.ErrorIs(t, manager.HandleEvent(event, map[string]string{corebroker.ExternalIDProperty: "attacker"}), ErrUntrustedEvent)
+	require.Equal(t, 1, manager.CertificateMetrics().CacheEntries)
+	require.Equal(t, uint64(1), manager.CertificateMetrics().EventsRejected)
+}
+
+func lifecycleEvent(t *testing.T, event, targetKind, targetID string, details map[string]any) []byte {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"schema_version":  1,
+		"event_id":        "3025f995-3425-4bc8-a306-e4992cb9cf9d",
+		"event":           event,
+		"occurred_at":     time.Now().UTC().Format(time.RFC3339),
+		"source":          "atom",
+		"actor_entity_id": nil,
+		"tenant_id":       testTenantID,
+		"target_kind":     targetKind,
+		"target_id":       targetID,
+		"outcome":         "allow",
+		"details":         details,
+		"request_id":      nil,
+	})
+	require.NoError(t, err)
+	return payload
+}
+
+func makePeerCertificate(t *testing.T, serial int64) (corebroker.PeerCertificate, []byte) {
+	t.Helper()
+	now := time.Now().UTC()
+	issuerKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	issuerTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(serial + 1000),
+		Subject:               pkix.Name{CommonName: "test issuer " + big.NewInt(serial).String()},
+		NotBefore:             now.Add(-time.Hour),
+		NotAfter:              now.Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	issuerDER, err := x509.CreateCertificate(rand.Reader, issuerTemplate, issuerTemplate, &issuerKey.PublicKey, issuerKey)
+	require.NoError(t, err)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(serial),
+		Subject:      pkix.Name{CommonName: "test peer"},
+		NotBefore:    now.Add(-time.Minute),
+		NotAfter:     now.Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, issuerTemplate, &leafKey.PublicKey, issuerKey)
+	require.NoError(t, err)
+	return corebroker.PeerCertificate{LeafDER: leafDER, IssuerDER: issuerDER}, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: issuerDER})
+}

--- a/pki/manager_test.go
+++ b/pki/manager_test.go
@@ -315,6 +315,42 @@ func TestLifecycleEventEvictsRevokedSessionAndDuplicateIsIdempotent(t *testing.T
 	require.Equal(t, uint64(1), manager.CertificateMetrics().CacheInvalidations)
 }
 
+func TestUnusableAuthorityEventDisconnectsSessionsIssuedByThatAuthority(t *testing.T) {
+	now := time.Now().UTC()
+	peer, _ := makePeerCertificate(t, 18)
+	resolver := &resolverStub{result: activeResolverResult(now)}
+	var liveIdentity corebroker.CertificateIdentity
+	disconnected := false
+	manager := newTestManager(t, resolver, &now, WithSessionInvalidator(func(match func(corebroker.CertificateIdentity) bool) int {
+		if disconnected || !match(liveIdentity) {
+			return 0
+		}
+		disconnected = true
+		return 1
+	}))
+	identity, err := manager.AuthenticateCertificate(context.Background(), peer)
+	require.NoError(t, err)
+	liveIdentity = identity
+
+	event := lifecycleEvent(t, "pki.authority.revoked", "authority", testIssuerID, map[string]any{
+		issuerIDDetail: testIssuerID,
+	})
+	require.NoError(t, manager.HandleEvent(event, map[string]string{corebroker.ExternalIDProperty: testEventPrincipal}))
+	require.Zero(t, manager.CertificateMetrics().CacheEntries)
+	require.True(t, disconnected)
+	require.Equal(t, uint64(1), manager.CertificateMetrics().SessionsDisconnected)
+
+	// Atom deliberately retains retiring and retired issuers for verification of
+	// already-issued certificates, so retirement must not drop live sessions.
+	retiredIssuerID := testIssuerID
+	_, disconnectRetired := sessionDisconnectionKeys(domainEvent{
+		Event:    "pki.authority.retired",
+		TargetID: &retiredIssuerID,
+		Details:  map[string]any{issuerIDDetail: testIssuerID},
+	})
+	require.False(t, disconnectRetired)
+}
+
 func TestLifecycleEventPreventsInflightResolutionFromRepopulatingCache(t *testing.T) {
 	now := time.Now().UTC()
 	peer, _ := makePeerCertificate(t, 12)

--- a/pki/manager_test.go
+++ b/pki/manager_test.go
@@ -246,6 +246,34 @@ func TestReviewedCacheAllowsBoundedOutageThenFailsClosed(t *testing.T) {
 	require.Equal(t, 2, resolver.callCount())
 }
 
+func TestAuthorizationResolverFailureDisconnectsCertificateSession(t *testing.T) {
+	now := time.Now().UTC()
+	peer, _ := makePeerCertificate(t, 13)
+	selectors, err := selectorsFromPeer(peer)
+	require.NoError(t, err)
+	resolver := &resolverStub{result: activeResolverResult(now)}
+	disconnected := false
+	manager := newTestManager(t, resolver, &now, WithSessionInvalidator(func(match func(corebroker.CertificateIdentity) bool) int {
+		if disconnected || !match(corebroker.CertificateIdentity{
+			CredentialID: testCredentialID,
+			Fingerprint:  selectors.FingerprintSHA256,
+		}) {
+			return 0
+		}
+		disconnected = true
+		return 1
+	}))
+	identity, err := manager.AuthenticateCertificate(context.Background(), peer)
+	require.NoError(t, err)
+	resolver.setError(errors.New("Atom unavailable"))
+	now = now.Add(manager.config.CacheTTL + time.Second)
+
+	err = manager.AuthorizeCertificate(context.Background(), identity, "m/"+testTenantID+"/c/channel")
+	require.ErrorContains(t, err, "Atom unavailable")
+	require.True(t, disconnected)
+	require.Equal(t, uint64(1), manager.CertificateMetrics().SessionsDisconnected)
+}
+
 func TestLifecycleEventEvictsRevokedSessionAndDuplicateIsIdempotent(t *testing.T) {
 	now := time.Now().UTC()
 	peer, _ := makePeerCertificate(t, 5)

--- a/pki/manager_test.go
+++ b/pki/manager_test.go
@@ -32,6 +32,7 @@ const (
 	testCredentialID   = "ca49950c-3ed2-41b4-a319-896085285686"
 	testIssuerID       = "95bdde91-c07a-4fc2-bf7f-cec505475449"
 	testEventPrincipal = "atom-events"
+	testRevokedStatus  = "revoked"
 )
 
 type resolverStub struct {
@@ -191,7 +192,11 @@ func TestResolverLifecycleDenialsOccurBeforeSession(t *testing.T) {
 		err    error
 	}{
 		{name: "unknown", result: activeResolverResult(now), err: errors.New("not found")},
-		{name: "revoked", result: func() ResolverResult { value := activeResolverResult(now); value.Status = "revoked"; return value }()},
+		{name: testRevokedStatus, result: func() ResolverResult {
+			value := activeResolverResult(now)
+			value.Status = testRevokedStatus
+			return value
+		}()},
 		{name: "expired", result: func() ResolverResult {
 			value := activeResolverResult(now)
 			value.ExpiresAt = now.Add(-time.Second).Format(time.RFC3339)
@@ -302,7 +307,7 @@ func TestLifecycleEventEvictsRevokedSessionAndDuplicateIsIdempotent(t *testing.T
 	require.Equal(t, uint64(1), manager.CertificateMetrics().SessionsDisconnected)
 
 	revoked := activeResolverResult(now)
-	revoked.Status = "revoked"
+	revoked.Status = testRevokedStatus
 	resolver.mu.Lock()
 	resolver.result = revoked
 	resolver.mu.Unlock()

--- a/pki/manager_test.go
+++ b/pki/manager_test.go
@@ -414,6 +414,26 @@ func TestResolverLoadCollapsesConcurrentConnections(t *testing.T) {
 	require.Equal(t, 1, manager.CertificateMetrics().CacheEntries)
 }
 
+func TestResolutionCacheEvictsAtConfiguredCapacity(t *testing.T) {
+	now := time.Now().UTC()
+	firstPeer, _ := makePeerCertificate(t, 15)
+	secondPeer, _ := makePeerCertificate(t, 16)
+	resolver := &resolverStub{result: activeResolverResult(now)}
+	manager := newTestManager(t, resolver, &now)
+	manager.cache.capacity = 1
+
+	_, err := manager.AuthenticateCertificate(context.Background(), firstPeer)
+	require.NoError(t, err)
+	_, err = manager.AuthenticateCertificate(context.Background(), secondPeer)
+	require.NoError(t, err)
+	require.Equal(t, 1, manager.CertificateMetrics().CacheEntries)
+	require.Equal(t, uint64(1), manager.CertificateMetrics().CacheEvictions)
+
+	_, err = manager.AuthenticateCertificate(context.Background(), firstPeer)
+	require.NoError(t, err)
+	require.Equal(t, 3, resolver.callCount(), "evicted fingerprints must resolve authoritatively again")
+}
+
 func TestTrustBundleRefreshAfterAuthorityProvisioningEvent(t *testing.T) {
 	now := time.Now().UTC()
 	_, firstPEM := makePeerCertificate(t, 9)

--- a/pki/manager_test.go
+++ b/pki/manager_test.go
@@ -438,6 +438,7 @@ func TestTrustBundleRefreshAfterAuthorityProvisioningEvent(t *testing.T) {
 	resolver := &resolverStub{result: activeResolverResult(now)}
 	manager, err := NewManager(Config{
 		ResolverAddress:      "atom.invalid:8081",
+		ResolverInsecure:     true,
 		ServiceTokenFile:     "unused-by-test-resolver",
 		TrustBundleURL:       server.URL,
 		EventSourcePrincipal: testEventPrincipal,
@@ -468,6 +469,13 @@ func TestTrustBundleRefreshAfterAuthorityProvisioningEvent(t *testing.T) {
 	current, err := wrapped.GetConfigForClient(nil)
 	require.NoError(t, err)
 	require.Len(t, current.ClientCAs.Subjects(), 2)
+}
+
+func TestTrustBundleRejectsNonCA(t *testing.T) {
+	peer, _ := makePeerCertificate(t, 14)
+	leafPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: peer.LeafDER})
+	_, err := parseTrustBundle(leafPEM)
+	require.ErrorContains(t, err, "cannot sign certificates")
 }
 
 func TestUntrustedEventCannotInvalidateCache(t *testing.T) {

--- a/pki/manager_test.go
+++ b/pki/manager_test.go
@@ -35,14 +35,17 @@ const (
 )
 
 type resolverStub struct {
-	mu       sync.Mutex
-	calls    int
-	requests []ResolverRequest
-	result   ResolverResult
-	results  map[string]ResolverResult
-	err      error
-	wait     bool
-	delay    time.Duration
+	mu        sync.Mutex
+	calls     int
+	requests  []ResolverRequest
+	result    ResolverResult
+	results   map[string]ResolverResult
+	err       error
+	wait      bool
+	delay     time.Duration
+	started   chan struct{}
+	release   chan struct{}
+	startOnce sync.Once
 }
 
 func (stub *resolverStub) ResolveCertificateV2(ctx context.Context, request ResolverRequest) (ResolverResult, error) {
@@ -57,8 +60,20 @@ func (stub *resolverStub) ResolveCertificateV2(ctx context.Context, request Reso
 	err := stub.err
 	wait := stub.wait
 	delay := stub.delay
+	started := stub.started
+	release := stub.release
 	stub.mu.Unlock()
 
+	if started != nil {
+		stub.startOnce.Do(func() { close(started) })
+	}
+	if release != nil {
+		select {
+		case <-release:
+		case <-ctx.Done():
+			return ResolverResult{}, ctx.Err()
+		}
+	}
 	if wait {
 		<-ctx.Done()
 		return ResolverResult{}, ctx.Err()
@@ -154,6 +169,7 @@ func TestTenantBindingRejectsCrossTenantAndGlobalEscalation(t *testing.T) {
 
 	err = manager.AuthorizeCertificate(context.Background(), identity, "m/"+testOtherTenantID+"/c/channel/messages")
 	require.ErrorIs(t, err, ErrTenantMismatch)
+	require.ErrorIs(t, manager.AuthorizeCertificate(context.Background(), identity, "$share/workers/m/"+testOtherTenantID+"/c/channel/messages"), ErrTenantMismatch)
 	require.Equal(t, 1, resolver.callCount(), "cross-tenant denial must happen before authorization lookup")
 
 	globalResolver := &resolverStub{result: activeResolverResult(now)}
@@ -234,9 +250,18 @@ func TestLifecycleEventEvictsRevokedSessionAndDuplicateIsIdempotent(t *testing.T
 	now := time.Now().UTC()
 	peer, _ := makePeerCertificate(t, 5)
 	resolver := &resolverStub{result: activeResolverResult(now)}
-	manager := newTestManager(t, resolver, &now)
+	var liveIdentity corebroker.CertificateIdentity
+	disconnected := false
+	manager := newTestManager(t, resolver, &now, WithSessionInvalidator(func(match func(corebroker.CertificateIdentity) bool) int {
+		if disconnected || !match(liveIdentity) {
+			return 0
+		}
+		disconnected = true
+		return 1
+	}))
 	identity, err := manager.AuthenticateCertificate(context.Background(), peer)
 	require.NoError(t, err)
+	liveIdentity = identity
 
 	event := lifecycleEvent(t, "certificate.revoke", "credential", testCredentialID, map[string]any{
 		"credential_id": testCredentialID,
@@ -245,6 +270,8 @@ func TestLifecycleEventEvictsRevokedSessionAndDuplicateIsIdempotent(t *testing.T
 	require.NoError(t, manager.HandleEvent(event, properties))
 	require.NoError(t, manager.HandleEvent(event, properties))
 	require.Zero(t, manager.CertificateMetrics().CacheEntries)
+	require.True(t, disconnected)
+	require.Equal(t, uint64(1), manager.CertificateMetrics().SessionsDisconnected)
 
 	revoked := activeResolverResult(now)
 	revoked.Status = "revoked"
@@ -253,6 +280,38 @@ func TestLifecycleEventEvictsRevokedSessionAndDuplicateIsIdempotent(t *testing.T
 	resolver.mu.Unlock()
 	require.Error(t, manager.AuthorizeCertificate(context.Background(), identity, "$SYS/global/status"))
 	require.Equal(t, uint64(1), manager.CertificateMetrics().CacheInvalidations)
+}
+
+func TestLifecycleEventPreventsInflightResolutionFromRepopulatingCache(t *testing.T) {
+	now := time.Now().UTC()
+	peer, _ := makePeerCertificate(t, 12)
+	resolver := &resolverStub{
+		result:  activeResolverResult(now),
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	manager := newTestManager(t, resolver, &now)
+	result := make(chan error, 1)
+	go func() {
+		_, err := manager.AuthenticateCertificate(context.Background(), peer)
+		result <- err
+	}()
+
+	select {
+	case <-resolver.started:
+	case <-time.After(time.Second):
+		t.Fatal("resolver call did not start")
+	}
+	event := lifecycleEvent(t, "certificate.revoke", "credential", testCredentialID, nil)
+	require.NoError(t, manager.HandleEvent(event, map[string]string{corebroker.ExternalIDProperty: testEventPrincipal}))
+	close(resolver.release)
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, ErrResolutionInvalidated)
+	case <-time.After(time.Second):
+		t.Fatal("in-flight resolver call did not finish")
+	}
+	require.Zero(t, manager.CertificateMetrics().CacheEntries)
 }
 
 func TestCertificateRotationRebindsSameEntity(t *testing.T) {
@@ -279,6 +338,23 @@ func TestCertificateRotationRebindsSameEntity(t *testing.T) {
 	require.Equal(t, oldIdentity.EntityID, newIdentity.EntityID)
 	require.NotEqual(t, oldIdentity.CredentialID, newIdentity.CredentialID)
 	require.NoError(t, manager.AuthorizeCertificate(context.Background(), newIdentity, "m/"+testTenantID+"/c/channel"))
+}
+
+func TestRenewalDisconnectsOnlyRevokedOldCredential(t *testing.T) {
+	oldCredentialID := testCredentialID
+	newCredentialID := "05119e28-6260-4a06-8742-f925bcfdccd4"
+	keys, disconnect := sessionDisconnectionKeys(domainEvent{
+		Event:    "certificate.renew",
+		TargetID: &oldCredentialID,
+		Details: map[string]any{
+			"old_credential_id": oldCredentialID,
+			"new_credential_id": newCredentialID,
+			"revoke_old":        true,
+		},
+	})
+	require.True(t, disconnect)
+	require.True(t, keys.matches(corebroker.CertificateIdentity{CredentialID: oldCredentialID}))
+	require.False(t, keys.matches(corebroker.CertificateIdentity{CredentialID: newCredentialID}))
 }
 
 func TestResolverLoadCollapsesConcurrentConnections(t *testing.T) {
@@ -378,6 +454,10 @@ func TestUntrustedEventCannotInvalidateCache(t *testing.T) {
 	require.ErrorIs(t, manager.HandleEvent(event, map[string]string{corebroker.ExternalIDProperty: "attacker"}), ErrUntrustedEvent)
 	require.Equal(t, 1, manager.CertificateMetrics().CacheEntries)
 	require.Equal(t, uint64(1), manager.CertificateMetrics().EventsRejected)
+
+	unrelated := lifecycleEvent(t, "audit.export", "credential", testCredentialID, nil)
+	require.NoError(t, manager.HandleEvent(unrelated, map[string]string{corebroker.ExternalIDProperty: testEventPrincipal}))
+	require.Equal(t, 1, manager.CertificateMetrics().CacheEntries)
 }
 
 func lifecycleEvent(t *testing.T, event, targetKind, targetID string, details map[string]any) []byte {

--- a/pki/trust.go
+++ b/pki/trust.go
@@ -39,6 +39,10 @@ func (m *Manager) RefreshTrustBundle(ctx context.Context) error {
 		return fmt.Errorf("fetch Atom trust bundle: %w", err)
 	}
 	defer response.Body.Close()
+	if !m.config.ResolverInsecure && response.Request != nil && response.Request.URL.Scheme != "https" {
+		m.metrics.trustRefreshFailures.Add(1)
+		return fmt.Errorf("Atom trust bundle redirect downgraded HTTPS")
+	}
 
 	if response.StatusCode == http.StatusNotModified {
 		m.trustMu.RLock()
@@ -95,6 +99,10 @@ func parseTrustBundle(bundle []byte) (*x509.CertPool, error) {
 		certificate, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {
 			return nil, fmt.Errorf("parse Atom trust bundle certificate: %w", err)
+		}
+		if !certificate.IsCA || !certificate.BasicConstraintsValid ||
+			(certificate.KeyUsage != 0 && certificate.KeyUsage&x509.KeyUsageCertSign == 0) {
+			return nil, fmt.Errorf("Atom trust bundle contains a certificate that cannot sign certificates")
 		}
 		pool.AddCert(certificate)
 		count++

--- a/pki/trust.go
+++ b/pki/trust.go
@@ -39,7 +39,7 @@ func (m *Manager) RefreshTrustBundle(ctx context.Context) error {
 		return fmt.Errorf("fetch Atom trust bundle: %w", err)
 	}
 	defer response.Body.Close()
-	if !m.config.ResolverInsecure && response.Request != nil && response.Request.URL.Scheme != "https" {
+	if !m.config.ResolverInsecure && response.Request != nil && response.Request.URL.Scheme != httpsScheme {
 		m.metrics.trustRefreshFailures.Add(1)
 		return fmt.Errorf("Atom trust bundle redirect downgraded HTTPS")
 	}
@@ -93,7 +93,7 @@ func parseTrustBundle(bundle []byte) (*x509.CertPool, error) {
 		if block == nil {
 			return nil, fmt.Errorf("Atom trust bundle contains malformed PEM data")
 		}
-		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+		if block.Type != certificatePEMType || len(block.Headers) != 0 {
 			return nil, fmt.Errorf("Atom trust bundle contains a non-certificate PEM block")
 		}
 		certificate, err := x509.ParseCertificate(block.Bytes)

--- a/pki/trust.go
+++ b/pki/trust.go
@@ -1,0 +1,177 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package pki
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// RefreshTrustBundle fetches Atom's public trust bundle with ETag
+// revalidation, validates every PEM block, then swaps the pool atomically.
+// A failed refresh leaves the last known-good pool in service.
+func (m *Manager) RefreshTrustBundle(ctx context.Context) error {
+	m.trustMu.RLock()
+	etag := m.trustETag
+	m.trustMu.RUnlock()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, m.config.TrustBundleURL, nil)
+	if err != nil {
+		m.metrics.trustRefreshFailures.Add(1)
+		return fmt.Errorf("build Atom trust bundle request: %w", err)
+	}
+	if etag != "" {
+		request.Header.Set("If-None-Match", etag)
+	}
+	response, err := m.httpClient.Do(request)
+	if err != nil {
+		m.metrics.trustRefreshFailures.Add(1)
+		return fmt.Errorf("fetch Atom trust bundle: %w", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode == http.StatusNotModified {
+		m.trustMu.RLock()
+		ready := m.trustPool != nil
+		m.trustMu.RUnlock()
+		if !ready {
+			m.metrics.trustRefreshFailures.Add(1)
+			return fmt.Errorf("Atom returned an unchanged trust bundle before initial load")
+		}
+		m.metrics.trustRefreshSuccess.Add(1)
+		return nil
+	}
+	if response.StatusCode != http.StatusOK {
+		m.metrics.trustRefreshFailures.Add(1)
+		return fmt.Errorf("fetch Atom trust bundle: unexpected HTTP status %d", response.StatusCode)
+	}
+
+	limited := io.LimitReader(response.Body, maximumTrustBundleBytes+1)
+	bundle, err := io.ReadAll(limited)
+	if err != nil {
+		m.metrics.trustRefreshFailures.Add(1)
+		return fmt.Errorf("read Atom trust bundle: %w", err)
+	}
+	if len(bundle) == 0 || len(bundle) > maximumTrustBundleBytes {
+		m.metrics.trustRefreshFailures.Add(1)
+		return fmt.Errorf("Atom trust bundle is empty or exceeds %d bytes", maximumTrustBundleBytes)
+	}
+	pool, err := parseTrustBundle(bundle)
+	if err != nil {
+		m.metrics.trustRefreshFailures.Add(1)
+		return err
+	}
+
+	m.trustMu.Lock()
+	m.trustPool = pool
+	m.trustETag = strings.TrimSpace(response.Header.Get("ETag"))
+	m.trustMu.Unlock()
+	m.metrics.trustRefreshSuccess.Add(1)
+	return nil
+}
+
+func parseTrustBundle(bundle []byte) (*x509.CertPool, error) {
+	pool := x509.NewCertPool()
+	rest := bundle
+	count := 0
+	for len(bytes.TrimSpace(rest)) != 0 {
+		block, remaining := pem.Decode(rest)
+		if block == nil {
+			return nil, fmt.Errorf("Atom trust bundle contains malformed PEM data")
+		}
+		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+			return nil, fmt.Errorf("Atom trust bundle contains a non-certificate PEM block")
+		}
+		certificate, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse Atom trust bundle certificate: %w", err)
+		}
+		pool.AddCert(certificate)
+		count++
+		rest = remaining
+	}
+	if count == 0 {
+		return nil, fmt.Errorf("Atom trust bundle contains no certificates")
+	}
+	return pool, nil
+}
+
+// WrapTLSConfig replaces static client roots with the current Atom-published
+// pool for one MQTT mTLS listener while preserving every other TLS option and
+// any pre-existing dynamic configuration callback.
+func (m *Manager) WrapTLSConfig(base *tls.Config) (*tls.Config, error) {
+	if base == nil {
+		return nil, fmt.Errorf("cannot attach Atom trust bundle to a nil TLS configuration")
+	}
+	m.trustMu.RLock()
+	initial := m.trustPool
+	m.trustMu.RUnlock()
+	if initial == nil {
+		return nil, fmt.Errorf("Atom trust bundle has not been loaded")
+	}
+
+	original := base.GetConfigForClient
+	baseCopy := base.Clone()
+	wrapped := base.Clone()
+	wrapped.ClientCAs = initial
+	wrapped.GetConfigForClient = func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+		selected := baseCopy
+		if original != nil {
+			candidate, err := original(hello)
+			if err != nil {
+				return nil, err
+			}
+			if candidate != nil {
+				selected = candidate
+			}
+		}
+		m.trustMu.RLock()
+		pool := m.trustPool
+		m.trustMu.RUnlock()
+		if pool == nil {
+			return nil, fmt.Errorf("Atom trust bundle is unavailable")
+		}
+		current := selected.Clone()
+		current.ClientCAs = pool
+		current.GetConfigForClient = nil
+		return current, nil
+	}
+	return wrapped, nil
+}
+
+func (m *Manager) requestTrustRefresh() {
+	select {
+	case m.refreshCh <- struct{}{}:
+	default:
+	}
+}
+
+func (m *Manager) trustRefreshLoop() {
+	defer m.wg.Done()
+	ticker := time.NewTicker(m.config.TrustRefreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-m.stopCh:
+			return
+		case <-ticker.C:
+		case <-m.refreshCh:
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), m.config.Timeout)
+		err := m.RefreshTrustBundle(ctx)
+		cancel()
+		if err != nil {
+			m.logger.Warn("Atom trust bundle refresh failed", slog.String("error", err.Error()))
+		}
+	}
+}

--- a/pki/trust.go
+++ b/pki/trust.go
@@ -164,7 +164,7 @@ func (m *Manager) requestTrustRefresh() {
 	}
 }
 
-func (m *Manager) trustRefreshLoop() {
+func (m *Manager) trustRefreshLoop(parent context.Context) {
 	defer m.wg.Done()
 	ticker := time.NewTicker(m.config.TrustRefreshInterval)
 	defer ticker.Stop()
@@ -175,7 +175,7 @@ func (m *Manager) trustRefreshLoop() {
 		case <-ticker.C:
 		case <-m.refreshCh:
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), m.config.Timeout)
+		ctx, cancel := context.WithTimeout(parent, m.config.Timeout)
 		err := m.RefreshTrustBundle(ctx)
 		cancel()
 		if err != nil {

--- a/server/api/server.go
+++ b/server/api/server.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	amqpbroker "github.com/absmach/fluxmq/amqp/broker"
+	corebroker "github.com/absmach/fluxmq/broker"
 	"github.com/absmach/fluxmq/cluster"
 	mqttbroker "github.com/absmach/fluxmq/mqtt/broker"
 	"github.com/absmach/fluxmq/pkg/proto/queue/v1/queuev1connect"
@@ -32,14 +33,21 @@ type Config struct {
 
 // Server provides the HTTP/gRPC API server using Connect protocol.
 type Server struct {
-	config        Config
-	broker        *mqttbroker.Broker
-	amqpBroker    *amqpbroker.Broker
-	cluster       cluster.Cluster
-	queueManager  *queue.Manager
-	reloadManager *reload.Manager
-	httpServer    *http.Server
-	logger        *slog.Logger
+	config             Config
+	broker             *mqttbroker.Broker
+	amqpBroker         *amqpbroker.Broker
+	cluster            cluster.Cluster
+	queueManager       *queue.Manager
+	reloadManager      *reload.Manager
+	certificateMetrics corebroker.CertificateMetricsProvider
+	httpServer         *http.Server
+	logger             *slog.Logger
+}
+
+// SetCertificateMetricsProvider exposes label-free PKI resolver counters in
+// the existing admin statistics endpoint.
+func (s *Server) SetCertificateMetricsProvider(provider corebroker.CertificateMetricsProvider) {
+	s.certificateMetrics = provider
 }
 
 // New creates a new API server.

--- a/server/api/stats.go
+++ b/server/api/stats.go
@@ -3,7 +3,11 @@
 
 package api
 
-import "net/http"
+import (
+	"net/http"
+
+	"github.com/absmach/fluxmq/broker"
+)
 
 type connectionStats struct {
 	Current        uint64 `json:"current"`
@@ -136,17 +140,25 @@ type queuePendingStats struct {
 }
 
 type statsResponse struct {
-	UptimeSeconds float64         `json:"uptime_seconds"`
-	Connections   connectionStats `json:"connections"`
-	Messages      messageStats    `json:"messages"`
-	Bytes         byteStats       `json:"bytes"`
-	Errors        errorStats      `json:"errors"`
-	ByProtocol    byProtocolStats `json:"by_protocol"`
-	Queues        *queueStats     `json:"queues,omitempty"`
+	UptimeSeconds float64                    `json:"uptime_seconds"`
+	Connections   connectionStats            `json:"connections"`
+	Messages      messageStats               `json:"messages"`
+	Bytes         byteStats                  `json:"bytes"`
+	Errors        errorStats                 `json:"errors"`
+	ByProtocol    byProtocolStats            `json:"by_protocol"`
+	Queues        *queueStats                `json:"queues,omitempty"`
+	Certificates  *broker.CertificateMetrics `json:"certificates,omitempty"`
 }
 
 func (s *Server) buildStatsResponse() statsResponse {
 	var resp statsResponse
+	if s.certificateMetrics != nil {
+		metrics := s.certificateMetrics.CertificateMetrics()
+		if s.broker != nil {
+			metrics.ActiveSessions = s.broker.CertificateSessionCount()
+		}
+		resp.Certificates = &metrics
+	}
 
 	if s.broker != nil {
 		st := s.broker.Stats()

--- a/server/api/stats_test.go
+++ b/server/api/stats_test.go
@@ -26,9 +26,10 @@ type certificateMetricsStub struct{}
 
 func (certificateMetricsStub) CertificateMetrics() corebroker.CertificateMetrics {
 	return corebroker.CertificateMetrics{
-		ResolverRequests:   7,
-		CacheEntries:       2,
-		CacheInvalidations: 3,
+		ResolverRequests:     7,
+		CacheEntries:         2,
+		CacheInvalidations:   3,
+		SessionsDisconnected: 1,
 	}
 }
 
@@ -108,7 +109,7 @@ func TestStatsIncludesLabelFreeCertificateMetrics(t *testing.T) {
 	if response.Certificates == nil {
 		t.Fatal("expected certificate metrics")
 	}
-	if response.Certificates.ResolverRequests != 7 || response.Certificates.CacheInvalidations != 3 {
+	if response.Certificates.ResolverRequests != 7 || response.Certificates.CacheInvalidations != 3 || response.Certificates.SessionsDisconnected != 1 {
 		t.Fatalf("unexpected certificate metrics: %+v", response.Certificates)
 	}
 }

--- a/server/api/stats_test.go
+++ b/server/api/stats_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	amqpbroker "github.com/absmach/fluxmq/amqp/broker"
+	corebroker "github.com/absmach/fluxmq/broker"
 	mqttbroker "github.com/absmach/fluxmq/mqtt/broker"
 	"github.com/absmach/fluxmq/queue"
 	qstorage "github.com/absmach/fluxmq/queue/storage"
@@ -20,6 +21,16 @@ import (
 	qtypes "github.com/absmach/fluxmq/queue/types"
 	"github.com/absmach/fluxmq/storage/memory"
 )
+
+type certificateMetricsStub struct{}
+
+func (certificateMetricsStub) CertificateMetrics() corebroker.CertificateMetrics {
+	return corebroker.CertificateMetrics{
+		ResolverRequests:   7,
+		CacheEntries:       2,
+		CacheInvalidations: 3,
+	}
+}
 
 func TestStatsMQTTOnly(t *testing.T) {
 	store := memory.New()
@@ -77,6 +88,28 @@ func TestStatsMQTTOnly(t *testing.T) {
 	}
 	if resp.ByProtocol.AMQP != nil {
 		t.Fatal("expected no amqp in by_protocol when amqp broker is nil")
+	}
+}
+
+func TestStatsIncludesLabelFreeCertificateMetrics(t *testing.T) {
+	store := memory.New()
+	b := mqttbroker.NewBroker(store, nil, mqttbroker.WithLogger(slog.Default()))
+	srv := New(Config{}, b, nil, nil, nil, nil, nil, slog.Default())
+	srv.SetCertificateMetricsProvider(certificateMetricsStub{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/stats", nil)
+	rec := httptest.NewRecorder()
+	srv.httpServer.Handler.ServeHTTP(rec, req)
+
+	var response statsResponse
+	if err := json.NewDecoder(rec.Body).Decode(&response); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if response.Certificates == nil {
+		t.Fatal("expected certificate metrics")
+	}
+	if response.Certificates.ResolverRequests != 7 || response.Certificates.CacheInvalidations != 3 {
+		t.Fatalf("unexpected certificate metrics: %+v", response.Certificates)
 	}
 }
 

--- a/server/http/server.go
+++ b/server/http/server.go
@@ -331,7 +331,7 @@ func (s *Server) publish(w http.ResponseWriter, r *http.Request, topic string, p
 		return
 	}
 
-	authenticated, externalID, err := s.broker.Authenticate(clientID, username, password)
+	authenticated, externalID, err := s.broker.AuthenticateContext(r.Context(), clientID, username, password)
 	if err != nil || !authenticated {
 		s.logger.Warn("http_publish_auth_failed",
 			slog.String("client_id", clientID),
@@ -361,7 +361,7 @@ func (s *Server) publish(w http.ResponseWriter, r *http.Request, topic string, p
 		return
 	}
 	topic, payload, qos, retain, props = hookReq.Topic, hookReq.Payload, hookReq.QoS, hookReq.Retain, hookReq.Properties
-	if !s.broker.CanPublish(clientID, topic) {
+	if !s.broker.CanPublishContext(r.Context(), clientID, topic) {
 		s.logger.Warn("http_publish_forbidden",
 			slog.String("client_id", clientID),
 			slog.String("topic", topic))

--- a/server/tcp/server.go
+++ b/server/tcp/server.go
@@ -46,6 +46,10 @@ type Config struct {
 	SendQueueSize    int
 	DisconnectOnFull bool
 	ProtocolVersion  int
+	// CertificateAuthentication marks this listener as the Atom-backed mTLS
+	// authentication boundary. Ordinary TLS listeners leave it false even when
+	// they request or verify optional client certificates.
+	CertificateAuthentication bool
 	// MaxPacketSize bounds an inbound MQTT packet's remaining length. The limit
 	// is applied from the fixed header, before the body is buffered, so an
 	// unauthenticated peer cannot reserve memory by advertising a large length.
@@ -291,7 +295,8 @@ func (s *Server) handleConnection(connCtx context.Context, conn net.Conn) {
 	// socket write by the connection itself.
 	hc := core.NewConnectionWithVersion(conn, s.config.SendQueueSize, s.config.DisconnectOnFull, s.config.ProtocolVersion,
 		core.WithMaxPacketSize(s.config.MaxPacketSize),
-		core.WithWriteTimeout(s.config.WriteTimeout))
+		core.WithWriteTimeout(s.config.WriteTimeout),
+		core.WithCertificateAuthentication(s.config.CertificateAuthentication))
 	broker.HandleConnection(connCtx, s.handler, hc)
 
 	s.config.Logger.Debug("connection closed",

--- a/server/tcp/tls_test.go
+++ b/server/tcp/tls_test.go
@@ -4,6 +4,7 @@
 package tcp
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
@@ -13,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	corebroker "github.com/absmach/fluxmq/broker"
+	core "github.com/absmach/fluxmq/mqtt"
 	"github.com/absmach/fluxmq/mqtt/broker"
 	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
 )
@@ -174,6 +177,45 @@ func TestTLS_RequireClientCert(t *testing.T) {
 		_ = tlsClient.Close()
 		waitForConnections(t, server)
 	})
+}
+
+func TestTLSConnectionExposesVerifiedPeerChain(t *testing.T) {
+	certs := GenerateTestCerts(t)
+	serverTLS := LoadServerTLSConfig(t, certs, tls.RequireAndVerifyClientCert)
+	clientTLS := LoadClientTLSConfig(t, certs, true)
+	clientTLS.ServerName = "localhost"
+
+	serverConn, clientConn := net.Pipe()
+	t.Cleanup(func() {
+		_ = serverConn.Close()
+		_ = clientConn.Close()
+	})
+	tlsServer := tls.Server(serverConn, serverTLS)
+	tlsClient := tls.Client(clientConn, clientTLS)
+	serverErr := make(chan error, 1)
+	go func() { serverErr <- tlsServer.Handshake() }()
+	if err := tlsHandshakeWithTimeout(tlsClient, 2*time.Second); err != nil {
+		t.Fatalf("client TLS handshake failed: %v", err)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server TLS handshake failed: %v", err)
+	}
+
+	state := tlsServer.ConnectionState()
+	if len(state.VerifiedChains) == 0 || len(state.VerifiedChains[0]) < 2 {
+		t.Fatal("expected a verified client leaf and issuer")
+	}
+	connection := core.NewConnection(tlsServer, 0, false)
+	peer, ok := connection.(corebroker.PeerCertificateSource)
+	if !ok {
+		t.Fatalf("expected certificate-aware TCP connection, got %T", connection)
+	}
+	if !bytes.Equal(peer.PeerCertificateDER(), state.VerifiedChains[0][0].Raw) {
+		t.Fatal("TCP connection did not expose the verified client leaf")
+	}
+	if !bytes.Equal(peer.PeerIssuerCertificateDER(), state.VerifiedChains[0][1].Raw) {
+		t.Fatal("TCP connection did not expose the verified client issuer")
+	}
 }
 
 func TestTLS_UntrustedServer(t *testing.T) {

--- a/server/tcp/tls_test.go
+++ b/server/tcp/tls_test.go
@@ -205,7 +205,7 @@ func TestTLSConnectionExposesVerifiedPeerChain(t *testing.T) {
 	if len(state.VerifiedChains) == 0 || len(state.VerifiedChains[0]) < 2 {
 		t.Fatal("expected a verified client leaf and issuer")
 	}
-	connection := core.NewConnection(tlsServer, 0, false)
+	connection := core.NewConnection(tlsServer, 0, false, core.WithCertificateAuthentication(true))
 	peer, ok := connection.(corebroker.PeerCertificateSource)
 	if !ok {
 		t.Fatalf("expected certificate-aware TCP connection, got %T", connection)
@@ -215,6 +215,10 @@ func TestTLSConnectionExposesVerifiedPeerChain(t *testing.T) {
 	}
 	if !bytes.Equal(peer.PeerIssuerCertificateDER(), state.VerifiedChains[0][1].Raw) {
 		t.Fatal("TCP connection did not expose the verified client issuer")
+	}
+	authentication, ok := connection.(corebroker.CertificateAuthenticationSource)
+	if !ok || !authentication.CertificateAuthenticationEnabled() {
+		t.Fatal("TCP connection did not retain certificate-authentication listener metadata")
 	}
 }
 

--- a/server/websocket/hardening_test.go
+++ b/server/websocket/hardening_test.go
@@ -212,7 +212,7 @@ func TestWSWriteTimeoutAppliedPerWrite(t *testing.T) {
 	serverWS, clientWS := wsConnPair(t)
 	t.Cleanup(func() { clientWS.Close() }) //nolint:errcheck // best-effort teardown
 
-	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolV3, 0, time.Nanosecond)
+	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolV3, 0, time.Nanosecond, false)
 	t.Cleanup(func() { conn.Close() }) //nolint:errcheck // best-effort teardown
 
 	err := conn.WritePacket(&v3.PingResp{
@@ -228,7 +228,7 @@ func TestWSWriteWithoutTimeoutHasNoDeadline(t *testing.T) {
 	serverWS, clientWS := wsConnPair(t)
 	t.Cleanup(func() { clientWS.Close() }) //nolint:errcheck // best-effort teardown
 
-	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolV3, 0, 0)
+	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolV3, 0, 0, false)
 	t.Cleanup(func() { conn.Close() }) //nolint:errcheck // best-effort teardown
 
 	require.NoError(t, conn.WritePacket(&v3.PingResp{

--- a/server/websocket/server.go
+++ b/server/websocket/server.go
@@ -67,6 +67,9 @@ type Config struct {
 	WriteTimeout time.Duration
 	// MaxConnections caps concurrently upgraded connections. 0 means unlimited.
 	MaxConnections int
+	// CertificateAuthentication marks this listener as the Atom-backed mTLS
+	// authentication boundary. Ordinary TLS listeners leave it false.
+	CertificateAuthentication bool
 }
 
 type Server struct {
@@ -330,7 +333,7 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 			peerCertificate.IssuerDER = append([]byte(nil), r.TLS.VerifiedChains[0][1].Raw...)
 		}
 	}
-	conn := newWSConnection(ws, r.RemoteAddr, s.config.ProtocolVersion, s.config.MaxPacketSize, s.config.WriteTimeout, peerCertificate)
+	conn := newWSConnection(ws, r.RemoteAddr, s.config.ProtocolVersion, s.config.MaxPacketSize, s.config.WriteTimeout, s.config.CertificateAuthentication, peerCertificate)
 
 	// Bound the pre-session phase: an upgraded client that never sends a CONNECT
 	// would otherwise hold a goroutine and a connection slot indefinitely. The
@@ -345,25 +348,26 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 // wsConnection implements core.Connection for WebSocket transport.
 type wsConnection struct {
-	ws              *websocket.Conn
-	remoteAddr      string
-	reader          io.Reader
-	frameReader     *wsFrameReader
-	version         int
-	mu              sync.RWMutex
-	closeOnce       sync.Once
-	readMu          sync.RWMutex
-	writeMu         sync.Mutex
-	closed          bool
-	closeCh         chan struct{}
-	readDeadline    time.Time
-	lastActivity    time.Time
-	onDisconnect    func(graceful bool)
-	pingStop        chan struct{}
-	pingOnce        sync.Once
-	maxPacketSize   int           // 0 = unlimited
-	writeTimeout    time.Duration // 0 = no write deadline
-	peerCertificate corebroker.PeerCertificate
+	ws                        *websocket.Conn
+	remoteAddr                string
+	reader                    io.Reader
+	frameReader               *wsFrameReader
+	version                   int
+	mu                        sync.RWMutex
+	closeOnce                 sync.Once
+	readMu                    sync.RWMutex
+	writeMu                   sync.Mutex
+	closed                    bool
+	closeCh                   chan struct{}
+	readDeadline              time.Time
+	lastActivity              time.Time
+	onDisconnect              func(graceful bool)
+	pingStop                  chan struct{}
+	pingOnce                  sync.Once
+	maxPacketSize             int           // 0 = unlimited
+	writeTimeout              time.Duration // 0 = no write deadline
+	peerCertificate           corebroker.PeerCertificate
+	certificateAuthentication bool
 }
 
 // wsFrameOverhead allows an MQTT packet's fixed header (up to 5 bytes) to fit
@@ -372,18 +376,19 @@ type wsConnection struct {
 // tearing the connection down first.
 const wsFrameOverhead = 5
 
-func newWSConnection(ws *websocket.Conn, remoteAddr string, protocolVersion, maxPacketSize int, writeTimeout time.Duration, peerCertificate ...corebroker.PeerCertificate) core.Connection {
+func newWSConnection(ws *websocket.Conn, remoteAddr string, protocolVersion, maxPacketSize int, writeTimeout time.Duration, certificateAuthentication bool, peerCertificate ...corebroker.PeerCertificate) core.Connection {
 	if ws != nil && maxPacketSize > 0 {
 		ws.SetReadLimit(int64(maxPacketSize) + wsFrameOverhead)
 	}
 	conn := &wsConnection{
-		ws:            ws,
-		remoteAddr:    remoteAddr,
-		version:       protocolVersion,
-		closed:        false,
-		closeCh:       make(chan struct{}),
-		maxPacketSize: maxPacketSize,
-		writeTimeout:  writeTimeout,
+		ws:                        ws,
+		remoteAddr:                remoteAddr,
+		version:                   protocolVersion,
+		closed:                    false,
+		closeCh:                   make(chan struct{}),
+		maxPacketSize:             maxPacketSize,
+		writeTimeout:              writeTimeout,
+		certificateAuthentication: certificateAuthentication,
 	}
 	if len(peerCertificate) != 0 {
 		conn.peerCertificate.LeafDER = append([]byte(nil), peerCertificate[0].LeafDER...)
@@ -400,6 +405,12 @@ func (c *wsConnection) PeerCertificateDER() []byte {
 // PeerIssuerCertificateDER returns a copy of the verified leaf issuer.
 func (c *wsConnection) PeerIssuerCertificateDER() []byte {
 	return append([]byte(nil), c.peerCertificate.IssuerDER...)
+}
+
+// CertificateAuthenticationEnabled reports whether this connection belongs to
+// the explicitly configured certificate-authentication listener.
+func (c *wsConnection) CertificateAuthenticationEnabled() bool {
+	return c.certificateAuthentication
 }
 
 func (c *wsConnection) ReadPacket() (packets.ControlPacket, error) {

--- a/server/websocket/server.go
+++ b/server/websocket/server.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	corebroker "github.com/absmach/fluxmq/broker"
 	"github.com/absmach/fluxmq/internal/connguard"
 	core "github.com/absmach/fluxmq/mqtt"
 	"github.com/absmach/fluxmq/mqtt/broker"
@@ -322,7 +323,14 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 	s.logger.Debug("websocket_connection_accepted", slog.String("remote_addr", r.RemoteAddr))
 
-	conn := newWSConnection(ws, r.RemoteAddr, s.config.ProtocolVersion, s.config.MaxPacketSize, s.config.WriteTimeout)
+	var peerCertificate corebroker.PeerCertificate
+	if r.TLS != nil && len(r.TLS.VerifiedChains) != 0 && len(r.TLS.VerifiedChains[0]) != 0 {
+		peerCertificate.LeafDER = append([]byte(nil), r.TLS.VerifiedChains[0][0].Raw...)
+		if len(r.TLS.VerifiedChains[0]) > 1 {
+			peerCertificate.IssuerDER = append([]byte(nil), r.TLS.VerifiedChains[0][1].Raw...)
+		}
+	}
+	conn := newWSConnection(ws, r.RemoteAddr, s.config.ProtocolVersion, s.config.MaxPacketSize, s.config.WriteTimeout, peerCertificate)
 
 	// Bound the pre-session phase: an upgraded client that never sends a CONNECT
 	// would otherwise hold a goroutine and a connection slot indefinitely. The
@@ -337,24 +345,25 @@ func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 // wsConnection implements core.Connection for WebSocket transport.
 type wsConnection struct {
-	ws            *websocket.Conn
-	remoteAddr    string
-	reader        io.Reader
-	frameReader   *wsFrameReader
-	version       int
-	mu            sync.RWMutex
-	closeOnce     sync.Once
-	readMu        sync.RWMutex
-	writeMu       sync.Mutex
-	closed        bool
-	closeCh       chan struct{}
-	readDeadline  time.Time
-	lastActivity  time.Time
-	onDisconnect  func(graceful bool)
-	pingStop      chan struct{}
-	pingOnce      sync.Once
-	maxPacketSize int           // 0 = unlimited
-	writeTimeout  time.Duration // 0 = no write deadline
+	ws              *websocket.Conn
+	remoteAddr      string
+	reader          io.Reader
+	frameReader     *wsFrameReader
+	version         int
+	mu              sync.RWMutex
+	closeOnce       sync.Once
+	readMu          sync.RWMutex
+	writeMu         sync.Mutex
+	closed          bool
+	closeCh         chan struct{}
+	readDeadline    time.Time
+	lastActivity    time.Time
+	onDisconnect    func(graceful bool)
+	pingStop        chan struct{}
+	pingOnce        sync.Once
+	maxPacketSize   int           // 0 = unlimited
+	writeTimeout    time.Duration // 0 = no write deadline
+	peerCertificate corebroker.PeerCertificate
 }
 
 // wsFrameOverhead allows an MQTT packet's fixed header (up to 5 bytes) to fit
@@ -363,11 +372,11 @@ type wsConnection struct {
 // tearing the connection down first.
 const wsFrameOverhead = 5
 
-func newWSConnection(ws *websocket.Conn, remoteAddr string, protocolVersion, maxPacketSize int, writeTimeout time.Duration) core.Connection {
+func newWSConnection(ws *websocket.Conn, remoteAddr string, protocolVersion, maxPacketSize int, writeTimeout time.Duration, peerCertificate ...corebroker.PeerCertificate) core.Connection {
 	if ws != nil && maxPacketSize > 0 {
 		ws.SetReadLimit(int64(maxPacketSize) + wsFrameOverhead)
 	}
-	return &wsConnection{
+	conn := &wsConnection{
 		ws:            ws,
 		remoteAddr:    remoteAddr,
 		version:       protocolVersion,
@@ -376,6 +385,21 @@ func newWSConnection(ws *websocket.Conn, remoteAddr string, protocolVersion, max
 		maxPacketSize: maxPacketSize,
 		writeTimeout:  writeTimeout,
 	}
+	if len(peerCertificate) != 0 {
+		conn.peerCertificate.LeafDER = append([]byte(nil), peerCertificate[0].LeafDER...)
+		conn.peerCertificate.IssuerDER = append([]byte(nil), peerCertificate[0].IssuerDER...)
+	}
+	return conn
+}
+
+// PeerCertificateDER returns a copy of the verified WebSocket TLS peer leaf.
+func (c *wsConnection) PeerCertificateDER() []byte {
+	return append([]byte(nil), c.peerCertificate.LeafDER...)
+}
+
+// PeerIssuerCertificateDER returns a copy of the verified leaf issuer.
+func (c *wsConnection) PeerIssuerCertificateDER() []byte {
+	return append([]byte(nil), c.peerCertificate.IssuerDER...)
 }
 
 func (c *wsConnection) ReadPacket() (packets.ControlPacket, error) {

--- a/server/websocket/server_test.go
+++ b/server/websocket/server_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	corebroker "github.com/absmach/fluxmq/broker"
 	core "github.com/absmach/fluxmq/mqtt"
 	"github.com/absmach/fluxmq/mqtt/packets"
 	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
@@ -28,6 +29,30 @@ func TestNewWSConnectionProtocolVersion(t *testing.T) {
 
 	if wsConn.version != core.ProtocolV5 {
 		t.Fatalf("expected protocol version %d, got %d", core.ProtocolV5, wsConn.version)
+	}
+}
+
+func TestWSConnectionExposesCopiedVerifiedPeerChain(t *testing.T) {
+	leaf := []byte{1, 2, 3}
+	issuer := []byte{4, 5, 6}
+	conn := newWSConnection(nil, "127.0.0.1:1111", core.ProtocolV5, 0, 0, corebroker.PeerCertificate{
+		LeafDER:   leaf,
+		IssuerDER: issuer,
+	})
+	peer, ok := conn.(corebroker.PeerCertificateSource)
+	if !ok {
+		t.Fatalf("expected certificate-aware WebSocket connection, got %T", conn)
+	}
+	leaf[0] = 9
+	issuer[0] = 9
+	gotLeaf := peer.PeerCertificateDER()
+	gotIssuer := peer.PeerIssuerCertificateDER()
+	if gotLeaf[0] != 1 || gotIssuer[0] != 4 {
+		t.Fatal("WebSocket connection did not retain defensive peer-chain copies")
+	}
+	gotLeaf[0] = 8
+	if peer.PeerCertificateDER()[0] != 1 {
+		t.Fatal("WebSocket peer leaf accessor leaked mutable internal state")
 	}
 }
 

--- a/server/websocket/server_test.go
+++ b/server/websocket/server_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestNewWSConnectionProtocolVersion(t *testing.T) {
-	conn := newWSConnection(nil, "127.0.0.1:1111", core.ProtocolV5, 0, 0)
+	conn := newWSConnection(nil, "127.0.0.1:1111", core.ProtocolV5, 0, 0, false)
 
 	wsConn, ok := conn.(*wsConnection)
 	if !ok {
@@ -35,7 +35,7 @@ func TestNewWSConnectionProtocolVersion(t *testing.T) {
 func TestWSConnectionExposesCopiedVerifiedPeerChain(t *testing.T) {
 	leaf := []byte{1, 2, 3}
 	issuer := []byte{4, 5, 6}
-	conn := newWSConnection(nil, "127.0.0.1:1111", core.ProtocolV5, 0, 0, corebroker.PeerCertificate{
+	conn := newWSConnection(nil, "127.0.0.1:1111", core.ProtocolV5, 0, 0, true, corebroker.PeerCertificate{
 		LeafDER:   leaf,
 		IssuerDER: issuer,
 	})
@@ -53,6 +53,10 @@ func TestWSConnectionExposesCopiedVerifiedPeerChain(t *testing.T) {
 	gotLeaf[0] = 8
 	if peer.PeerCertificateDER()[0] != 1 {
 		t.Fatal("WebSocket peer leaf accessor leaked mutable internal state")
+	}
+	authentication, ok := conn.(corebroker.CertificateAuthenticationSource)
+	if !ok || !authentication.CertificateAuthenticationEnabled() {
+		t.Fatal("WebSocket connection did not retain certificate-authentication listener metadata")
 	}
 }
 
@@ -195,7 +199,7 @@ func TestReadPacketAcrossWebSocketMessages(t *testing.T) {
 	serverWS, clientWS := wsConnPair(t)
 	defer clientWS.Close()
 
-	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolAuto, 0, 0)
+	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolAuto, 0, 0, false)
 	defer conn.Close()
 
 	want := &v3.Connect{
@@ -248,7 +252,7 @@ func TestReadPacketSequentialMessages(t *testing.T) {
 	serverWS, clientWS := wsConnPair(t)
 	defer clientWS.Close()
 
-	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolAuto, 0, 0)
+	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolAuto, 0, 0, false)
 	defer conn.Close()
 
 	const count = 50
@@ -290,7 +294,7 @@ func TestReadPacketTimeoutDoesNotPoisonWebSocket(t *testing.T) {
 	serverWS, clientWS := wsConnPair(t)
 	defer clientWS.Close()
 
-	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolAuto, 0, 0)
+	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolAuto, 0, 0, false)
 	defer conn.Close()
 
 	if err := conn.SetReadDeadline(time.Now().Add(10 * time.Millisecond)); err != nil {
@@ -339,7 +343,7 @@ func TestSetKeepAliveAfterReadPacketProcessesPong(t *testing.T) {
 	serverWS, clientWS := wsConnPair(t)
 	defer clientWS.Close()
 
-	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolAuto, 0, 0).(*wsConnection)
+	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolAuto, 0, 0, false).(*wsConnection)
 	defer conn.Close()
 
 	connect := &v3.Connect{
@@ -393,7 +397,7 @@ func TestReadPumpStopsAfterCloseWithBufferedRead(t *testing.T) {
 	serverWS, clientWS := wsConnPair(t)
 	defer clientWS.Close()
 
-	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolAuto, 0, 0).(*wsConnection)
+	conn := newWSConnection(serverWS, "127.0.0.1:9999", core.ProtocolAuto, 0, 0, false).(*wsConnection)
 	reader := &wsFrameReader{conn: conn}
 	reader.once.Do(reader.start)
 


### PR DESCRIPTION
## Objective

Implement PR-012's consuming-service contract in FluxMQ as the reference relying-party integration for MQTT TCP and WebSocket mTLS. This integration declares the **resolver verification tier**: Atom's `ResolveCertificateV2` is authoritative for certificate identity and lifecycle state, with a reviewed bounded cache controlling the outage and revocation window.

## Dependencies

- Atom PR-011 — merged as [absmach/atom#56](https://github.com/absmach/atom/pull/56), merge commit `0dd667403746b68afad1e81ab53d144b463c9f28`.
- Atom PR-014 — merged as [absmach/atom#58](https://github.com/absmach/atom/pull/58), merge commit `a67967114a8f338a16dd31bff829c1cf578e9740`.
- FluxMQ `certificates` base — `dbfc4d32686d97ea848a319632cc12b1ea6654e2`.

## Changes

- Mark only the named Atom-backed mTLS TCP/WebSocket listeners as certificate-authentication transports, then extract defensively copied verified peer leaf/issuer DER and derive canonical SHA-256/serial selectors. Optional certificates on ordinary TLS listeners remain on the existing authentication path.
- Invoke only `/atom.v1.CertificateService/ResolveCertificateV2`; reread the bearer token file on every resolver call for safe rotation.
- Hold certificate authentication pending until hooks and persistent-session ownership checks pass, serialize same-client MQTT 3/5 connection setup, and use generation-bound cleanup so stale disconnects cannot erase replacement identities.
- Map the resolver result to the MQTT external entity, prevent cross-entity client-ID takeover, and prevent persistent session inheritance by another certificate entity.
- Compare canonical `m/<tenant>/...` and `hc/<tenant>/...` scopes—including shared subscriptions and CONNECT-time Wills—before the existing external authorizer.
- Add a bounded LRU resolver cache (30s default, 5m maximum, certificate-expiry capped), singleflight collapse, bounded live certificate state, and fail-closed misses.
- Consume authenticated Atom v1 outbox events from a reserved stream and idempotently invalidate by credential/entity/tenant/issuer. Credential, entity, tenant, and unusable-authority lifecycle events proactively disconnect matching sessions without publishing Wills; resolver failure after cache expiry does the same. Retiring/retired issuers remain connected because Atom deliberately retains them for verification.
- Prevent an in-flight resolver call from repopulating state after lifecycle invalidation.
- Load Atom's published PEM trust bundle before listener startup, reject non-CA bundles and HTTPS downgrade, refresh by ETag/polling and immediately on `pki.authority.*` events, and retain the last known-good bundle after refresh failure.
- Add strict opt-in configuration, documentation, OpenAPI/admin label-free metrics, and migration guidance with no legacy certificate-service dependency.

## Acceptance criteria validation

- [x] **Cross-tenant certificates are denied despite common trust roots.** Canonical topic tenant comparison precedes normal authorization; shared filters and Wills are covered by `TestTenantBindingRejectsCrossTenantAndGlobalEscalation` and `TestCertificateAuthenticationRejectsUnauthorizedWillBeforeSession`.
- [x] **Global entities stay global.** Empty Atom tenant IDs never acquire tenant scope; covered by `TestTenantBindingRejectsCrossTenantAndGlobalEscalation`.
- [x] **Unknown, revoked, expired, inactive-entity, and frozen-tenant credentials fail before session establishment.** Resolver results must be active, unexpired, and UUID-consistent; covered by `TestResolverLifecycleDenialsOccurBeforeSession` and MQTT CONNECT tests.
- [x] **Atom outage behavior is explicitly fail closed outside a reviewed bounded cache.** Misses/expiry fail closed; the default 30s and maximum 5m window and RTO are documented; covered by `TestReviewedCacheAllowsBoundedOutageThenFailsClosed`, `TestResolverTimeoutFailsClosed`, and `TestAuthorizationResolverFailureDisconnectsCertificateSession`.
- [x] **Certificate identity maps to the correct Atom entity.** Only V2 resolver output supplies identity; covered by `TestResolverAuthenticationExtractsAllTLSSelectorsAndMapsEntity` and the MQTT 3/5 CONNECT test.
- [x] **Revocation propagates within the documented lag.** Authenticated events invalidate immediately and disconnect matching sessions; event interruption falls back to bounded TTL plus next-operation fail-closed resolution. Covered by `TestLifecycleEventEvictsRevokedSessionAndDuplicateIsIdempotent`, `TestLifecycleEventPreventsInflightResolutionFromRepopulatingCache`, and `TestCertificateLifecycleInvalidationDisconnectsLiveSession`.
- [x] **Existing non-certificate authentication remains unaffected.** Certificate resolution requires an explicit transport marker, so even a verified optional certificate on an ordinary TLS listener follows username/password authentication; covered by `TestVerifiedCertificateOnOrdinaryTLSListenerUsesExistingAuthentication`, `TestAuthEngineNonCertificatePathUnchanged`, and the full repository suite.
- [x] **No legacy certificate service is required.** Production code uses only `ResolveCertificateV2`; verified by source review/search.
- [x] **Atom trust bundle is consumed and refreshes for new authorities.** Startup is synchronous/fail-closed; refresh is atomic and ETag/event driven; covered by `TestTrustBundleRefreshAfterAuthorityProvisioningEvent` and `TestTrustBundleRejectsNonCA`.

## Mandatory tests

- [x] Per-protocol authentication and listener isolation: `TestCertificateAuthenticationRunsForMQTTV3AndV5`, `TestVerifiedCertificateOnOrdinaryTLSListenerUsesExistingAuthentication`, `TestTLSConnectionExposesVerifiedPeerChain`, `TestWSConnectionExposesCopiedVerifiedPeerChain`.
- [x] Cross-tenant/global entity: `TestTenantBindingRejectsCrossTenantAndGlobalEscalation`, `TestCertificateAuthenticationRejectsUnauthorizedWillBeforeSession`.
- [x] Revoked/unusable-issuer session policy: `TestLifecycleEventEvictsRevokedSessionAndDuplicateIsIdempotent`, `TestUnusableAuthorityEventDisconnectsSessionsIssuedByThatAuthority`, `TestCertificateLifecycleInvalidationDisconnectsLiveSession`, `TestAuthorizationResolverFailureDisconnectsCertificateSession`.
- [x] Resolver timeout: `TestResolverTimeoutFailsClosed`.
- [x] Cache expiry/event invalidation: `TestReviewedCacheAllowsBoundedOutageThenFailsClosed`, `TestLifecycleEventPreventsInflightResolutionFromRepopulatingCache`.
- [x] Certificate rotation mid-session: `TestCertificateRotationRebindsSameEntity`, `TestAuthEngineCertificateRotationRebindsClientBeforeNextOperation`, `TestDisconnectCallbackCapturesCertificateBindingGeneration`.
- [x] Trust refresh after CA provisioning: `TestTrustBundleRefreshAfterAuthorityProvisioningEvent`.
- [x] Authorization denial: `TestAuthEngineCertificateDenialStopsNormalAuthorization`, `TestAuthEngineNormalAuthorizationCanDenyCertificateIdentity`.
- [x] Expected-rate/load and bounds: `TestResolverLoadCollapsesConcurrentConnections` (250 concurrent attempts), `TestResolutionCacheEvictsAtConfiguredCapacity`, `TestAuthEngineBoundsPendingAndCommittedCertificateSessions`.
- [x] Additional isolation: untrusted/malformed event rejection, cross-entity takeover rejection, rejected reconnect preservation, persistent-session ownership, concurrent authentication serialization, and label-free stats.

All mandatory tests are implemented in the branch. The full local CI test target passes on the final head; hosted checks for that head are pending.

## Additional validation

Passed locally on the final head:

```text
golangci-lint v2.12.2 run --timeout=10m  # PASS: 0 issues
make test                         # PASS: go test -short -race -failfast -timeout 3m -v ./...
go test ./pki/...                 # PASS
go test -race ./broker -run 'TestRejectedPlainTakeoverPreservesCertificateSession|TestAuthenticatedPlainTakeoverIsRejectedAndPreservesCertificateSession'  # PASS
DPRINT_CACHE_DIR=/tmp/pki-dprint-cache XDG_CACHE_HOME=/tmp/pki-xdg dprint fmt <all changed Go files>  # PASS
git diff --check                 # PASS
jq empty docs/content/docs/configuration/meta.json  # PASS
python3 -c 'import yaml; yaml.safe_load(open("api/openapi.yaml"))'  # PASS
make build                         # PASS with Go 1.26.5
cd ui && pnpm 10.33.0 install --frozen-lockfile --prefer-offline  # PASS
cd ui && pnpm run lint && pnpm run build  # PASS
cd docs && pnpm exec biome check content/docs/configuration/meta.json  # PASS
```

The complete race-enabled repository suite found and drove a session-safety correction: failed ordinary credentials now leave the live certificate-bound session untouched, while successfully authenticated ordinary credentials are still denied before they can replace that identity. Both rejection paths have focused race tests.

Remaining hosted-only CI-equivalent commands are tracked by GitHub Actions on the current head:

```text
make proto && git diff --exit-code
govulncheck ./...
trivy fs
```

## Review corrections

- The MQTT v3 and v5 handlers now require listener metadata before exposing a verified peer certificate to Atom; the ordinary-TLS regression proves existing authentication remains selected.
- Authenticated revoked/expired/failed/disabled/removed authority events now match live sessions by `IssuerID` and disconnect them immediately. Retirement is explicitly excluded because Atom continues to verify credentials issued by retained retiring/retired authorities.
- The complete local race suite, linter, focused transport/lifecycle suites, build, and diff checks were rerun after these corrections and passed.

## Non-goals

PR-012 does not change MQTT topic/resource design or Atom authorization semantics. The existing external authorizer still makes the normal operation decision after certificate tenant/lifecycle checks. It does not add offline URI-SAN verification, certificate issuance, or any legacy resolver. AMQP, HTTP, CoAP, plain MQTT, and server-auth-only TLS paths remain unchanged.

## Compatibility and risks

- Opt-in only: `auth.certificate.enabled` defaults to false; certificate configuration is restart-required.
- No database migration or persisted FluxMQ model change.
- Existing non-certificate authentication remains backward compatible. Same-client CONNECT setup is now serialized across MQTT 3/5 to prevent identity interleaving.
- The admin stats response adds an optional `certificates` object with no identity labels.
- Lifecycle revocation and post-cache resolver failure intentionally disconnect affected certificate sessions gracefully and suppress their Wills.
- Atom availability becomes a connection/operation dependency after the bounded cache expires; the documented default recovery window is 30 seconds.
- Initial trust fetch failure prevents mTLS listener startup; later failure keeps the last known-good roots. Redirect downgrade and non-CA bundles are rejected.
- The exact protected event-stream topology is intentionally single-node because current FluxMQ validation rejects exact local-principal durable targets in clustered mode.
- Resolver tokens, private keys, DER, and entity/tenant/credential/fingerprint identifiers are neither logged nor used as metric labels.
