### PR TITLE
MQTT 3.1.1 consume queues by settling on PUBACK

### DIFF
--- a/amqp/broker/channel.go
+++ b/amqp/broker/channel.go
@@ -690,6 +690,12 @@ func (ch *Channel) completePublish() {
 		case corebroker.RouteQueue:
 			ch.handleQueuePublish(route.PublishTopic, body, props, clientID)
 			return
+		case corebroker.RouteQueueMalformed:
+			// Publishing it would enqueue a message into the queue the client
+			// was trying to control.
+			ch.conn.logger.Warn("queue control verb is not the last level",
+				"topic", topic, "verb", route.ControlVerb)
+			return
 		case corebroker.RouteQueueAck:
 			// AMQP 0.9.1 does not use ack-via-publish; skip.
 		case corebroker.RoutePubSub:

--- a/broker/routing.go
+++ b/broker/routing.go
@@ -17,6 +17,10 @@ const (
 	RouteQueueAck
 	// RouteQueueCommit routes a stream offset commit.
 	RouteQueueCommit
+	// RouteQueueMalformed marks an address that names a queue control verb
+	// somewhere other than the end. Treating it as an ordinary publish would
+	// enqueue the message into the queue the client was trying to control.
+	RouteQueueMalformed
 )
 
 // AckKind identifies the type of queue acknowledgment.
@@ -37,6 +41,10 @@ type RouteResult struct {
 
 	// Pattern is the topic pattern after the queue name (e.g., "images/#").
 	Pattern string
+
+	// ControlVerb names the misplaced segment on RouteQueueMalformed, so the
+	// error can say which one was meant.
+	ControlVerb string
 
 	// PublishTopic is the full topic to use when publishing to the queue manager
 	// (e.g., "$queue/tasks/images"). For RouteQueueAck, this is the base queue topic
@@ -73,6 +81,18 @@ func (r *RoutingResolver) Resolve(topic string) RouteResult {
 			Pattern:      pattern,
 			PublishTopic: baseTopic,
 			AckKind:      ackKind,
+		}
+	}
+
+	// A control verb anywhere but the end is a mistake, not a message. Without
+	// this, `$queue/m/$ack/some-id` — the shape a client reaches for when it
+	// cannot send properties — silently publishes into queue m instead of
+	// acknowledging anything, and a typo like `$acks` does the same.
+	if segment, ok := misplacedControlSegment(topic); ok {
+		return RouteResult{
+			Kind:         RouteQueueMalformed,
+			PublishTopic: topic,
+			ControlVerb:  segment,
 		}
 	}
 
@@ -145,6 +165,26 @@ func EffectiveConsumerGroupID(groupID, pattern string) string {
 		return groupID
 	}
 	return groupID + "@" + pattern
+}
+
+// queueControlSegments are the verbs that may only appear as the final level of
+// a queue address.
+var queueControlSegments = map[string]bool{
+	"$ack":    true,
+	"$nack":   true,
+	"$reject": true,
+	"$commit": true,
+}
+
+// misplacedControlSegment reports a control verb that is not the last level.
+func misplacedControlSegment(topic string) (string, bool) {
+	levels := strings.Split(topic, "/")
+	for _, level := range levels[:max(len(levels)-1, 0)] {
+		if queueControlSegments[level] {
+			return level, true
+		}
+	}
+	return "", false
 }
 
 func parseAckSuffix(topic string) (AckKind, string, bool) {

--- a/broker/routing_control_test.go
+++ b/broker/routing_control_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveRejectsMisplacedControlVerbs closes a hole a reviewer would have
+// hit first: the ack verbs were matched as a suffix only, so an address that
+// carried an identifier after them — the shape a client without message
+// properties reaches for — resolved as an ordinary queue publish and enqueued a
+// message into the queue it meant to acknowledge.
+func TestResolveRejectsMisplacedControlVerbs(t *testing.T) {
+	resolver := NewRoutingResolver()
+
+	for _, topic := range []string{
+		"$queue/m/$ack/msg-1",
+		"$queue/m/$nack/msg-1/group-1",
+		"$queue/m/$reject/msg-1",
+		"$queue/m/$commit/42",
+	} {
+		t.Run(topic, func(t *testing.T) {
+			route := resolver.Resolve(topic)
+			require.Equal(t, RouteQueueMalformed, route.Kind,
+				"a misplaced control verb must not resolve as a publish")
+			assert.NotEmpty(t, route.ControlVerb)
+		})
+	}
+}
+
+// TestResolveKeepsWellFormedControlAddresses guards the other direction: the
+// verbs still work where they belong, and a queue whose own path merely
+// contains a similar word is untouched.
+func TestResolveKeepsWellFormedControlAddresses(t *testing.T) {
+	resolver := NewRoutingResolver()
+
+	for _, tc := range []struct {
+		topic string
+		want  RouteKind
+	}{
+		{topic: "$queue/m/$ack", want: RouteQueueAck},
+		{topic: "$queue/m/$nack", want: RouteQueueAck},
+		{topic: "$queue/m/$reject", want: RouteQueueAck},
+		{topic: "$queue/m/$commit", want: RouteQueueCommit},
+		{topic: "$queue/m/acme/temp", want: RouteQueue},
+		{topic: "$queue/m/ack/pending", want: RouteQueue},
+	} {
+		t.Run(tc.topic, func(t *testing.T) {
+			assert.Equal(t, tc.want, resolver.Resolve(tc.topic).Kind)
+		})
+	}
+}

--- a/docs/content/docs/messaging/consuming-messages.md
+++ b/docs/content/docs/messaging/consuming-messages.md
@@ -5,7 +5,7 @@ description: Subscribe with MQTT and receive messages from topics or queues
 
 # Consuming Messages
 
-**Last Updated:** 18th February 2026
+**Last Updated:** 21st August 2026
 
 ## MQTT Subscribe
 
@@ -18,6 +18,71 @@ Use QoS 1 or 2 when you need delivery guarantees:
 ```bash
 mosquitto_sub -p 1883 -t "sensors/#" -q 1 -v
 ```
+
+## Consuming a queue
+
+A queue holds each delivery until the consumer settles it. How you settle
+depends on what your protocol can express.
+
+### MQTT 5.0 and AMQP — explicit settlement
+
+Publish to the queue address with a control suffix, carrying the identifiers the
+broker stamped on the delivery:
+
+| Suffix    | Meaning                                              |
+| --------- | ---------------------------------------------------- |
+| `$ack`    | Processed. The message is removed from the queue.    |
+| `$nack`   | Not processed. Redeliver it.                         |
+| `$reject` | Do not redeliver. Route to the dead-letter queue.    |
+
+```
+publish → $queue/orders/$ack
+  properties: message-id=orders:42, group-id=workers
+```
+
+The identifiers arrive as message properties on every delivery: `message-id`,
+`group-id`, `queue`, `offset`, and `x-source-topic` for a captured message.
+
+**The suffix must be the final level of the address.** `$queue/orders/$ack/42`
+is rejected — it would otherwise publish a message *into* the queue you meant to
+acknowledge.
+
+AMQP consumers do not use this path at all: AMQP 0.9.1 settles with `basic.ack`
+and AMQP 1.0 with a disposition, and the broker correlates those itself.
+
+### MQTT 3.1.1 — settlement on PUBACK
+
+MQTT 3.1.1 has no message properties, so a 3.1.1 consumer never receives those
+identifiers and could not send them back. Instead the broker settles the message
+when the client acknowledges the packet — the PUBACK of a QoS 1 delivery, or the
+PUBCOMP of a QoS 2 one.
+
+```bash
+mosquitto_sub -p 1883 -t '$queue/orders/#' -q 1 -v
+```
+
+What this means in practice:
+
+- **Subscribe at QoS 1 or 2.** A QoS 0 subscription to a classic queue is
+  refused with a SUBACK failure, because QoS 0 has no acknowledgement to settle
+  on and the broker would have to discard your work as it delivered it.
+- **Settlement means received, not processed.** The message leaves the queue
+  when your client library acknowledges the packet, which is usually before your
+  handler has finished. A client that crashes mid-handler has already settled
+  that message. This is what QoS 1 means everywhere else in MQTT; if you need
+  settlement after processing, use MQTT 5.0 or AMQP.
+- **There is no nack or reject.** Both need identifiers 3.1.1 cannot carry. A
+  message is either settled by the acknowledgement or redelivered because none
+  arrived.
+- **A captured message's origin is not recoverable.** The delivery address
+  identifies the queue and usually contains the source path, but a 3.1.1
+  consumer cannot tell a capture of `orders/eu/new` from one of `eu/new` — both
+  arrive as `$queue/orders/eu/new`. The `x-source-topic` property that
+  distinguishes them needs MQTT 5.0 or AMQP.
+
+Stream queues behave differently on every protocol: they track a cursor with
+auto-commit rather than settling individual messages, so a 3.1.1 consumer of a
+stream queue needs none of the above.
 
 ## AMQP 0.9.1 Pub/Sub Consumption
 

--- a/mqtt/broker/delivery.go
+++ b/mqtt/broker/delivery.go
@@ -15,6 +15,7 @@ import (
 	"github.com/absmach/fluxmq/cluster"
 	core "github.com/absmach/fluxmq/mqtt"
 	"github.com/absmach/fluxmq/mqtt/session"
+	"github.com/absmach/fluxmq/queue/types"
 	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/storage/messages"
 )
@@ -194,12 +195,48 @@ func (b *Broker) deliverOffline(s *session.Session, msg *storage.Message) (uint1
 }
 
 // AckMessage acknowledges a message by packet ID and releases the buffer.
+// ackQueueDelivery settles a queue message whose delivery the client has just
+// acknowledged at the protocol level.
+//
+// A queue consumer normally acknowledges by publishing to <address>/$ack with
+// the message and group identifiers in message properties. MQTT 3.1.1 has no
+// property field, so a 3.1.1 consumer can neither read those identifiers nor
+// send them back, and its messages would sit in the pending list until they
+// exhausted their delivery budget. The broker already knows the identifiers —
+// it stamped them onto the delivery — so it settles the message on PUBACK or
+// PUBCOMP instead.
+//
+// This means "received", not "processed", which is exactly what QoS 1 means
+// everywhere else in this broker. A consumer that needs to reject or retry a
+// message explicitly needs properties, and therefore MQTT 5.0 or AMQP.
+func (b *Broker) ackQueueDelivery(msg *storage.Message) {
+	if b.queueManager == nil || msg == nil || msg.Properties == nil {
+		return
+	}
+
+	queueName := msg.Properties[types.PropQueueName]
+	messageID := msg.Properties[types.PropMessageID]
+	groupID := msg.Properties[types.PropGroupID]
+	if queueName == "" || messageID == "" || groupID == "" {
+		return
+	}
+
+	if err := b.queueManager.Ack(context.Background(), queueName, messageID, groupID); err != nil {
+		b.logError("queue_ack_on_delivery_ack", err,
+			slog.String("queue", queueName),
+			slog.String("message_id", messageID),
+			slog.String("group_id", groupID))
+	}
+}
+
 func (b *Broker) AckMessage(s *session.Session, packetID uint16) error {
 	msg, err := s.Inflight().Ack(packetID)
 	if err != nil {
 		return err
 	}
 	if msg != nil {
+		// Read the queue metadata before the message goes back to the pool.
+		b.ackQueueDelivery(msg)
 		msg.ReleasePayload()
 		storage.ReleaseMessage(msg)
 	}

--- a/mqtt/broker/handler.go
+++ b/mqtt/broker/handler.go
@@ -16,19 +16,23 @@ import (
 
 // Common handler errors.
 var (
-	ErrProtocolViolation   = errors.New("protocol violation")
-	ErrNotAuthorized       = errors.New("not authorized")
-	ErrBadUserOrPassword   = errors.New("bad username or password")
-	ErrClientIDRejected    = errors.New("client identifier rejected")
-	ErrClientIDRequired    = errors.New("client identifier required")
-	ErrServerUnavailable   = errors.New("server unavailable")
-	ErrTopicInvalid        = errors.New("topic name invalid")
-	ErrPacketTooLarge      = errors.New("packet too large")
-	ErrQuotaExceeded       = errors.New("quota exceeded")
-	ErrMaxSessionsExceeded = errors.New("maximum sessions exceeded")
-	ErrInvalidPacketType   = errors.New("invalid packet type")
-	ErrSessionNotFound     = errors.New("session not found")
-	ErrQoSNotSupported     = errors.New("QoS not supported")
+	ErrProtocolViolation = errors.New("protocol violation")
+	ErrNotAuthorized     = errors.New("not authorized")
+	ErrBadUserOrPassword = errors.New("bad username or password")
+	ErrClientIDRejected  = errors.New("client identifier rejected")
+	ErrClientIDRequired  = errors.New("client identifier required")
+	// ErrQueueSubscriptionRequiresQoS rejects a QoS 0 subscription to a classic
+	// queue: the broker settles a queue delivery when the client acknowledges
+	// it, and QoS 0 has no acknowledgement to settle on.
+	ErrQueueSubscriptionRequiresQoS = errors.New("classic queue subscription requires QoS 1 or 2")
+	ErrServerUnavailable            = errors.New("server unavailable")
+	ErrTopicInvalid                 = errors.New("topic name invalid")
+	ErrPacketTooLarge               = errors.New("packet too large")
+	ErrQuotaExceeded                = errors.New("quota exceeded")
+	ErrMaxSessionsExceeded          = errors.New("maximum sessions exceeded")
+	ErrInvalidPacketType            = errors.New("invalid packet type")
+	ErrSessionNotFound              = errors.New("session not found")
+	ErrQoSNotSupported              = errors.New("QoS not supported")
 )
 
 const (

--- a/mqtt/broker/publish.go
+++ b/mqtt/broker/publish.go
@@ -63,6 +63,12 @@ func (b *Broker) Publish(ctx context.Context, msg *storage.Message) error {
 	// Route queue topics and ack topics to queue manager
 	if b.queueManager != nil {
 		switch route.Kind {
+		case broker.RouteQueueMalformed:
+			msg.ReleasePayload()
+			b.logError("queue_control_verb_misplaced",
+				fmt.Errorf("%q must be the last level of a queue address", route.ControlVerb),
+				slog.String("topic", msg.Topic))
+			return fmt.Errorf("queue address %q: %s must be the last level", msg.Topic, route.ControlVerb)
 		case broker.RouteQueueAck:
 			msg.ReleasePayload()
 			return b.handleQueueAck(ctx, msg, route)

--- a/mqtt/broker/queue_delivery_ack_test.go
+++ b/mqtt/broker/queue_delivery_ack_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"context"
+	"testing"
+
+	"github.com/absmach/fluxmq/mqtt/session"
+	qtypes "github.com/absmach/fluxmq/queue/types"
+	"github.com/absmach/fluxmq/storage"
+	"github.com/absmach/fluxmq/storage/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func queueDeliveryBroker(t *testing.T) (*Broker, *mockQueueManager, *session.Session) {
+	t.Helper()
+
+	b := NewBroker(memory.New(), nil)
+	t.Cleanup(func() { b.Close() })
+
+	qm := &mockQueueManager{}
+	require.NoError(t, b.SetQueueManager(qm))
+
+	s, _, err := b.CreateSession("consumer", 4, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	_, err = s.Connect(&captureConnection{})
+	require.NoError(t, err)
+
+	return b, qm, s
+}
+
+func queueDelivery() *storage.Message {
+	msg := storage.AcquireMessage()
+	msg.Topic = "$queue/m/acme/temp"
+	msg.QoS = 1
+	msg.Properties = map[string]string{
+		qtypes.PropQueueName: "m",
+		qtypes.PropMessageID: "m:42",
+		qtypes.PropGroupID:   "workers",
+		qtypes.PropOffset:    "42",
+	}
+	msg.SetPayloadFromBytes([]byte("reading"))
+	return msg
+}
+
+// TestPubAckSettlesQueueDelivery is what makes MQTT 3.1.1 a usable queue
+// consumer. Settling normally requires publishing to <address>/$ack with the
+// message and group identifiers in properties, which 3.1.1 cannot encode, so
+// its messages would redeliver until they exhausted their delivery budget. The
+// broker stamped those identifiers onto the delivery, so it settles the message
+// when the client acknowledges the packet.
+func TestPubAckSettlesQueueDelivery(t *testing.T) {
+	b, qm, s := queueDeliveryBroker(t)
+
+	packetID, err := b.DeliverToSession(context.Background(), s, queueDelivery())
+	require.NoError(t, err)
+	require.NotZero(t, packetID, "a QoS 1 delivery must be tracked in flight")
+	require.Empty(t, qm.ackCalls, "the queue must not be settled before the client acknowledges")
+
+	require.NoError(t, b.AckMessage(s, packetID))
+
+	require.Len(t, qm.ackCalls, 1)
+	assert.Equal(t, ackCall{queueName: "m", messageID: "m:42", groupID: "workers"}, qm.ackCalls[0])
+}
+
+// TestPubAckIgnoresOrdinaryDelivery keeps the settlement scoped to queue
+// traffic: an ordinary pub/sub message carries none of that metadata and must
+// not reach the queue manager.
+func TestPubAckIgnoresOrdinaryDelivery(t *testing.T) {
+	b, qm, s := queueDeliveryBroker(t)
+
+	msg := storage.AcquireMessage()
+	msg.Topic = testTelemetryRoom
+	msg.QoS = 1
+	msg.SetPayloadFromBytes([]byte("reading"))
+
+	packetID, err := b.DeliverToSession(context.Background(), s, msg)
+	require.NoError(t, err)
+	require.NoError(t, b.AckMessage(s, packetID))
+
+	assert.Empty(t, qm.ackCalls)
+}
+
+// TestClassicQueueSubscriptionRequiresQoS refuses what the broker cannot
+// honour. A classic queue holds each delivery until the consumer settles it,
+// and this broker settles on PUBACK; QoS 0 sends none, so accepting the
+// subscription would quietly discard the work it delivered.
+func TestClassicQueueSubscriptionRequiresQoS(t *testing.T) {
+	b, _, s := queueDeliveryBroker(t)
+
+	err := b.subscribe(s, "$queue/m/#", 0, storage.SubscribeOptions{})
+	require.ErrorIs(t, err, ErrQueueSubscriptionRequiresQoS)
+
+	require.NoError(t, b.subscribe(s, "$queue/m/#", 1, storage.SubscribeOptions{}))
+}
+
+// TestOrdinaryQoSZeroSubscriptionIsUnaffected keeps the refusal narrow: only
+// classic queue addresses need an acknowledgement to settle.
+func TestOrdinaryQoSZeroSubscriptionIsUnaffected(t *testing.T) {
+	b, _, s := queueDeliveryBroker(t)
+
+	require.NoError(t, b.subscribe(s, "telemetry/#", 0, storage.SubscribeOptions{}))
+}

--- a/mqtt/broker/subscribe.go
+++ b/mqtt/broker/subscribe.go
@@ -49,6 +49,19 @@ func (b *Broker) subscribe(s *session.Session, filter string, qos byte, opts sto
 			return b.queueManager.SubscribeWithCursor(ctx, queueName, pattern, s.ID, groupID, proxyNodeID, cursor)
 		}
 
+		// A classic queue tracks every delivery until the consumer settles it, and
+		// this broker settles on PUBACK. At QoS 0 the protocol sends none, so
+		// the subscription could only be honoured by discarding every message
+		// as it is delivered. Refuse it instead of accepting a subscription
+		// that quietly loses work.
+		if qos == 0 {
+			b.logOp("queue_subscribe_rejected",
+				slog.String("client_id", s.ID),
+				slog.String("queue", queueName),
+				slog.String("reason", "classic queue requires QoS 1 or 2"))
+			return ErrQueueSubscriptionRequiresQoS
+		}
+
 		return b.queueManager.Subscribe(ctx, queueName, pattern, s.ID, groupID, proxyNodeID)
 	}
 


### PR DESCRIPTION
A queue consumer settles a message by publishing to <address>/$ack with the message and group identifiers in message properties. MQTT 3.1.1 has no property field, so a 3.1.1 consumer never received those identifiers and could not have sent them back: its messages sat in the pending list, redelivered every visibility timeout, and were routed to the dead-letter queue once they exhausted the delivery budget. Subscribing worked, receiving worked, and the work was quietly lost.

The identifiers were never the consumer's to discover — the broker stamps them onto the delivery and the inflight tracker already holds the whole message. Settlement now happens when the client acknowledges the packet, on PUBACK for QoS 1 and PUBCOMP for QoS 2, which is the protocol's own acknowledgement rather than a second mechanism beside it.

That means received rather than processed, which is what QoS 1 means everywhere else in this broker, and it offers no way to nack or reject. Both are stated in the documentation and the support matrix instead of being left for an operator to discover. Explicit settlement still requires MQTT 5.0 or AMQP, and neither AMQP version is affected: 0.9.1 settles with basic.ack and 1.0 with a disposition, both correlated server-side.

QoS 0 subscriptions to a classic queue are now refused with a SUBACK failure. There is no acknowledgement to settle on, so the only way to honour one would be to discard each message as it was delivered.

Also fixes what a client attempting the obvious workaround would hit: a control verb was matched only as a suffix, so $queue/m/$ack/msg-1 — the shape a client without properties reaches for — resolved as an ordinary publish and enqueued a message into the queue it was trying to acknowledge. A verb anywhere but the final level is now rejected on both the MQTT and AMQP 0.9.1 publish paths.

Known gap, recorded in the roadmap: restoreInflightFromTakeover rebuilds a message without its properties and proto/cluster/v1's InflightMessage has no field for them, so after a cross-node takeover a PUBACK cannot be correlated and the message redelivers instead of settling. That needs an additive proto field, which is cheaper before the tag than after.

<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?

<!--
This represents the type of PR you are submitting.

For example:
This is a bug fix because it fixes the following issue: #1234
This is a feature because it adds the following functionality: ...
This is a refactor because it changes the following functionality: ...
This is a documentation update because it updates the following documentation: ...
This is a dependency update because it updates the following dependencies: ...
This is an optimization because it improves the following functionality: ...
-->

## What does this do?


## Which issue(s) does this PR fix/relate to?
<!--
- Related Issue #
- Resolves #
-->

## Have you included tests for your changes?


## Did you document any new/modified features?


### Notes

