### PR TITLE
Fix session takeover lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12.2
+          version: v2.13.1
 
   test-build:
     runs-on: ubuntu-latest

--- a/mqtt/broker/background.go
+++ b/mqtt/broker/background.go
@@ -33,56 +33,60 @@ func (b *Broker) expiryLoop() {
 	}
 }
 
-// expireSessions removes expired sessions.
+// expireSessions removes expired sessions. Session.HasExpired is evaluated
+// twice: once here to pick candidates without the client-ID lock, and again
+// under that lock, because a reconnect in between makes the first answer stale.
 func (b *Broker) expireSessions() {
 	now := time.Now()
-	var toDelete []string
+	var expired []*session.Session
 
 	b.sessionsMap.ForEach(func(s *session.Session) {
-		if s.IsConnected() {
-			return
-		}
-
-		if s.ExpiryInterval > 0 {
-			expiryTime := s.GetDisconnectedAt().Add(time.Duration(s.ExpiryInterval) * time.Second)
-			if now.After(expiryTime) {
-				toDelete = append(toDelete, s.ID)
-			}
+		if s.HasExpired(now) {
+			expired = append(expired, s)
 		}
 	})
 
-	for _, clientID := range toDelete {
-		b.expireSession(context.Background(), clientID)
+	for _, s := range expired {
+		b.expireSession(context.Background(), s, now)
 	}
 }
 
-// expireSession retires a session whose expiry interval has elapsed. Expiry ends
-// the session, and a Will still waiting on its delay is due when the session ends
-// or the delay passes, whichever comes first [MQTT-3.1.2-8], so the record is
-// captured before destruction deletes it and published after the lock is
-// released.
-func (b *Broker) expireSession(ctx context.Context, clientID string) {
+// expireSession retires s if it is still the session registered for its client
+// ID and still expired once the lock is held. The scan runs without that lock,
+// so a reconnect or a Clean Start replacement can land in between; destroying
+// whatever currently answers to the client ID would take out a live connection.
+//
+// Expiry ends the session, and a Will waiting on its delay is due when the
+// session ends or the delay passes, whichever comes first [MQTT-3.1.2-8]. The
+// record is captured before destruction deletes it and published afterwards,
+// outside the lock and only once the teardown that removed it succeeded.
+func (b *Broker) expireSession(ctx context.Context, s *session.Session, now time.Time) {
 	var dueWill *storage.WillMessage
 
-	sessionLock := b.sessionLocks.Key(clientID)
+	sessionLock := b.sessionLocks.Key(s.ID)
 	sessionLock.Lock()
-	if s := b.sessionsMap.Get(clientID); s != nil {
+	if b.sessionsMap.Get(s.ID) == s && s.HasExpired(now) {
 		if b.stores.wills != nil {
-			will, err := b.stores.wills.Get(ctx, clientID)
+			will, err := b.stores.wills.Get(ctx, s.ID)
 			switch {
 			case err == nil:
 				dueWill = will
 			case !errors.Is(err, storage.ErrNotFound):
-				b.logError("load_expiring_session_will", err, slog.String("client_id", clientID))
+				b.logError("load_expiring_session_will", err, slog.String("client_id", s.ID))
 			}
 		}
-		b.destroySessionLocked(ctx, s) //nolint:errcheck // best-effort session cleanup during expired session sweep
+		if err := b.destroySessionLocked(ctx, s); err != nil {
+			// The record the Will was read from may still be there, so leave it
+			// for the sweep rather than publishing a copy it can publish again.
+			b.logError("destroy_expired_session", err, slog.String("client_id", s.ID))
+			dueWill = nil
+		}
 	}
 	sessionLock.Unlock()
 
 	if dueWill != nil {
 		if err := b.publishWillMessage(ctx, dueWill); err != nil {
-			b.logError("publish_expired_session_will", err, slog.String("client_id", clientID))
+			b.logError("publish_expired_session_will", err, slog.String("client_id", s.ID))
 		}
 	}
 }

--- a/mqtt/broker/background.go
+++ b/mqtt/broker/background.go
@@ -5,11 +5,14 @@ package broker
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/absmach/fluxmq/message"
 	"github.com/absmach/fluxmq/mqtt/session"
+	"github.com/absmach/fluxmq/storage"
 )
 
 // expiryLoop periodically checks for expired sessions.
@@ -49,13 +52,38 @@ func (b *Broker) expireSessions() {
 	})
 
 	for _, clientID := range toDelete {
-		sessionLock := b.sessionLocks.Key(clientID)
-		sessionLock.Lock()
-		s := b.sessionsMap.Get(clientID)
-		if s != nil {
-			b.destroySessionLocked(context.Background(), s) //nolint:errcheck // best-effort session cleanup during expired session sweep
+		b.expireSession(context.Background(), clientID)
+	}
+}
+
+// expireSession retires a session whose expiry interval has elapsed. Expiry ends
+// the session, and a Will still waiting on its delay is due when the session ends
+// or the delay passes, whichever comes first [MQTT-3.1.2-8], so the record is
+// captured before destruction deletes it and published after the lock is
+// released.
+func (b *Broker) expireSession(ctx context.Context, clientID string) {
+	var dueWill *storage.WillMessage
+
+	sessionLock := b.sessionLocks.Key(clientID)
+	sessionLock.Lock()
+	if s := b.sessionsMap.Get(clientID); s != nil {
+		if b.stores.wills != nil {
+			will, err := b.stores.wills.Get(ctx, clientID)
+			switch {
+			case err == nil:
+				dueWill = will
+			case !errors.Is(err, storage.ErrNotFound):
+				b.logError("load_expiring_session_will", err, slog.String("client_id", clientID))
+			}
 		}
-		sessionLock.Unlock()
+		b.destroySessionLocked(ctx, s) //nolint:errcheck // best-effort session cleanup during expired session sweep
+	}
+	sessionLock.Unlock()
+
+	if dueWill != nil {
+		if err := b.publishWillMessage(ctx, dueWill); err != nil {
+			b.logError("publish_expired_session_will", err, slog.String("client_id", clientID))
+		}
 	}
 }
 

--- a/mqtt/broker/broker.go
+++ b/mqtt/broker/broker.go
@@ -27,6 +27,12 @@ const (
 	queuePrefix    = "/queue/"
 )
 
+// Reasons carried by a client-disconnected event.
+const (
+	disconnectReasonNormal = "normal"
+	disconnectReasonError  = "error"
+)
+
 type queueManager interface {
 	broker.QueueLifecycle
 	broker.QueuePublisher

--- a/mqtt/broker/broker_test.go
+++ b/mqtt/broker/broker_test.go
@@ -17,6 +17,10 @@ import (
 	"github.com/absmach/fluxmq/mqtt/session"
 )
 
+// testNodeID names the local node in the cluster stubs across this package's
+// tests.
+const testNodeID = "node-a"
+
 // mockAddr implements net.Addr for testing.
 type mockAddr struct{}
 

--- a/mqtt/broker/clean_session_reconnect_test.go
+++ b/mqtt/broker/clean_session_reconnect_test.go
@@ -36,7 +36,7 @@ type cleanupSpyCluster struct {
 	removeAllSubscriptionsCalls int
 }
 
-func (c *cleanupSpyCluster) NodeID() string { return "node-a" }
+func (c *cleanupSpyCluster) NodeID() string { return testNodeID }
 
 func (c *cleanupSpyCluster) GetSessionOwner(context.Context, string) (string, bool, error) {
 	c.mu.Lock()
@@ -61,6 +61,10 @@ func (c *cleanupSpyCluster) ReleaseSession(context.Context, string) error {
 	c.owner = false
 	c.releases++
 	return nil
+}
+
+func (c *cleanupSpyCluster) GetSubscriptionsForClient(context.Context, string) ([]*storage.Subscription, error) {
+	return nil, nil
 }
 
 func (c *cleanupSpyCluster) RemoveAllSubscriptions(context.Context, string) error {

--- a/mqtt/broker/clean_session_reconnect_test.go
+++ b/mqtt/broker/clean_session_reconnect_test.go
@@ -20,6 +20,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	// reasonTakeover is the ClientDisconnected reason a retired connection reports.
+	reasonTakeover = "takeover"
+	// willPayloadOffline is the Will payload these tests watch for on the wire.
+	willPayloadOffline = "offline"
+)
+
 type cleanupSpyCluster struct {
 	cluster.Cluster
 	mu                          sync.Mutex
@@ -134,7 +141,7 @@ func TestHandleConnect_CleanV3ReplacementPublishesOldWill(t *testing.T) {
 	oldConnect := cleanV3Connect(clientID)
 	oldConnect.WillFlag = true
 	oldConnect.WillTopic = willTopic
-	oldConnect.WillMessage = []byte("offline")
+	oldConnect.WillMessage = []byte(willPayloadOffline)
 	oldConn := newSyncConn()
 	var oldWG sync.WaitGroup
 	oldWG.Add(1)
@@ -191,7 +198,7 @@ func TestHandleConnect_CleanV5ReplacementNotifiesAndPublishesDelayedWill(t *test
 	require.NoError(t, err)
 	require.NoError(t, b.subscribe(sub, willTopic, 0, storage.SubscribeOptions{}))
 
-	oldConnect := v5ConnectWillDelay(clientID, willTopic, []byte("offline"), 60)
+	oldConnect := v5ConnectWillDelay(clientID, willTopic, []byte(willPayloadOffline), 60)
 	oldConnect.CleanStart = true
 	oldConn := newSyncConn()
 	var oldWG sync.WaitGroup
@@ -263,7 +270,7 @@ func TestHandleDisconnect_CleanSessionPublishesWillBeforeDestroy(t *testing.T) {
 		Will: &storage.WillMessage{
 			ClientID: clientID,
 			Topic:    willTopic,
-			Payload:  []byte("offline"),
+			Payload:  []byte(willPayloadOffline),
 		},
 	})
 	require.NoError(t, err)
@@ -289,7 +296,7 @@ func TestHandleDisconnect_CleanSessionPublishesWillBeforeDestroy(t *testing.T) {
 	waitFor(t, func() bool {
 		for _, p := range subConn.writtenPackets() {
 			if pub, ok := p.(*v3.Publish); ok && pub.TopicName == willTopic {
-				return string(pub.Payload) == "offline"
+				return string(pub.Payload) == willPayloadOffline
 			}
 		}
 		return false
@@ -316,7 +323,7 @@ func TestCreateSession_CleanStartPublishesStoredDelayedWill(t *testing.T) {
 		Will: &storage.WillMessage{
 			ClientID: clientID,
 			Topic:    willTopic,
-			Payload:  []byte("offline"),
+			Payload:  []byte(willPayloadOffline),
 			Delay:    60,
 		},
 	})
@@ -336,7 +343,7 @@ func TestCreateSession_CleanStartPublishesStoredDelayedWill(t *testing.T) {
 	waitFor(t, func() bool {
 		for _, p := range subConn.writtenPackets() {
 			if pub, ok := p.(*v5.Publish); ok && pub.TopicName == willTopic {
-				return string(pub.Payload) == "offline"
+				return string(pub.Payload) == willPayloadOffline
 			}
 		}
 		return false
@@ -497,7 +504,7 @@ func TestHandleDisconnect_PersistentZeroDelayWillPublishesWithoutStorage(t *test
 		Will: &storage.WillMessage{
 			ClientID: clientID,
 			Topic:    willTopic,
-			Payload:  []byte("offline"),
+			Payload:  []byte(willPayloadOffline),
 		},
 	})
 	require.NoError(t, err)
@@ -508,7 +515,7 @@ func TestHandleDisconnect_PersistentZeroDelayWillPublishesWithoutStorage(t *test
 	waitFor(t, func() bool {
 		for _, p := range subConn.writtenPackets() {
 			if pub, ok := p.(*v5.Publish); ok && pub.TopicName == willTopic {
-				return string(pub.Payload) == "offline"
+				return string(pub.Payload) == willPayloadOffline
 			}
 		}
 		return false
@@ -585,7 +592,7 @@ func TestClaimPendingWillRejectsNewerIdenticalGeneration(t *testing.T) {
 	will := &storage.WillMessage{
 		ClientID: clientID,
 		Topic:    "clients/identical-will-generation/status",
-		Payload:  []byte("offline"),
+		Payload:  []byte(willPayloadOffline),
 	}
 	ctx := context.Background()
 	require.NoError(t, store.Wills().Set(ctx, clientID, will))
@@ -713,7 +720,7 @@ func TestHandleConnect_CleanReplacementEmitsClientDisconnected(t *testing.T) {
 	waitFor(t, func() bool {
 		return len(hook.snapshot()) == 1
 	}, "replaced connection reports its disconnect")
-	require.Equal(t, []string{"takeover"}, hook.snapshot())
+	require.Equal(t, []string{reasonTakeover}, hook.snapshot())
 
 	newConn.Close()
 	oldWG.Wait()
@@ -752,7 +759,7 @@ func TestHandleConnect_PersistentReplacementEmitsOneTakeoverDisconnect(t *testin
 	oldWG.Wait()
 
 	waitFor(t, func() bool { return len(hook.snapshot()) == 1 }, "persistent takeover reports the retired socket")
-	require.Equal(t, []string{"takeover"}, hook.snapshot())
+	require.Equal(t, []string{reasonTakeover}, hook.snapshot())
 
 	newConn.Close()
 	newWG.Wait()
@@ -775,7 +782,7 @@ func TestRetireSession_NotifiesEveryRetiredConnection(t *testing.T) {
 				superseded:  &session.Superseded{Conn: newBlockingConn()},
 				sessionEnds: true,
 			},
-			want: []string{"takeover"},
+			want: []string{reasonTakeover},
 		},
 		{
 			name: "takeover/session_continues",
@@ -783,7 +790,7 @@ func TestRetireSession_NotifiesEveryRetiredConnection(t *testing.T) {
 				clientID:   clientID,
 				superseded: &session.Superseded{Conn: newBlockingConn()},
 			},
-			want: []string{"takeover"},
+			want: []string{reasonTakeover},
 		},
 		{
 			name: "clean_replacement/no_connection",
@@ -808,4 +815,52 @@ func TestRetireSession_NotifiesEveryRetiredConnection(t *testing.T) {
 			require.Equal(t, tc.want, hook.snapshot())
 		})
 	}
+}
+
+// A Clean Start CONNECT ends the previous session even when no session object
+// survives to detach it — after an expiry sweep, a lost lease, or a restart that
+// outlived only the Will record. Ending the session makes a pending delayed Will
+// due, so it must be published rather than cancelled as if the session resumed.
+func TestCreateSession_CleanStartPublishesStoredWillWithoutLocalSession(t *testing.T) {
+	store := memory.New()
+	b := NewBroker(store, nil)
+	defer b.Close()
+
+	const clientID = "orphaned-delayed-will"
+	const willTopic = "clients/orphaned-delayed-will/status"
+
+	sub, _, err := b.CreateSession("orphaned-delayed-will-sub", 5, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	subConn := newSyncConn()
+	_, err = sub.Connect(subConn)
+	require.NoError(t, err)
+	require.NoError(t, b.subscribe(sub, willTopic, 0, storage.SubscribeOptions{}))
+
+	// Model the record a previous broker generation left behind: the Will is in
+	// the store, but the session it belonged to is gone from memory.
+	require.NoError(t, store.Wills().Set(context.Background(), clientID, &storage.WillMessage{
+		ClientID: clientID,
+		Topic:    willTopic,
+		Payload:  []byte(willPayloadOffline),
+		Delay:    60,
+	}))
+	require.Nil(t, b.sessionsMap.Get(clientID))
+
+	_, created, err := b.CreateSession(clientID, 5, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	waitFor(t, func() bool {
+		for _, p := range subConn.writtenPackets() {
+			if pub, ok := p.(*v5.Publish); ok && pub.TopicName == willTopic {
+				return string(pub.Payload) == willPayloadOffline
+			}
+		}
+		return false
+	}, "Clean Start publishes a stored Will left without a local session")
+
+	// The claim is exclusive: the record is gone, so neither the sweep nor a
+	// later attach can publish or cancel it again.
+	_, err = store.Wills().Get(context.Background(), clientID)
+	require.ErrorIs(t, err, storage.ErrNotFound)
 }

--- a/mqtt/broker/clean_session_reconnect_test.go
+++ b/mqtt/broker/clean_session_reconnect_test.go
@@ -397,12 +397,12 @@ func TestHandleDisconnect_StalePersistentCallbackCannotMutateReplacementGenerati
 		Payload:  []byte("old"),
 		Delay:    60,
 	}
-	s, _, expectedEpoch, err := b.createSessionForConnection(clientID, 5, session.Options{
+	s, _, claim, err := b.createSessionForConnection(clientID, 5, session.Options{
 		ExpiryInterval: 300,
 		Will:           oldWill,
 	}, false)
 	require.NoError(t, err)
-	oldEpoch, err := b.attachSession(context.Background(), s, expectedEpoch, newSyncConn(), session.ConnectOptions{
+	oldEpoch, err := b.attachSession(context.Background(), s, claim, newSyncConn(), session.ConnectOptions{
 		Version:        5,
 		KeepAlive:      time.Minute,
 		Will:           oldWill,
@@ -422,13 +422,13 @@ func TestHandleDisconnect_StalePersistentCallbackCannotMutateReplacementGenerati
 	require.NoError(t, s.Disconnect(false, v5.DisconnectUnspecifiedError))
 	<-callbackStarted
 
-	claimed, created, replacementEpoch, err := b.createSessionForConnection(clientID, 5, session.Options{
+	claimed, created, replacementClaim, err := b.createSessionForConnection(clientID, 5, session.Options{
 		ExpiryInterval: 300,
 	}, false)
 	require.NoError(t, err)
 	require.False(t, created)
 	require.Same(t, s, claimed, "persistent reconnect must reuse the session pointer")
-	require.Equal(t, oldEpoch, replacementEpoch)
+	require.Equal(t, oldEpoch, replacementClaim.epoch)
 
 	newWill := &storage.WillMessage{
 		ClientID: clientID,
@@ -436,7 +436,7 @@ func TestHandleDisconnect_StalePersistentCallbackCannotMutateReplacementGenerati
 		Payload:  []byte("new"),
 		Delay:    120,
 	}
-	newEpoch, err := b.attachSession(context.Background(), s, replacementEpoch, newSyncConn(), session.ConnectOptions{
+	newEpoch, err := b.attachSession(context.Background(), s, replacementClaim, newSyncConn(), session.ConnectOptions{
 		Version:        5,
 		KeepAlive:      time.Minute,
 		Will:           newWill,
@@ -470,13 +470,13 @@ func TestAttachSessionRejectsClaimReplacedByCleanStart(t *testing.T) {
 	defer b.Close()
 
 	const clientID = "replaced-before-attach"
-	stale, _, expectedEpoch, err := b.createSessionForConnection(clientID, 4, session.Options{}, false)
+	stale, _, staleClaim, err := b.createSessionForConnection(clientID, 4, session.Options{}, false)
 	require.NoError(t, err)
 	replacement, _, err := b.CreateSession(clientID, 4, session.Options{CleanStart: true})
 	require.NoError(t, err)
 	require.NotSame(t, stale, replacement)
 
-	_, err = b.attachSession(context.Background(), stale, expectedEpoch, newSyncConn(), session.ConnectOptions{
+	_, err = b.attachSession(context.Background(), stale, staleClaim, newSyncConn(), session.ConnectOptions{
 		Version:        4,
 		ReceiveMaximum: 16,
 	}, nil)
@@ -557,12 +557,12 @@ func TestAttachSessionCancelsStoredDelayedWillBeforeLaterCleanStart(t *testing.T
 		return err == nil
 	}, "delayed Will stored after disconnect")
 
-	claimed, created, expectedEpoch, err := b.createSessionForConnection(clientID, 5, session.Options{
+	claimed, created, claim, err := b.createSessionForConnection(clientID, 5, session.Options{
 		ExpiryInterval: 300,
 	}, false)
 	require.NoError(t, err)
 	require.False(t, created)
-	_, err = b.attachSession(context.Background(), claimed, expectedEpoch, newSyncConn(), session.ConnectOptions{
+	_, err = b.attachSession(context.Background(), claimed, claim, newSyncConn(), session.ConnectOptions{
 		Version:        5,
 		KeepAlive:      time.Minute,
 		ReceiveMaximum: 16,
@@ -818,9 +818,13 @@ func TestRetireSession_NotifiesEveryRetiredConnection(t *testing.T) {
 }
 
 // A Clean Start CONNECT ends the previous session even when no session object
-// survives to detach it — after an expiry sweep, a lost lease, or a restart that
-// outlived only the Will record. Ending the session makes a pending delayed Will
-// due, so it must be published rather than cancelled as if the session resumed.
+// survives to detach it: a restart empties the session map while the records it
+// wrote remain. Ending the session makes a pending delayed Will due, so it must
+// be published rather than cancelled as if the session had resumed.
+//
+// A sweep or a lost lease cannot leave this state — the sweep publishes the Will
+// and deletes the record (TestExpireSessionPublishesDueWill), and lease loss
+// keeps the session in memory.
 func TestCreateSession_CleanStartPublishesStoredWillWithoutLocalSession(t *testing.T) {
 	store := memory.New()
 	b := NewBroker(store, nil)

--- a/mqtt/broker/clean_session_reconnect_test.go
+++ b/mqtt/broker/clean_session_reconnect_test.go
@@ -8,8 +8,10 @@ import (
 	"slices"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/absmach/fluxmq/cluster"
+	"github.com/absmach/fluxmq/message"
 	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
 	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/mqtt/session"
@@ -269,8 +271,8 @@ func TestHandleDisconnect_CleanSessionPublishesWillBeforeDestroy(t *testing.T) {
 	require.NoError(t, err)
 
 	disconnected := make(chan struct{})
-	s.SetOnDisconnect(func(s *session.Session, graceful bool) {
-		b.handleDisconnect(s, graceful)
+	s.SetOnDisconnectWithEpoch(func(s *session.Session, graceful bool, epoch uint64) {
+		b.handleDisconnect(s, graceful, epoch)
 		close(disconnected)
 	})
 	require.NoError(t, s.Disconnect(false, v5.DisconnectUnspecifiedError))
@@ -349,6 +351,7 @@ func TestHandleDisconnect_StaleCleanSessionDoesNotDeleteReplacementClusterState(
 	const clientID = "cluster-clean-reconnect"
 	oldSession, _, err := b.CreateSession(clientID, 4, session.Options{CleanStart: true})
 	require.NoError(t, err)
+	oldEpoch := oldSession.Epoch()
 
 	replacement, _, err := b.CreateSession(clientID, 4, session.Options{CleanStart: true})
 	require.NoError(t, err)
@@ -363,7 +366,7 @@ func TestHandleDisconnect_StaleCleanSessionDoesNotDeleteReplacementClusterState(
 
 	// Model the old Session.Disconnect callback starting after the replacement
 	// was installed. It must not touch client-ID-scoped cluster state.
-	b.handleDisconnect(oldSession, false)
+	b.handleDisconnect(oldSession, false, oldEpoch)
 
 	require.Same(t, replacement, b.sessionsMap.Get(clientID))
 	owner, acquires, releases, removeAllSubscriptionsCalls = cl.snapshot()
@@ -371,6 +374,234 @@ func TestHandleDisconnect_StaleCleanSessionDoesNotDeleteReplacementClusterState(
 	require.Equal(t, 2, acquires)
 	require.Equal(t, 1, releases)
 	require.Equal(t, 1, removeAllSubscriptionsCalls)
+}
+
+func TestHandleDisconnect_StalePersistentCallbackCannotMutateReplacementGeneration(t *testing.T) {
+	store := memory.New()
+	b := NewBroker(store, nil)
+	defer b.Close()
+	hook := &disconnectSpyHook{}
+	b.SetEventHook(hook)
+
+	const clientID = "persistent-stale-callback"
+	oldWill := &storage.WillMessage{
+		ClientID: clientID,
+		Topic:    "clients/persistent-stale-callback/old",
+		Payload:  []byte("old"),
+		Delay:    60,
+	}
+	s, _, expectedEpoch, err := b.createSessionForConnection(clientID, 5, session.Options{
+		ExpiryInterval: 300,
+		Will:           oldWill,
+	}, false)
+	require.NoError(t, err)
+	oldEpoch, err := b.attachSession(context.Background(), s, expectedEpoch, newSyncConn(), session.ConnectOptions{
+		Version:        5,
+		KeepAlive:      time.Minute,
+		Will:           oldWill,
+		ReceiveMaximum: 16,
+	}, nil)
+	require.NoError(t, err)
+
+	callbackStarted := make(chan struct{})
+	releaseCallback := make(chan struct{})
+	callbackDone := make(chan struct{})
+	s.SetOnDisconnectWithEpoch(func(s *session.Session, graceful bool, epoch uint64) {
+		close(callbackStarted)
+		<-releaseCallback
+		b.handleDisconnect(s, graceful, epoch)
+		close(callbackDone)
+	})
+	require.NoError(t, s.Disconnect(false, v5.DisconnectUnspecifiedError))
+	<-callbackStarted
+
+	claimed, created, replacementEpoch, err := b.createSessionForConnection(clientID, 5, session.Options{
+		ExpiryInterval: 300,
+	}, false)
+	require.NoError(t, err)
+	require.False(t, created)
+	require.Same(t, s, claimed, "persistent reconnect must reuse the session pointer")
+	require.Equal(t, oldEpoch, replacementEpoch)
+
+	newWill := &storage.WillMessage{
+		ClientID: clientID,
+		Topic:    "clients/persistent-stale-callback/new",
+		Payload:  []byte("new"),
+		Delay:    120,
+	}
+	newEpoch, err := b.attachSession(context.Background(), s, replacementEpoch, newSyncConn(), session.ConnectOptions{
+		Version:        5,
+		KeepAlive:      time.Minute,
+		Will:           newWill,
+		ReceiveMaximum: 16,
+	}, nil)
+	require.NoError(t, err)
+	require.Greater(t, newEpoch, oldEpoch)
+
+	queued := message.NewDelivery("replacement/queued", []byte("replacement"), 1, false)
+	require.NoError(t, s.OfflineQueue().Enqueue(queued))
+	message.Release(queued)
+
+	close(releaseCallback)
+	<-callbackDone
+	s.SetOnDisconnectWithEpoch(func(s *session.Session, graceful bool, epoch uint64) {
+		b.handleDisconnect(s, graceful, epoch)
+	})
+
+	require.Same(t, newWill, s.GetWill(), "stale callback must not consume the replacement Will")
+	require.Equal(t, 1, s.OfflineQueue().Len(), "stale callback must not persist and drain replacement queue state")
+	_, err = store.Wills().Get(context.Background(), clientID)
+	require.ErrorIs(t, err, storage.ErrNotFound, "stale callback must not persist the replacement Will")
+	stored, err := store.Sessions().Get(clientID)
+	require.NoError(t, err)
+	require.True(t, stored.Connected, "stale callback must not persist the replacement as disconnected")
+	require.Equal(t, []string{"error"}, hook.snapshot(), "the old physical disconnect is still reported exactly once")
+}
+
+func TestAttachSessionRejectsClaimReplacedByCleanStart(t *testing.T) {
+	b := NewBroker(nil, nil)
+	defer b.Close()
+
+	const clientID = "replaced-before-attach"
+	stale, _, expectedEpoch, err := b.createSessionForConnection(clientID, 4, session.Options{}, false)
+	require.NoError(t, err)
+	replacement, _, err := b.CreateSession(clientID, 4, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	require.NotSame(t, stale, replacement)
+
+	_, err = b.attachSession(context.Background(), stale, expectedEpoch, newSyncConn(), session.ConnectOptions{
+		Version:        4,
+		ReceiveMaximum: 16,
+	}, nil)
+	require.ErrorIs(t, err, errSessionReplacedBeforeAttach)
+	require.Same(t, replacement, b.Get(clientID))
+	require.False(t, stale.IsConnected())
+}
+
+func TestHandleDisconnect_PersistentZeroDelayWillPublishesWithoutStorage(t *testing.T) {
+	store := memory.New()
+	b := NewBroker(store, nil)
+	defer b.Close()
+
+	const clientID = "persistent-zero-delay"
+	const willTopic = "clients/persistent-zero-delay/status"
+	sub, _, err := b.CreateSession("persistent-zero-delay-sub", 5, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	subConn := newSyncConn()
+	_, err = sub.Connect(subConn)
+	require.NoError(t, err)
+	require.NoError(t, b.subscribe(sub, willTopic, 0, storage.SubscribeOptions{}))
+
+	s, _, err := b.CreateSession(clientID, 5, session.Options{
+		ExpiryInterval: 300,
+		Will: &storage.WillMessage{
+			ClientID: clientID,
+			Topic:    willTopic,
+			Payload:  []byte("offline"),
+		},
+	})
+	require.NoError(t, err)
+	_, err = s.Connect(newSyncConn())
+	require.NoError(t, err)
+	require.NoError(t, s.Disconnect(false, v5.DisconnectUnspecifiedError))
+
+	waitFor(t, func() bool {
+		for _, p := range subConn.writtenPackets() {
+			if pub, ok := p.(*v5.Publish); ok && pub.TopicName == willTopic {
+				return string(pub.Payload) == "offline"
+			}
+		}
+		return false
+	}, "persistent zero-delay Will is published directly")
+	_, err = store.Wills().Get(context.Background(), clientID)
+	require.ErrorIs(t, err, storage.ErrNotFound, "zero-delay Wills must never enter delayed-Will storage")
+}
+
+func TestAttachSessionCancelsStoredDelayedWillBeforeLaterCleanStart(t *testing.T) {
+	store := memory.New()
+	b := NewBroker(store, nil)
+	defer b.Close()
+
+	const clientID = "cancel-stored-delayed-will"
+	const willTopic = "clients/cancel-stored-delayed-will/status"
+	sub, _, err := b.CreateSession("cancel-stored-delayed-will-sub", 5, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	subConn := newSyncConn()
+	_, err = sub.Connect(subConn)
+	require.NoError(t, err)
+	require.NoError(t, b.subscribe(sub, willTopic, 0, storage.SubscribeOptions{}))
+
+	oldWill := &storage.WillMessage{
+		ClientID: clientID,
+		Topic:    willTopic,
+		Payload:  []byte("obsolete"),
+		Delay:    60,
+	}
+	s, _, err := b.CreateSession(clientID, 5, session.Options{
+		ExpiryInterval: 300,
+		Will:           oldWill,
+	})
+	require.NoError(t, err)
+	_, err = s.Connect(newSyncConn())
+	require.NoError(t, err)
+	require.NoError(t, s.Disconnect(false, v5.DisconnectUnspecifiedError))
+	waitFor(t, func() bool {
+		_, err := store.Wills().Get(context.Background(), clientID)
+		return err == nil
+	}, "delayed Will stored after disconnect")
+
+	claimed, created, expectedEpoch, err := b.createSessionForConnection(clientID, 5, session.Options{
+		ExpiryInterval: 300,
+	}, false)
+	require.NoError(t, err)
+	require.False(t, created)
+	_, err = b.attachSession(context.Background(), claimed, expectedEpoch, newSyncConn(), session.ConnectOptions{
+		Version:        5,
+		KeepAlive:      time.Minute,
+		ReceiveMaximum: 16,
+	}, nil)
+	require.NoError(t, err)
+	_, err = store.Wills().Get(context.Background(), clientID)
+	require.ErrorIs(t, err, storage.ErrNotFound, "persistent reconnect cancels the previous delayed Will")
+
+	_, _, err = b.CreateSession(clientID, 5, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	require.Never(t, func() bool {
+		for _, p := range subConn.writtenPackets() {
+			if pub, ok := p.(*v5.Publish); ok && pub.TopicName == willTopic {
+				return true
+			}
+		}
+		return false
+	}, 100*time.Millisecond, 5*time.Millisecond, "a later Clean Start must not resurrect a cancelled delayed Will")
+}
+
+func TestClaimPendingWillRejectsNewerIdenticalGeneration(t *testing.T) {
+	store := memory.New()
+	b := NewBroker(store, nil)
+	defer b.Close()
+
+	const clientID = "identical-will-generation"
+	will := &storage.WillMessage{
+		ClientID: clientID,
+		Topic:    "clients/identical-will-generation/status",
+		Payload:  []byte("offline"),
+	}
+	ctx := context.Background()
+	require.NoError(t, store.Wills().Set(ctx, clientID, will))
+	snapshotTime := time.Now()
+	pending, err := store.Wills().GetPending(ctx, snapshotTime)
+	require.NoError(t, err)
+	require.Len(t, pending, 1, "the first generation supplies triggerWills' stale snapshot")
+
+	require.NoError(t, store.Wills().Delete(ctx, clientID))
+	require.NoError(t, store.Wills().Set(ctx, clientID, will), "store an identical Will for a newer disconnect generation")
+
+	require.Nil(t, b.claimPendingWill(ctx, clientID, snapshotTime),
+		"the old snapshot must not claim an identical newer generation before its deadline")
+	current, err := store.Wills().Get(ctx, clientID)
+	require.NoError(t, err)
+	require.Equal(t, will, current, "rejecting the stale snapshot must preserve the newer generation")
 }
 
 // disconnectSpyHook records the reason of every OnDisconnect the broker emits.
@@ -489,31 +720,79 @@ func TestHandleConnect_CleanReplacementEmitsClientDisconnected(t *testing.T) {
 	newWG.Wait()
 }
 
-// drainSuperseded owns the notification for a connection it retires, and only
-// when the session behind it ended. A takeover that continues the same session
-// keeps the client ID connected under the replacement socket and owes nothing.
-func TestDrainSuperseded_NotifiesOnlyForEndedSessions(t *testing.T) {
+func TestHandleConnect_PersistentReplacementEmitsOneTakeoverDisconnect(t *testing.T) {
+	b := NewBroker(nil, nil)
+	defer b.Close()
+	hook := &disconnectSpyHook{}
+	b.SetEventHook(hook)
+	h := newV3Handler(b)
+
+	const clientID = "persistent-replacement-notifies"
+	oldConn := newBlockingConn()
+	var oldWG sync.WaitGroup
+	oldWG.Add(1)
+	go func() {
+		defer oldWG.Done()
+		_ = h.HandleConnect(context.Background(), oldConn, v3Connect(clientID))
+	}()
+	<-oldConn.reading
+
+	newConn := newBlockingConn()
+	var newWG sync.WaitGroup
+	newWG.Add(1)
+	go func() {
+		defer newWG.Done()
+		_ = h.HandleConnect(context.Background(), newConn, v3Connect(clientID))
+	}()
+	<-newConn.reading
+	waitFor(t, func() bool {
+		s := b.Get(clientID)
+		return s != nil && s.Conn() == newConn && oldConn.closed.Load()
+	}, "persistent replacement retires the old socket")
+	oldWG.Wait()
+
+	waitFor(t, func() bool { return len(hook.snapshot()) == 1 }, "persistent takeover reports the retired socket")
+	require.Equal(t, []string{"takeover"}, hook.snapshot())
+
+	newConn.Close()
+	newWG.Wait()
+}
+
+// retireSession owns the notification for every physical connection it retires,
+// whether the MQTT session ends or continues on another socket.
+func TestRetireSession_NotifiesEveryRetiredConnection(t *testing.T) {
 	const clientID = "spy"
 
 	cases := []struct {
 		name       string
-		superseded *session.Superseded
+		retirement *sessionRetirement
 		want       []string
 	}{
 		{
-			name:       "clean_replacement/retired_connection",
-			superseded: &session.Superseded{ClientID: clientID, Conn: newBlockingConn(), SessionEnds: true},
-			want:       []string{"takeover"},
+			name: "clean_replacement/retired_connection",
+			retirement: &sessionRetirement{
+				clientID:    clientID,
+				superseded:  &session.Superseded{Conn: newBlockingConn()},
+				sessionEnds: true,
+			},
+			want: []string{"takeover"},
 		},
 		{
-			name:       "takeover/session_continues",
-			superseded: &session.Superseded{ClientID: clientID, Conn: newBlockingConn(), SessionEnds: false},
-			want:       nil,
+			name: "takeover/session_continues",
+			retirement: &sessionRetirement{
+				clientID:   clientID,
+				superseded: &session.Superseded{Conn: newBlockingConn()},
+			},
+			want: []string{"takeover"},
 		},
 		{
-			name:       "clean_replacement/no_connection",
-			superseded: &session.Superseded{ClientID: clientID, SessionEnds: true},
-			want:       nil,
+			name: "clean_replacement/no_connection",
+			retirement: &sessionRetirement{
+				clientID:    clientID,
+				superseded:  &session.Superseded{},
+				sessionEnds: true,
+			},
+			want: nil,
 		},
 	}
 
@@ -524,7 +803,7 @@ func TestDrainSuperseded_NotifiesOnlyForEndedSessions(t *testing.T) {
 			hook := &disconnectSpyHook{}
 			b.SetEventHook(hook)
 
-			b.drainSuperseded(context.Background(), tc.superseded)
+			b.retireSession(context.Background(), tc.retirement)
 
 			require.Equal(t, tc.want, hook.snapshot())
 		})

--- a/mqtt/broker/clean_session_reconnect_test.go
+++ b/mqtt/broker/clean_session_reconnect_test.go
@@ -466,7 +466,7 @@ func TestHandleDisconnect_StalePersistentCallbackCannotMutateReplacementGenerati
 	stored, err := store.Sessions().Get(clientID)
 	require.NoError(t, err)
 	require.True(t, stored.Connected, "stale callback must not persist the replacement as disconnected")
-	require.Equal(t, []string{"error"}, hook.snapshot(), "the old physical disconnect is still reported exactly once")
+	require.Equal(t, []string{disconnectReasonError}, hook.snapshot(), "the old physical disconnect is still reported exactly once")
 }
 
 func TestAttachSessionRejectsClaimReplacedByCleanStart(t *testing.T) {
@@ -678,7 +678,7 @@ func TestDestroySession_EmitsClientDisconnected(t *testing.T) {
 	waitFor(t, func() bool {
 		return len(hook.snapshot()) == 1
 	}, "destroyed session reports its disconnect")
-	require.Equal(t, []string{"error"}, hook.snapshot())
+	require.Equal(t, []string{disconnectReasonError}, hook.snapshot())
 
 	wg.Wait()
 }

--- a/mqtt/broker/clean_session_reconnect_test.go
+++ b/mqtt/broker/clean_session_reconnect_test.go
@@ -5,13 +5,16 @@ package broker
 
 import (
 	"context"
+	"slices"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/absmach/fluxmq/cluster"
 	v3 "github.com/absmach/fluxmq/mqtt/packets/v3"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/mqtt/session"
+	"github.com/absmach/fluxmq/storage"
+	"github.com/absmach/fluxmq/storage/memory"
 	"github.com/stretchr/testify/require"
 )
 
@@ -89,13 +92,6 @@ func TestHandleConnect_CleanSessionReconnectKeepsReplacement(t *testing.T) {
 		s := b.sessionsMap.Get(clientID)
 		return s != nil && s.IsConnected()
 	}, "old clean session connected")
-	oldSession := b.sessionsMap.Get(clientID)
-	require.NotNil(t, oldSession)
-	oldDisconnectHandled := make(chan struct{})
-	oldSession.SetOnDisconnect(func(s *session.Session, graceful bool) {
-		b.handleDisconnect(s, graceful)
-		close(oldDisconnectHandled)
-	})
 
 	newConn := newBlockingConn()
 	var newWG sync.WaitGroup
@@ -105,12 +101,8 @@ func TestHandleConnect_CleanSessionReconnectKeepsReplacement(t *testing.T) {
 		_ = h.HandleConnect(context.Background(), newConn, cleanV3Connect(clientID))
 	}()
 
+	waitFor(t, func() bool { return oldConn.closed.Load() }, "old clean connection retired")
 	oldWG.Wait()
-	select {
-	case <-oldDisconnectHandled:
-	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for old clean session disconnect callback")
-	}
 	<-newConn.reading
 	waitFor(t, func() bool {
 		s := b.sessionsMap.Get(clientID)
@@ -120,6 +112,233 @@ func TestHandleConnect_CleanSessionReconnectKeepsReplacement(t *testing.T) {
 
 	newConn.Close()
 	newWG.Wait()
+}
+
+func TestHandleConnect_CleanV3ReplacementPublishesOldWill(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+	h := newV3Handler(b)
+
+	const clientID = "clean-v3-will"
+	const willTopic = "clients/clean-v3-will/status"
+
+	sub, _, err := b.CreateSession("clean-v3-will-sub", 4, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	subConn := newSyncConn()
+	_, err = sub.Connect(subConn)
+	require.NoError(t, err)
+	require.NoError(t, b.subscribe(sub, willTopic, 0, storage.SubscribeOptions{}))
+
+	oldConnect := cleanV3Connect(clientID)
+	oldConnect.WillFlag = true
+	oldConnect.WillTopic = willTopic
+	oldConnect.WillMessage = []byte("offline")
+	oldConn := newSyncConn()
+	var oldWG sync.WaitGroup
+	oldWG.Add(1)
+	go func() {
+		defer oldWG.Done()
+		h.HandleConnect(context.Background(), oldConn, oldConnect) //nolint:errcheck
+	}()
+
+	<-oldConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(clientID)
+		return s != nil && s.IsConnected()
+	}, "old clean v3 session connected")
+
+	newConn := newSyncConn()
+	var newWG sync.WaitGroup
+	newWG.Add(1)
+	go func() {
+		defer newWG.Done()
+		h.HandleConnect(context.Background(), newConn, cleanV3Connect(clientID)) //nolint:errcheck
+	}()
+
+	<-newConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(clientID)
+		return s != nil && s.IsConnected() && s.Conn() == newConn
+	}, "replacement clean v3 session current")
+	waitFor(t, func() bool {
+		for _, p := range subConn.writtenPackets() {
+			if pub, ok := p.(*v3.Publish); ok && pub.TopicName == willTopic {
+				return true
+			}
+		}
+		return false
+	}, "old clean v3 connection's Will published")
+
+	oldWG.Wait()
+	newConn.Close()
+	newWG.Wait()
+}
+
+func TestHandleConnect_CleanV5ReplacementNotifiesAndPublishesDelayedWill(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+	h := newV5Handler(b)
+
+	const clientID = "clean-v5-will"
+	const willTopic = "clients/clean-v5-will/status"
+
+	sub, _, err := b.CreateSession("clean-v5-will-sub", 5, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	subConn := newSyncConn()
+	_, err = sub.Connect(subConn)
+	require.NoError(t, err)
+	require.NoError(t, b.subscribe(sub, willTopic, 0, storage.SubscribeOptions{}))
+
+	oldConnect := v5ConnectWillDelay(clientID, willTopic, []byte("offline"), 60)
+	oldConnect.CleanStart = true
+	oldConn := newSyncConn()
+	var oldWG sync.WaitGroup
+	oldWG.Add(1)
+	go func() {
+		defer oldWG.Done()
+		h.HandleConnect(context.Background(), oldConn, oldConnect) //nolint:errcheck
+	}()
+
+	<-oldConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(clientID)
+		return s != nil && s.IsConnected()
+	}, "old clean v5 session connected")
+
+	newConnect := v5Connect(clientID, "", nil)
+	newConnect.CleanStart = true
+	newConn := newSyncConn()
+	var newWG sync.WaitGroup
+	newWG.Add(1)
+	go func() {
+		defer newWG.Done()
+		h.HandleConnect(context.Background(), newConn, newConnect) //nolint:errcheck
+	}()
+
+	<-newConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(clientID)
+		return s != nil && s.IsConnected() && s.Conn() == newConn
+	}, "replacement clean v5 session current")
+	waitFor(t, func() bool {
+		for _, p := range oldConn.writtenPackets() {
+			if d, ok := p.(*v5.Disconnect); ok && d.ReasonCode == v5.DisconnectSessionTakenOver {
+				return true
+			}
+		}
+		return false
+	}, "old clean v5 connection receives DISCONNECT 0x8E")
+	waitFor(t, func() bool {
+		for _, p := range subConn.writtenPackets() {
+			if pub, ok := p.(*v5.Publish); ok && pub.TopicName == willTopic {
+				return true
+			}
+		}
+		return false
+	}, "old clean v5 connection's delayed Will published immediately")
+
+	oldWG.Wait()
+	newConn.Close()
+	newWG.Wait()
+}
+
+func TestHandleDisconnect_CleanSessionPublishesWillBeforeDestroy(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+
+	const clientID = "clean-disconnect-will"
+	const willTopic = "clients/clean-disconnect-will/status"
+
+	sub, _, err := b.CreateSession("clean-disconnect-will-sub", 4, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	subConn := newSyncConn()
+	_, err = sub.Connect(subConn)
+	require.NoError(t, err)
+	require.NoError(t, b.subscribe(sub, willTopic, 0, storage.SubscribeOptions{}))
+
+	s, _, err := b.CreateSession(clientID, 4, session.Options{
+		CleanStart: true,
+		Will: &storage.WillMessage{
+			ClientID: clientID,
+			Topic:    willTopic,
+			Payload:  []byte("offline"),
+		},
+	})
+	require.NoError(t, err)
+	_, err = s.Connect(newSyncConn())
+	require.NoError(t, err)
+
+	disconnected := make(chan struct{})
+	s.SetOnDisconnect(func(s *session.Session, graceful bool) {
+		b.handleDisconnect(s, graceful)
+		close(disconnected)
+	})
+	require.NoError(t, s.Disconnect(false, v5.DisconnectUnspecifiedError))
+	waitFor(t, func() bool {
+		select {
+		case <-disconnected:
+			return true
+		default:
+			return false
+		}
+	}, "clean disconnect callback completes")
+
+	require.Nil(t, b.Get(clientID), "clean session is destroyed after its Will is captured")
+	waitFor(t, func() bool {
+		for _, p := range subConn.writtenPackets() {
+			if pub, ok := p.(*v3.Publish); ok && pub.TopicName == willTopic {
+				return string(pub.Payload) == "offline"
+			}
+		}
+		return false
+	}, "clean disconnect callback publishes the Will")
+}
+
+func TestCreateSession_CleanStartPublishesStoredDelayedWill(t *testing.T) {
+	store := memory.New()
+	b := NewBroker(store, nil)
+	defer b.Close()
+
+	const clientID = "stored-delayed-will"
+	const willTopic = "clients/stored-delayed-will/status"
+
+	sub, _, err := b.CreateSession("stored-delayed-will-sub", 5, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	subConn := newSyncConn()
+	_, err = sub.Connect(subConn)
+	require.NoError(t, err)
+	require.NoError(t, b.subscribe(sub, willTopic, 0, storage.SubscribeOptions{}))
+
+	old, _, err := b.CreateSession(clientID, 5, session.Options{
+		ExpiryInterval: 300,
+		Will: &storage.WillMessage{
+			ClientID: clientID,
+			Topic:    willTopic,
+			Payload:  []byte("offline"),
+			Delay:    60,
+		},
+	})
+	require.NoError(t, err)
+	_, err = old.Connect(newSyncConn())
+	require.NoError(t, err)
+	require.NoError(t, old.Disconnect(false, v5.DisconnectUnspecifiedError))
+	waitFor(t, func() bool {
+		_, err := store.Wills().Get(context.Background(), clientID)
+		return err == nil
+	}, "disconnect callback stores the delayed Will")
+
+	replacement, created, err := b.CreateSession(clientID, 5, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	require.True(t, created)
+	require.NotSame(t, old, replacement)
+	waitFor(t, func() bool {
+		for _, p := range subConn.writtenPackets() {
+			if pub, ok := p.(*v5.Publish); ok && pub.TopicName == willTopic {
+				return string(pub.Payload) == "offline"
+			}
+		}
+		return false
+	}, "Clean Start publishes the stored delayed Will immediately")
 }
 
 func TestHandleDisconnect_StaleCleanSessionDoesNotDeleteReplacementClusterState(t *testing.T) {
@@ -152,4 +371,162 @@ func TestHandleDisconnect_StaleCleanSessionDoesNotDeleteReplacementClusterState(
 	require.Equal(t, 2, acquires)
 	require.Equal(t, 1, releases)
 	require.Equal(t, 1, removeAllSubscriptionsCalls)
+}
+
+// disconnectSpyHook records the reason of every OnDisconnect the broker emits.
+type disconnectSpyHook struct {
+	mu      sync.Mutex
+	reasons []string
+}
+
+func (h *disconnectSpyHook) OnConnect(context.Context, string, string, string) error { return nil }
+
+func (h *disconnectSpyHook) OnDisconnect(_ context.Context, _, reason string) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.reasons = append(h.reasons, reason)
+
+	return nil
+}
+
+func (h *disconnectSpyHook) OnSubscribe(context.Context, string, string, byte) error { return nil }
+
+func (h *disconnectSpyHook) OnUnsubscribe(context.Context, string, string) error { return nil }
+
+func (h *disconnectSpyHook) OnPublish(context.Context, string, string, byte, []byte) error {
+	return nil
+}
+
+func (h *disconnectSpyHook) Close() error { return nil }
+
+func (h *disconnectSpyHook) snapshot() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return slices.Clone(h.reasons)
+}
+
+// A destroyed session's connection is gone, so the disconnect is owed to the
+// event hook even though the identity check stops the callback from touching
+// state that now belongs to nobody.
+func TestDestroySession_EmitsClientDisconnected(t *testing.T) {
+	b := NewBroker(nil, nil)
+	defer b.Close()
+	hook := &disconnectSpyHook{}
+	b.SetEventHook(hook)
+	h := newV3Handler(b)
+
+	const clientID = "destroy-notifies"
+	conn := newBlockingConn()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = h.HandleConnect(context.Background(), conn, v3Connect(clientID))
+	}()
+
+	<-conn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(clientID)
+		return s != nil && s.IsConnected()
+	}, "session connected")
+
+	require.NoError(t, b.DestroySession(clientID))
+
+	waitFor(t, func() bool {
+		return len(hook.snapshot()) == 1
+	}, "destroyed session reports its disconnect")
+	require.Equal(t, []string{"error"}, hook.snapshot())
+
+	wg.Wait()
+}
+
+// A Clean Start replacement retires the old connection without running its
+// disconnect callback, so the notification has to come from the retirement path.
+func TestHandleConnect_CleanReplacementEmitsClientDisconnected(t *testing.T) {
+	b := NewBroker(nil, nil)
+	defer b.Close()
+	hook := &disconnectSpyHook{}
+	b.SetEventHook(hook)
+	h := newV3Handler(b)
+
+	const clientID = "clean-replacement-notifies"
+	oldConn := newBlockingConn()
+	var oldWG sync.WaitGroup
+	oldWG.Add(1)
+	go func() {
+		defer oldWG.Done()
+		_ = h.HandleConnect(context.Background(), oldConn, cleanV3Connect(clientID))
+	}()
+
+	<-oldConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(clientID)
+		return s != nil && s.IsConnected()
+	}, "old clean session connected")
+
+	newConn := newBlockingConn()
+	var newWG sync.WaitGroup
+	newWG.Add(1)
+	go func() {
+		defer newWG.Done()
+		_ = h.HandleConnect(context.Background(), newConn, cleanV3Connect(clientID))
+	}()
+
+	<-newConn.reading
+	waitFor(t, func() bool {
+		s := b.sessionsMap.Get(clientID)
+		return s != nil && s.IsConnected() && s.Conn() == newConn
+	}, "replacement clean session is current")
+
+	waitFor(t, func() bool {
+		return len(hook.snapshot()) == 1
+	}, "replaced connection reports its disconnect")
+	require.Equal(t, []string{"takeover"}, hook.snapshot())
+
+	newConn.Close()
+	oldWG.Wait()
+	newWG.Wait()
+}
+
+// drainSuperseded owns the notification for a connection it retires, and only
+// when the session behind it ended. A takeover that continues the same session
+// keeps the client ID connected under the replacement socket and owes nothing.
+func TestDrainSuperseded_NotifiesOnlyForEndedSessions(t *testing.T) {
+	const clientID = "spy"
+
+	cases := []struct {
+		name       string
+		superseded *session.Superseded
+		want       []string
+	}{
+		{
+			name:       "clean_replacement/retired_connection",
+			superseded: &session.Superseded{ClientID: clientID, Conn: newBlockingConn(), SessionEnds: true},
+			want:       []string{"takeover"},
+		},
+		{
+			name:       "takeover/session_continues",
+			superseded: &session.Superseded{ClientID: clientID, Conn: newBlockingConn(), SessionEnds: false},
+			want:       nil,
+		},
+		{
+			name:       "clean_replacement/no_connection",
+			superseded: &session.Superseded{ClientID: clientID, SessionEnds: true},
+			want:       nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b := NewBroker(nil, nil)
+			defer b.Close()
+			hook := &disconnectSpyHook{}
+			b.SetEventHook(hook)
+
+			b.drainSuperseded(context.Background(), tc.superseded)
+
+			require.Equal(t, tc.want, hook.snapshot())
+		})
+	}
 }

--- a/mqtt/broker/publish.go
+++ b/mqtt/broker/publish.go
@@ -444,15 +444,15 @@ func (b *Broker) triggerWills() {
 	}
 
 	ctx := context.Background()
-	pending, err := b.stores.wills.GetPending(ctx, time.Now())
+	now := time.Now()
+	pending, err := b.stores.wills.GetPending(ctx, now)
 	if err != nil {
 		return
 	}
 
-	for _, will := range pending {
-		s := b.Get(will.ClientID)
-		if s != nil && s.IsConnected() {
-			b.stores.wills.Delete(ctx, will.ClientID) //nolint:errcheck // best-effort will cleanup for connected client
+	for _, candidate := range pending {
+		will := b.claimPendingWill(ctx, candidate.ClientID, now)
+		if will == nil {
 			continue
 		}
 
@@ -466,9 +466,58 @@ func (b *Broker) triggerWills() {
 		b.distribute(ctx, msg) //nolint:errcheck // fire-and-forget will message distribution
 
 		message.Release(msg)
-
-		b.stores.wills.Delete(ctx, will.ClientID) //nolint:errcheck // best-effort will cleanup after distribution
 	}
+}
+
+// claimPendingWill revalidates a delayed-Will snapshot under the same client-ID
+// lock used by disconnect, reconnect, and Clean Start. GetPending carries the
+// store's disconnect timestamp, so re-querying here distinguishes an older
+// pending generation from a newer identical Will whose delay has not elapsed.
+// The record is deleted before unlocking; a reconnect that follows cannot
+// cancel a Will whose deadline already won the lock, while a reconnect that
+// wins first removes the record and this claim returns nil.
+func (b *Broker) claimPendingWill(ctx context.Context, clientID string, now time.Time) *storage.WillMessage {
+	sessionLock := b.sessionLocks.Key(clientID)
+	sessionLock.Lock()
+	defer sessionLock.Unlock()
+
+	current, err := pendingWillForClient(ctx, b.stores.wills, clientID, now)
+	if err != nil {
+		return nil
+	}
+
+	s := b.sessionsMap.Get(clientID)
+	if s != nil && s.IsConnected() {
+		b.stores.wills.Delete(ctx, clientID) //nolint:errcheck // best-effort delayed-Will cancellation for connected client
+		return nil
+	}
+
+	if err := b.stores.wills.Delete(ctx, clientID); err != nil {
+		return nil
+	}
+	return current
+}
+
+type clientPendingWillStore interface {
+	GetPendingForClient(ctx context.Context, clientID string, before time.Time) (*storage.WillMessage, error)
+}
+
+// pendingWillForClient uses the built-in stores' keyed fast path while keeping
+// the public WillStore interface source-compatible for custom implementations.
+func pendingWillForClient(ctx context.Context, store storage.WillStore, clientID string, before time.Time) (*storage.WillMessage, error) {
+	if keyed, ok := store.(clientPendingWillStore); ok {
+		return keyed.GetPendingForClient(ctx, clientID, before)
+	}
+	pending, err := store.GetPending(ctx, before)
+	if err != nil {
+		return nil, err
+	}
+	for _, will := range pending {
+		if will.ClientID == clientID {
+			return will, nil
+		}
+	}
+	return nil, storage.ErrNotFound
 }
 
 // GetRetainedMessage implements cluster.MessageHandler.GetRetainedMessage.

--- a/mqtt/broker/session.go
+++ b/mqtt/broker/session.go
@@ -152,59 +152,29 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 	}
 
 	existing := b.sessionsMap.Get(clientID)
-	if opts.CleanStart {
-		switch {
-		case existing != nil:
-			retired := existing.DetachForTakeover()
-			// If the network callback already scheduled the Will, it consumed the
-			// in-memory copy. Ending the old session makes any stored delayed Will
-			// due now, while an already-published Will is absent from the store.
-			if retired.Conn == nil && retired.Will == nil && b.stores.wills != nil {
-				storedWill, err := b.stores.wills.Get(ctx, clientID)
-				if err != nil && !errors.Is(err, storage.ErrNotFound) {
-					return nil, false, fmt.Errorf("failed to load replaced session will: %w", err)
-				}
-				retired.Will = storedWill
+	if opts.CleanStart && existing != nil {
+		retired := existing.DetachForTakeover()
+		// If the network callback already scheduled the Will, it consumed the
+		// in-memory copy. Ending the old session makes any stored delayed Will
+		// due now, while an already-published Will is absent from the store.
+		if retired.Conn == nil && retired.Will == nil && b.stores.wills != nil {
+			storedWill, err := b.stores.wills.Get(ctx, clientID)
+			if err != nil && !errors.Is(err, storage.ErrNotFound) {
+				return nil, false, fmt.Errorf("failed to load replaced session will: %w", err)
 			}
-			retirements = append(retirements, &sessionRetirement{
-				clientID:    clientID,
-				superseded:  retired,
-				sessionEnds: true,
-			})
-			// destroySessionLocked removes the stored record under this lock, so
-			// the sweep cannot publish the same Will a second time.
-			if err := b.destroySessionLocked(ctx, existing); err != nil {
-				return nil, false, err
-			}
-			existing = nil
-
-		default:
-			// Clean Start ends the previous session even when no session object
-			// survives to detach it — a restart outlives the session map while
-			// the records it wrote remain. Ending the session makes a pending
-			// delayed Will due [MQTT-3.1.2-8], and leaves nothing for the fresh
-			// session to inherit, so the Will is claimed and the rest purged.
-			// Without this the Will is never published (attachSession would
-			// cancel it as though the session had resumed) and the old
-			// subscriptions and queued messages survive to be restored into a
-			// later persistent reconnect, possibly under another identity.
-			storedWill, purge, err := b.orphanedSessionState(ctx, clientID)
-			if err != nil {
-				return nil, false, err
-			}
-			if purge {
-				if err := b.purgeSessionState(ctx, clientID); err != nil {
-					return nil, false, err
-				}
-			}
-			if storedWill != nil {
-				retirements = append(retirements, &sessionRetirement{
-					clientID:    clientID,
-					superseded:  &session.Superseded{Will: storedWill},
-					sessionEnds: true,
-				})
-			}
+			retired.Will = storedWill
 		}
+		retirements = append(retirements, &sessionRetirement{
+			clientID:    clientID,
+			superseded:  retired,
+			sessionEnds: true,
+		})
+		// destroySessionLocked removes the stored record under this lock, so
+		// the sweep cannot publish the same Will a second time.
+		if err := b.destroySessionLocked(ctx, existing); err != nil {
+			return nil, false, err
+		}
+		existing = nil
 	}
 
 	if existing != nil && identity != nil && identity.RequireBound && existing.ExternalIdentity() == "" {
@@ -279,6 +249,36 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 	if err != nil {
 		return nil, false, err
 	}
+
+	// Inheriting neither a migrated session nor a persisted record means this
+	// CONNECT starts a fresh session under a recycled client ID. Whatever the
+	// previous session left behind is not this one's, and that session has ended,
+	// so its delayed Will is due now [MQTT-3.1.2-8].
+	//
+	// The resolved restore decides this, not the migrated state this CONNECT
+	// arrived with: Clean Start discards a takeover, and the fresh session it
+	// asks for must not inherit what that session left under the client ID
+	// either.
+	//
+	// This has to run before anything is restored: the restores below key off the
+	// client ID alone and would otherwise hand the old subscriptions and messages
+	// to the new session, possibly under a different principal. It also has to
+	// claim the Will rather than merely decline to cancel it, because the sweep
+	// drops a pending Will once a session is connected under that client ID.
+	if restore.takeover == nil && restore.stored == nil {
+		orphanWill, err := b.claimOrphanedSessionState(ctx, clientID)
+		if err != nil {
+			return nil, false, err
+		}
+		if orphanWill != nil {
+			retirements = append(retirements, &sessionRetirement{
+				clientID:    clientID,
+				superseded:  &session.Superseded{Will: orphanWill},
+				sessionEnds: true,
+			})
+		}
+	}
+
 	takeoverWill := willFromTakeover(clientID, takeoverState)
 	takeoverState = restore.takeover
 	if takeoverWill != nil {
@@ -569,34 +569,76 @@ func (b *Broker) resolveSessionRestore(ctx context.Context, clientID string, opt
 	return sessionRestore{stored: stored, local: true}, nil
 }
 
-// orphanedSessionState reports what a client ID left behind in storage when no
-// session object holds it any more: the Will that a Clean Start makes due, and
-// whether anything at all is there to purge.
+// claimOrphanedSessionState takes over whatever a previous session left in
+// storage under this client ID, clearing it and returning a delayed Will that
+// the end of that session makes due.
 //
-// The two reads keep the common cold connect cheap. Most Clean Start clients
-// have no persisted state, and answering that with two lookups is worth avoiding
-// four unconditional deletes on the CONNECT path.
-func (b *Broker) orphanedSessionState(ctx context.Context, clientID string) (will *storage.WillMessage, purge bool, err error) {
+// The purge is unconditional. The four key spaces expire independently — badger
+// gives the session record a TTL of its own expiry interval
+// (storage/badger/session.go) while the subscriptions and messages keyed by the
+// same client ID stay — so the presence of any one record says nothing about the
+// others, and a probe would have to read all four to save the writes.
+//
+// The cluster routing table is cleared too, but only where an entry is actually
+// found, so a cold CONNECT to a client ID nothing has used costs a read and no
+// write.
+func (b *Broker) claimOrphanedSessionState(ctx context.Context, clientID string) (*storage.WillMessage, error) {
+	var will *storage.WillMessage
 	if b.stores.wills != nil {
-		storedWill, err := b.stores.wills.Get(ctx, clientID)
+		stored, err := b.stores.wills.Get(ctx, clientID)
 		if err != nil && !errors.Is(err, storage.ErrNotFound) {
-			return nil, false, fmt.Errorf("failed to load replaced session will: %w", err)
+			return nil, fmt.Errorf("failed to load replaced session will: %w", err)
 		}
-		will = storedWill
-	}
-	if will != nil {
-		return will, true, nil
+		will = stored
 	}
 
-	if b.stores.sessions != nil {
-		stored, err := b.stores.sessions.Get(clientID)
-		if err != nil && !errors.Is(err, storage.ErrNotFound) {
-			return nil, false, fmt.Errorf("failed to load replaced session: %w", err)
-		}
-		purge = stored != nil
+	if err := b.deleteDurableSessionState(ctx, clientID); err != nil {
+		return nil, err
+	}
+	if err := b.removeOrphanedClusterSubscriptions(ctx, clientID); err != nil {
+		return nil, err
 	}
 
-	return nil, purge, nil
+	return will, nil
+}
+
+// removeOrphanedClusterSubscriptions clears the cluster routing entries a
+// previous session left under this client ID.
+//
+// They outlive the local records they were written beside — a badger session
+// record carries a TTL the subscriptions do not, and a node that crashes leaves
+// its entries for the lease to reclaim — and restoreSessionFromStorage reads
+// subscriptions from the cluster in preference to local storage. An entry left
+// here is therefore restored into the next persistent session under this client
+// ID, whoever it now belongs to.
+//
+// Reaching this path means no session was inherited, so the cluster resolved no
+// live owner and nothing found here is another node's. The removal is still
+// conditional on finding an entry: an unconditional delete would put an etcd
+// write on every cold CONNECT.
+func (b *Broker) removeOrphanedClusterSubscriptions(ctx context.Context, clientID string) error {
+	if b.cluster == nil {
+		return nil
+	}
+
+	subs, err := b.cluster.GetSubscriptionsForClient(ctx, clientID)
+	switch {
+	case errors.Is(err, cluster.ErrClusterNotEnabled):
+		// A single node keeps no cluster routing table, so its local state is
+		// the whole story and deleteDurableSessionState has already cleared it.
+		return nil
+	case err != nil:
+		return fmt.Errorf("failed to load cluster subscriptions: %w", err)
+	}
+	if len(subs) == 0 {
+		return nil
+	}
+
+	if err := b.cluster.RemoveAllSubscriptions(ctx, clientID); err != nil {
+		return fmt.Errorf("failed to remove cluster subscriptions: %w", err)
+	}
+
+	return nil
 }
 
 // purgeSessionState removes every trace of a persisted session that will not
@@ -658,6 +700,10 @@ func (b *Broker) releaseUnattachedSession(ctx context.Context, s *session.Sessio
 		return
 	}
 
+	// Restoring a session moved its queued and inflight messages out of storage
+	// and into this object, and dropping it releases them. Write them back first
+	// or a failed CONNECT silently consumes the client's undelivered messages.
+	b.persistSessionMessages(s)
 	b.dropSessionLocked(ctx, s, true)
 }
 
@@ -824,24 +870,7 @@ func (b *Broker) handleDisconnect(s *session.Session, graceful bool, disconnectE
 	} else if graceful && b.stores.wills != nil {
 		b.stores.wills.Delete(context.Background(), s.ID) //nolint:errcheck // best-effort Will cleanup on graceful disconnect
 	}
-	if b.stores.messages != nil {
-		msgs := s.OfflineQueue().Drain()
-		for i, msg := range msgs {
-			key := fmt.Sprintf("%s%s%d", s.ID, queuePrefix, i)
-			b.stores.messages.Store(key, msg) //nolint:errcheck // best-effort offline message persistence
-			message.Release(msg)
-		}
-
-		for _, inf := range s.Inflight().GetAll() {
-			// Key by direction so an inbound and outbound entry sharing a packet
-			// ID do not overwrite each other, and carry the direction and state
-			// on the message so they survive a restore.
-			key := fmt.Sprintf("%s%s%d/%d", s.ID, inflightPrefix, inf.Direction, inf.PacketID)
-			inf.Message.BrokerMeta.Delivery.InflightDirection = byte(inf.Direction)
-			inf.Message.BrokerMeta.Delivery.InflightState = byte(inf.State)
-			b.stores.messages.Store(key, inf.Message) //nolint:errcheck // best-effort inflight message persistence
-		}
-	}
+	b.persistSessionMessages(s)
 
 	if sessionEnds {
 		b.destroySessionLocked(context.Background(), s) //nolint:errcheck // best-effort session cleanup for clean-start sessions
@@ -867,6 +896,33 @@ func (b *Broker) emitClientDisconnected(ctx context.Context, clientID, reason st
 		if err := b.eventHook.OnDisconnect(ctx, clientID, reason); err != nil {
 			b.logError("event_hook_disconnect", err, slog.String("client_id", clientID))
 		}
+	}
+}
+
+// persistSessionMessages writes a session's offline queue and inflight entries
+// back to storage and empties the queue. Restoring a session moves these
+// messages out of storage and into memory, so anything that gives up a session
+// object has to write them back or they are gone.
+func (b *Broker) persistSessionMessages(s *session.Session) {
+	if b.stores.messages == nil {
+		return
+	}
+
+	msgs := s.OfflineQueue().Drain()
+	for i, msg := range msgs {
+		key := fmt.Sprintf("%s%s%d", s.ID, queuePrefix, i)
+		b.stores.messages.Store(key, msg) //nolint:errcheck // best-effort offline message persistence
+		message.Release(msg)
+	}
+
+	for _, inf := range s.Inflight().GetAll() {
+		// Key by direction so an inbound and outbound entry sharing a packet
+		// ID do not overwrite each other, and carry the direction and state
+		// on the message so they survive a restore.
+		key := fmt.Sprintf("%s%s%d/%d", s.ID, inflightPrefix, inf.Direction, inf.PacketID)
+		inf.Message.BrokerMeta.Delivery.InflightDirection = byte(inf.Direction)
+		inf.Message.BrokerMeta.Delivery.InflightState = byte(inf.State)
+		b.stores.messages.Store(key, inf.Message) //nolint:errcheck // best-effort inflight message persistence
 	}
 }
 

--- a/mqtt/broker/session.go
+++ b/mqtt/broker/session.go
@@ -242,13 +242,28 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 	inflight := messages.NewInflightTracker(serverReceiveMax)
 	offlineQueue := messages.NewMessageQueue(sessionCfg.MaxOfflineQueueSize, sessionCfg.OfflineQueuePolicy == config.OfflineQueuePolicyEvict)
 
-	// Ownership is taken before any client-ID-scoped state is read or written,
-	// because it is what makes this node's answer to those questions binding.
-	// The ownership check above is a read: another node can acquire the client
-	// ID between it and this line, and everything below — the orphan claim's
-	// cluster deletion above all — would then be acting on a session that is
-	// live somewhere else. Losing the race here costs a rejected CONNECT;
-	// losing it after the cleanup would cost the winner its routes.
+	// Which state this CONNECT may inherit is decided before any of it is
+	// loaded, so an unauthorized client never reaches another principal's
+	// inflight, queued, or subscribed messages.
+	restore, err := b.resolveSessionRestore(ctx, clientID, &opts, takeoverState, identity)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Ownership is taken before any client-ID-scoped state is written, because
+	// it is what makes this node's answer binding. The ownership check above is
+	// a read: another node can acquire the client ID between it and this line,
+	// and the purges below — the orphan claim's cluster deletion above all —
+	// would then be acting on a session that is live somewhere else. Losing the
+	// race here costs a rejected CONNECT; losing it after the cleanup would
+	// cost the winner its routes.
+	//
+	// It is taken no earlier than this because announcing ownership is itself
+	// visible: a CONNECT rejected while resolving what it may inherit would
+	// have advertised this node as the owner and then withdrawn it, and a
+	// takeover that latched onto that announcement finds no session here and
+	// completes with nothing, stranding the durable state it was after.
+	// Resolving is all reads, so it costs nothing to do it first.
 	//
 	// Failing past this point hands ownership back through the deferred
 	// rollback above, except where keepOwnership marks a session deliberately
@@ -260,14 +275,6 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 		ownershipAcquired = true
 	}
 
-	// Which state this CONNECT may inherit is decided before any of it is
-	// loaded, so an unauthorized client never reaches another principal's
-	// inflight, queued, or subscribed messages.
-	restore, err := b.resolveSessionRestore(ctx, clientID, &opts, takeoverState, identity)
-	if err != nil {
-		return nil, false, err
-	}
-
 	// Inheriting neither a migrated session nor a persisted record means this
 	// CONNECT starts a fresh session under a recycled client ID. Whatever the
 	// previous session left behind is not this one's, and that session has ended,
@@ -276,7 +283,11 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 	// The resolved restore decides this, not the migrated state this CONNECT
 	// arrived with: Clean Start discards a takeover, and the fresh session it
 	// asks for must not inherit what that session left under the client ID
-	// either.
+	// either. State that resolving actively discarded — a session bound to no
+	// principal, a migrated one whose owner has nothing left to keep — reaches
+	// this same point and is cleared by this one pass. Clearing it in resolve as
+	// well would delete the Will before the read below could capture it, and
+	// would put a local delete ahead of the cluster call that can fail.
 	//
 	// This has to run before anything is restored: the restores below key off the
 	// client ID alone and would otherwise hand the old subscriptions and messages
@@ -511,10 +522,9 @@ func (b *Broker) resolveSessionRestore(ctx context.Context, clientID string, opt
 				slog.String("client_id", clientID),
 				slog.String("source", "takeover"),
 				slog.String("external_id", opts.ExternalID))
-			if err := b.purgeSessionState(ctx, clientID); err != nil {
-				return sessionRestore{}, err
-			}
 
+			// Inheriting nothing, so the caller's orphan claim clears what is
+			// left under the client ID and publishes the Will it makes due.
 			return sessionRestore{}, nil
 		}
 		if !session.IdentityAllows(takeoverState.ExternalId, identity.ExternalID, identity.RequireBound) {
@@ -525,10 +535,6 @@ func (b *Broker) resolveSessionRestore(ctx context.Context, clientID string, opt
 			// holding it for the expiry this CONNECT asked for, which is not
 			// its owner's to set.
 			if takeoverState.ExpiryInterval == 0 {
-				if err := b.purgeSessionState(ctx, clientID); err != nil {
-					return sessionRestore{}, err
-				}
-
 				return sessionRestore{}, nil
 			}
 			opts.ExternalID = takeoverState.ExternalId
@@ -566,10 +572,9 @@ func (b *Broker) resolveSessionRestore(ctx context.Context, clientID string, opt
 			slog.String("client_id", clientID),
 			slog.String("source", "storage"),
 			slog.String("external_id", opts.ExternalID))
-		if err := b.purgeSessionState(ctx, clientID); err != nil {
-			return sessionRestore{}, err
-		}
 
+		// As above: the caller's orphan claim is the single pass that clears
+		// the discarded session and publishes its due Will.
 		return sessionRestore{}, nil
 	}
 	if !session.IdentityAllows(stored.ExternalID, identity.ExternalID, identity.RequireBound) {
@@ -655,21 +660,6 @@ func (b *Broker) removeOrphanedClusterSubscriptions(ctx context.Context, clientI
 
 	if err := b.cluster.RemoveAllSubscriptions(ctx, clientID); err != nil {
 		return fmt.Errorf("failed to remove cluster subscriptions: %w", err)
-	}
-
-	return nil
-}
-
-// purgeSessionState removes every trace of a persisted session that will not
-// be restored, so a session started fresh cannot resurrect it later.
-func (b *Broker) purgeSessionState(ctx context.Context, clientID string) error {
-	if err := b.deleteDurableSessionState(ctx, clientID); err != nil {
-		return err
-	}
-	if b.cluster != nil {
-		if err := b.cluster.RemoveAllSubscriptions(ctx, clientID); err != nil {
-			b.logError("cluster_remove_all_subscriptions", err, slog.String("client_id", clientID))
-		}
 	}
 
 	return nil

--- a/mqtt/broker/session.go
+++ b/mqtt/broker/session.go
@@ -45,7 +45,13 @@ func (b *Broker) CreateSessionForIdentity(clientID string, version byte, opts se
 func (b *Broker) createSession(clientID string, version byte, opts session.Options, identity *cluster.SessionIdentityGuard) (sess *session.Session, created bool, err error) {
 	sessionLock := b.sessionLocks.Key(clientID)
 	sessionLock.Lock()
-	defer sessionLock.Unlock()
+	var superseded []*session.Superseded
+	defer func() {
+		sessionLock.Unlock()
+		for _, retired := range superseded {
+			go b.drainSuperseded(context.Background(), retired)
+		}
+	}()
 
 	ctx := context.Background()
 
@@ -122,6 +128,18 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 
 	existing := b.sessionsMap.Get(clientID)
 	if opts.CleanStart && existing != nil {
+		retired := existing.DetachForTakeover(true)
+		// If the network callback already scheduled the Will, it consumed the
+		// in-memory copy. Ending the old session makes any stored delayed Will
+		// due now, while an already-published Will is absent from the store.
+		if retired.Conn == nil && retired.Will == nil && b.stores.wills != nil {
+			storedWill, err := b.stores.wills.Get(ctx, clientID)
+			if err != nil && !errors.Is(err, storage.ErrNotFound) {
+				return nil, false, fmt.Errorf("failed to load replaced session will: %w", err)
+			}
+			retired.Will = storedWill
+		}
+		superseded = append(superseded, retired)
 		if err := b.destroySessionLocked(ctx, existing); err != nil {
 			return nil, false, err
 		}
@@ -196,7 +214,37 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 	if err != nil {
 		return nil, false, err
 	}
+	takeoverWill := willFromTakeover(clientID, takeoverState)
 	takeoverState = restore.takeover
+	if takeoverWill != nil {
+		switch {
+		case restore.preserveForOwner:
+			// The attempted reconnect was rejected after the previous owner had
+			// already transferred and closed the session. Keep a delayed Will
+			// pending for the real owner; a zero-delay Will is due now.
+			if takeoverWill.Delay == 0 {
+				superseded = append(superseded, &session.Superseded{ClientID: clientID, Will: takeoverWill})
+			} else if b.stores.wills != nil {
+				if err := b.stores.wills.Set(ctx, clientID, takeoverWill); err != nil {
+					return nil, false, fmt.Errorf("failed to preserve takeover will: %w", err)
+				}
+			}
+		default:
+			// The old connection's Will belongs to that connection, not to the
+			// new CONNECT. A continued session cancels only a delayed Will; when
+			// the old session was discarded, every Will is due immediately.
+			superseded = append(superseded, &session.Superseded{
+				ClientID:    clientID,
+				Will:        takeoverWill,
+				SessionEnds: takeoverState == nil,
+			})
+		}
+	}
+	if restore.preserveForOwner {
+		// This CONNECT is rejected below, so its proposed Will must never become
+		// part of the migrated session retained for another principal.
+		opts.Will = nil
+	}
 
 	if takeoverState != nil {
 		if err := b.restoreInflightFromTakeover(takeoverState, inflight); err != nil {
@@ -214,19 +262,7 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 		}
 	}
 
-	// Handle will message from takeover or from opts
-	if takeoverState != nil && takeoverState.Will != nil {
-		// Restore will from takeover state
-		opts.Will = &storage.WillMessage{
-			ClientID:   clientID,
-			Topic:      takeoverState.Will.Topic,
-			Payload:    takeoverState.Will.Payload,
-			QoS:        byte(takeoverState.Will.Qos),
-			Retain:     takeoverState.Will.Retain,
-			Delay:      takeoverState.Will.Delay,
-			Properties: nil,
-		}
-	} else if opts.Will != nil {
+	if opts.Will != nil {
 		// Ensure ClientID is set
 		opts.Will.ClientID = clientID
 	}
@@ -540,7 +576,29 @@ func (b *Broker) HandleSessionLeaseLost(_ context.Context, clientIDs []string) {
 func (b *Broker) handleDisconnect(s *session.Session, graceful bool) {
 	sessionLock := b.sessionLocks.Key(s.ID)
 	sessionLock.Lock()
-	defer sessionLock.Unlock()
+	var publishWill *storage.WillMessage
+	notifyDisconnect := false
+	disconnectReason := "normal"
+	if !graceful {
+		disconnectReason = "error"
+	}
+	defer func() {
+		sessionLock.Unlock()
+		if publishWill != nil {
+			if err := b.publishWillMessage(context.Background(), publishWill); err != nil {
+				b.logError("publish_disconnected_will", err, slog.String("client_id", publishWill.ClientID))
+			}
+		}
+		if notifyDisconnect {
+			b.emitClientDisconnected(context.Background(), s.ID, disconnectReason)
+		}
+	}()
+
+	// The connection really did drop, so the notification is owed regardless of
+	// which session currently holds the client ID. Everything past the identity
+	// check writes state keyed by that ID instead, and must not run on behalf of
+	// a session that has already been replaced.
+	notifyDisconnect = true
 
 	// Disconnect callbacks run asynchronously. A clean reconnect can replace
 	// the session before the old callback starts; that stale callback must not
@@ -553,35 +611,22 @@ func (b *Broker) handleDisconnect(s *session.Session, graceful bool) {
 		b.auth.Forget(s.ID)
 	}
 
-	// Webhook: client disconnected
-	disconnectReason := "normal"
-	if !graceful {
-		disconnectReason = "error"
-	}
-	if b.telemetry.webhooks != nil {
-		b.telemetry.webhooks.Notify(context.Background(), events.ClientDisconnected{ //nolint:errcheck // fire-and-forget webhook notification
-			ClientID:   s.ID,
-			Reason:     disconnectReason,
-			RemoteAddr: "", // Not available at broker level
-		})
-	}
-
-	// Event hook: client disconnected
-	if b.eventHook != nil {
-		if err := b.eventHook.OnDisconnect(context.Background(), s.ID, disconnectReason); err != nil {
-			b.logError("event_hook_disconnect", err, slog.String("client_id", s.ID))
-		}
-	}
-
 	b.persistSessionInfo(s)
+	sessionEnds := s.CleanStart && s.ExpiryInterval == 0
+	will := s.TakeWill()
 	if b.stores.wills != nil {
 		ctx := context.Background()
-		will := s.GetWill()
 		if !graceful && will != nil {
-			b.stores.wills.Set(ctx, s.ID, will) //nolint:errcheck // best-effort will persistence on disconnect
+			if sessionEnds {
+				publishWill = will
+			} else {
+				b.stores.wills.Set(ctx, s.ID, will) //nolint:errcheck // best-effort will persistence on disconnect
+			}
 		} else if graceful {
 			b.stores.wills.Delete(ctx, s.ID) //nolint:errcheck // best-effort will cleanup on graceful disconnect
 		}
+	} else if !graceful && sessionEnds {
+		publishWill = will
 	}
 	if b.stores.messages != nil {
 		msgs := s.OfflineQueue().Drain()
@@ -602,12 +647,31 @@ func (b *Broker) handleDisconnect(s *session.Session, graceful bool) {
 		}
 	}
 
-	if s.CleanStart && s.ExpiryInterval == 0 {
+	if sessionEnds {
 		b.destroySessionLocked(context.Background(), s) //nolint:errcheck // best-effort session cleanup for clean-start sessions
 	}
 	// For persistent sessions, DON'T release ownership immediately
 	// Keep ownership so messages can still be routed to this node
 	// Ownership will expire naturally after TTL (30s)
+}
+
+// emitClientDisconnected runs external notifications without holding the
+// client-ID shard lock. Event hooks are user-supplied and webhooks may perform
+// network I/O, so neither may delay CONNECT or cleanup for colliding keys.
+func (b *Broker) emitClientDisconnected(ctx context.Context, clientID, reason string) {
+	if b.telemetry.webhooks != nil {
+		b.telemetry.webhooks.Notify(ctx, events.ClientDisconnected{ //nolint:errcheck // fire-and-forget webhook notification
+			ClientID:   clientID,
+			Reason:     reason,
+			RemoteAddr: "", // Not available at broker level
+		})
+	}
+
+	if b.eventHook != nil {
+		if err := b.eventHook.OnDisconnect(ctx, clientID, reason); err != nil {
+			b.logError("event_hook_disconnect", err, slog.String("client_id", clientID))
+		}
+	}
 }
 
 func (b *Broker) persistSessionInfo(s *session.Session) {
@@ -777,6 +841,21 @@ func (b *Broker) restoreInflightFromTakeover(state *clusterv1.SessionState, trac
 	return nil
 }
 
+func willFromTakeover(clientID string, state *clusterv1.SessionState) *storage.WillMessage {
+	if state == nil || state.Will == nil {
+		return nil
+	}
+
+	return &storage.WillMessage{
+		ClientID: clientID,
+		Topic:    state.Will.Topic,
+		Payload:  bytes.Clone(state.Will.Payload),
+		QoS:      byte(state.Will.Qos),
+		Retain:   state.Will.Retain,
+		Delay:    state.Will.Delay,
+	}
+}
+
 // restoreQueueFromTakeover restores offline queue from takeover state.
 func (b *Broker) restoreQueueFromTakeover(state *clusterv1.SessionState, queue messages.Queue) error {
 	if state == nil || state.QueuedMessages == nil {
@@ -849,7 +928,13 @@ func (b *Broker) restoreSubscriptionsFromTakeover(s *session.Session, state *clu
 func (b *Broker) GetSessionStateAndClose(ctx context.Context, clientID string, identity *cluster.SessionIdentityGuard) (*clusterv1.SessionState, error) {
 	sessionLock := b.sessionLocks.Key(clientID)
 	sessionLock.Lock()
-	defer sessionLock.Unlock()
+	var superseded *session.Superseded
+	defer func() {
+		sessionLock.Unlock()
+		if superseded != nil {
+			go b.drainSuperseded(context.WithoutCancel(ctx), superseded)
+		}
+	}()
 
 	s := b.sessionsMap.Get(clientID)
 	if s == nil {
@@ -914,8 +999,17 @@ func (b *Broker) GetSessionStateAndClose(ctx context.Context, clientID string, i
 		message.Release(msg)
 	}
 
-	// Capture will message
-	if will := s.GetWill(); will != nil {
+	// Capture the active Will, or a delayed Will already scheduled by a
+	// completed disconnect callback. Destruction below removes the old store.
+	will := s.GetWill()
+	if will == nil && b.stores.wills != nil {
+		storedWill, err := b.stores.wills.Get(ctx, s.ID)
+		if err != nil && !errors.Is(err, storage.ErrNotFound) {
+			return nil, fmt.Errorf("failed to capture session will: %w", err)
+		}
+		will = storedWill
+	}
+	if will != nil {
 		state.Will = &clusterv1.WillMessage{
 			Topic:   will.Topic,
 			Payload: bytes.Clone(will.Payload),
@@ -925,9 +1019,12 @@ func (b *Broker) GetSessionStateAndClose(ctx context.Context, clientID string, i
 		}
 	}
 
-	// The takeover caller owns the distributed handoff. Suppress the ordinary
-	// disconnect callback and retain the old owner key until its final CAS.
-	s.SetOnDisconnect(nil)
+	// Detach while the client-ID lock still protects the old owner, then notify
+	// and close after unlocking. The Will travels in state so the new owner can
+	// decide whether Clean Start ends the session or a reconnect cancels its
+	// delay; the old owner must not publish it independently.
+	superseded = s.DetachForTakeover(false)
+	superseded.Will = nil
 	if err := b.destroySessionForTakeoverLocked(ctx, s); err != nil {
 		return nil, fmt.Errorf("failed to destroy session: %w", err)
 	}

--- a/mqtt/broker/session.go
+++ b/mqtt/broker/session.go
@@ -829,9 +829,9 @@ func (b *Broker) handleDisconnect(s *session.Session, graceful bool, disconnectE
 	sessionLock.Lock()
 	var publishWill *storage.WillMessage
 	notifyDisconnect := false
-	disconnectReason := "normal"
+	disconnectReason := disconnectReasonNormal
 	if !graceful {
-		disconnectReason = "error"
+		disconnectReason = disconnectReasonError
 	}
 	defer func() {
 		sessionLock.Unlock()

--- a/mqtt/broker/session.go
+++ b/mqtt/broker/session.go
@@ -141,27 +141,54 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 	}
 
 	existing := b.sessionsMap.Get(clientID)
-	if opts.CleanStart && existing != nil {
-		retired := existing.DetachForTakeover()
-		// If the network callback already scheduled the Will, it consumed the
-		// in-memory copy. Ending the old session makes any stored delayed Will
-		// due now, while an already-published Will is absent from the store.
-		if retired.Conn == nil && retired.Will == nil && b.stores.wills != nil {
+	if opts.CleanStart {
+		switch {
+		case existing != nil:
+			retired := existing.DetachForTakeover()
+			// If the network callback already scheduled the Will, it consumed the
+			// in-memory copy. Ending the old session makes any stored delayed Will
+			// due now, while an already-published Will is absent from the store.
+			if retired.Conn == nil && retired.Will == nil && b.stores.wills != nil {
+				storedWill, err := b.stores.wills.Get(ctx, clientID)
+				if err != nil && !errors.Is(err, storage.ErrNotFound) {
+					return nil, false, fmt.Errorf("failed to load replaced session will: %w", err)
+				}
+				retired.Will = storedWill
+			}
+			retirements = append(retirements, &sessionRetirement{
+				clientID:    clientID,
+				superseded:  retired,
+				sessionEnds: true,
+			})
+			// destroySessionLocked removes the stored record under this lock, so
+			// the sweep cannot publish the same Will a second time.
+			if err := b.destroySessionLocked(ctx, existing); err != nil {
+				return nil, false, err
+			}
+			existing = nil
+
+		case b.stores.wills != nil:
+			// Clean Start ends the previous session even when no session object
+			// survives to detach: it expired, its lease was lost, or a restart
+			// outlived only the Will record. Ending the session still makes a
+			// pending delayed Will due [MQTT-3.1.2-8], so it is claimed here.
+			// Without this, attachSession would cancel the record as if the
+			// session had resumed, and the Will would never be published.
 			storedWill, err := b.stores.wills.Get(ctx, clientID)
-			if err != nil && !errors.Is(err, storage.ErrNotFound) {
+			switch {
+			case err == nil:
+				if err := b.stores.wills.Delete(ctx, clientID); err != nil {
+					return nil, false, fmt.Errorf("failed to claim replaced session will: %w", err)
+				}
+				retirements = append(retirements, &sessionRetirement{
+					clientID:    clientID,
+					superseded:  &session.Superseded{Will: storedWill},
+					sessionEnds: true,
+				})
+			case !errors.Is(err, storage.ErrNotFound):
 				return nil, false, fmt.Errorf("failed to load replaced session will: %w", err)
 			}
-			retired.Will = storedWill
 		}
-		retirements = append(retirements, &sessionRetirement{
-			clientID:    clientID,
-			superseded:  retired,
-			sessionEnds: true,
-		})
-		if err := b.destroySessionLocked(ctx, existing); err != nil {
-			return nil, false, err
-		}
-		existing = nil
 	}
 
 	if existing != nil && identity != nil && identity.RequireBound && existing.ExternalIdentity() == "" {
@@ -357,9 +384,10 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 var errSessionReplacedBeforeAttach = errors.New("session replaced before connection attachment")
 
 // attachSession commits a CONNECT to the session claim returned by
-// createSessionForConnection. Identity, epoch verification, stored delayed-Will
-// cancellation, connection attachment, auth binding, and persistence happen
-// under the same client-ID lock. A callback or Clean Start replacement can
+// createSessionForConnection. Verifying that the claim still names the current
+// session and generation, cancelling a stored delayed Will, attaching the
+// connection, binding the external identity, and persisting the session all
+// happen under the same client-ID lock. A callback or Clean Start replacement can
 // therefore run either before this operation or after it, but cannot interleave
 // client-ID-scoped state with the new connection generation.
 func (b *Broker) attachSession(ctx context.Context, s *session.Session, expectedEpoch uint64, conn core.Connection, opts session.ConnectOptions, expiryInterval *uint32) (epoch uint64, err error) {
@@ -571,6 +599,22 @@ func (b *Broker) DestroySession(clientID string) error {
 	}
 
 	return b.destroySessionLocked(context.Background(), s)
+}
+
+// destroyIfCurrent removes s only while it is still the session installed for
+// its client ID. A CONNECT that fails after createSession installed the session
+// hands it back this way, together with its cluster ownership, without
+// disturbing a replacement that arrived in between.
+func (b *Broker) destroyIfCurrent(ctx context.Context, s *session.Session) error {
+	sessionLock := b.sessionLocks.Key(s.ID)
+	sessionLock.Lock()
+	defer sessionLock.Unlock()
+
+	if b.sessionsMap.Get(s.ID) != s {
+		return nil
+	}
+
+	return b.destroySessionLocked(ctx, s)
 }
 
 // destroySessionLocked destroys a session. Must be called with the session's key lock held.

--- a/mqtt/broker/session.go
+++ b/mqtt/broker/session.go
@@ -582,7 +582,18 @@ func (b *Broker) resolveSessionRestore(ctx context.Context, clientID string, opt
 // The cluster routing table is cleared too, but only where an entry is actually
 // found, so a cold CONNECT to a client ID nothing has used costs a read and no
 // write.
+//
+// The cluster goes first because it is the part that can fail on its own — a
+// remote call, against state this node does not hold. Deleting the local
+// records ahead of it would mean a failed claim had already dropped the Will it
+// never got to return, silently, with nothing left to publish it from. Failing
+// before the local purge leaves the whole claim to be made again by the next
+// CONNECT, which is the only caller that can act on it.
 func (b *Broker) claimOrphanedSessionState(ctx context.Context, clientID string) (*storage.WillMessage, error) {
+	if err := b.removeOrphanedClusterSubscriptions(ctx, clientID); err != nil {
+		return nil, err
+	}
+
 	var will *storage.WillMessage
 	if b.stores.wills != nil {
 		stored, err := b.stores.wills.Get(ctx, clientID)
@@ -593,9 +604,6 @@ func (b *Broker) claimOrphanedSessionState(ctx context.Context, clientID string)
 	}
 
 	if err := b.deleteDurableSessionState(ctx, clientID); err != nil {
-		return nil, err
-	}
-	if err := b.removeOrphanedClusterSubscriptions(ctx, clientID); err != nil {
 		return nil, err
 	}
 
@@ -625,7 +633,7 @@ func (b *Broker) removeOrphanedClusterSubscriptions(ctx context.Context, clientI
 	switch {
 	case errors.Is(err, cluster.ErrClusterNotEnabled):
 		// A single node keeps no cluster routing table, so its local state is
-		// the whole story and deleteDurableSessionState has already cleared it.
+		// the whole story and the purge that follows is the whole claim.
 		return nil
 	case err != nil:
 		return fmt.Errorf("failed to load cluster subscriptions: %w", err)

--- a/mqtt/broker/session.go
+++ b/mqtt/broker/session.go
@@ -242,6 +242,24 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 	inflight := messages.NewInflightTracker(serverReceiveMax)
 	offlineQueue := messages.NewMessageQueue(sessionCfg.MaxOfflineQueueSize, sessionCfg.OfflineQueuePolicy == config.OfflineQueuePolicyEvict)
 
+	// Ownership is taken before any client-ID-scoped state is read or written,
+	// because it is what makes this node's answer to those questions binding.
+	// The ownership check above is a read: another node can acquire the client
+	// ID between it and this line, and everything below — the orphan claim's
+	// cluster deletion above all — would then be acting on a session that is
+	// live somewhere else. Losing the race here costs a rejected CONNECT;
+	// losing it after the cleanup would cost the winner its routes.
+	//
+	// Failing past this point hands ownership back through the deferred
+	// rollback above, except where keepOwnership marks a session deliberately
+	// retained for its own principal.
+	if b.cluster != nil {
+		if err := b.cluster.AcquireSession(ctx, clientID, b.cluster.NodeID()); err != nil {
+			return nil, false, fmt.Errorf("failed to acquire session ownership: %w", err)
+		}
+		ownershipAcquired = true
+	}
+
 	// Which state this CONNECT may inherit is decided before any of it is
 	// loaded, so an unauthorized client never reaches another principal's
 	// inflight, queued, or subscribed messages.
@@ -365,13 +383,6 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 	s.SetOnDisconnectWithEpoch(func(s *session.Session, graceful bool, epoch uint64) {
 		b.handleDisconnect(s, graceful, epoch)
 	})
-
-	if b.cluster != nil {
-		if err := b.cluster.AcquireSession(ctx, clientID, b.cluster.NodeID()); err != nil {
-			return nil, false, fmt.Errorf("failed to acquire session ownership: %w", err)
-		}
-		ownershipAcquired = true
-	}
 
 	if b.stores.sessions != nil {
 		if err := b.stores.sessions.Save(s.Info()); err != nil {

--- a/mqtt/broker/session.go
+++ b/mqtt/broker/session.go
@@ -43,20 +43,31 @@ func (b *Broker) CreateSessionForIdentity(clientID string, version byte, opts se
 	return b.createSession(clientID, version, opts, identity, nil)
 }
 
-// createSessionForConnection returns the session epoch observed while the
-// client-ID lock is still held. The protocol handler must present that epoch to
-// attachSession; a Clean Start replacement or another completed attachment in
+// sessionClaim is what a CONNECT carries from createSessionForConnection to
+// attachSession: the generation observed while the client-ID lock was held, and
+// whether the session continues a previous one rather than starting fresh.
+type sessionClaim struct {
+	epoch uint64
+	// continuesSession marks a session inherited from a live session, a
+	// takeover, or persisted storage. Only such a CONNECT is "a new Network
+	// Connection to this Session" [MQTT-3.1.3-9] and may cancel the previous
+	// generation's delayed Will; a fresh session leaves that Will due.
+	continuesSession bool
+}
+
+// createSessionForConnection returns the claim the protocol handler must present
+// to attachSession. A Clean Start replacement or another completed attachment in
 // between makes the claim stale and the connection is rejected.
-func (b *Broker) createSessionForConnection(clientID string, version byte, opts session.Options, requireBound bool) (sess *session.Session, created bool, expectedEpoch uint64, err error) {
+func (b *Broker) createSessionForConnection(clientID string, version byte, opts session.Options, requireBound bool) (sess *session.Session, created bool, claim sessionClaim, err error) {
 	identity := &cluster.SessionIdentityGuard{
 		ExternalID:   opts.ExternalID,
 		RequireBound: requireBound,
 	}
-	sess, created, err = b.createSession(clientID, version, opts, identity, &expectedEpoch)
+	sess, created, err = b.createSession(clientID, version, opts, identity, &claim)
 	return
 }
 
-func (b *Broker) createSession(clientID string, version byte, opts session.Options, identity *cluster.SessionIdentityGuard, expectedEpoch *uint64) (sess *session.Session, created bool, err error) {
+func (b *Broker) createSession(clientID string, version byte, opts session.Options, identity *cluster.SessionIdentityGuard, claim *sessionClaim) (sess *session.Session, created bool, err error) {
 	sessionLock := b.sessionLocks.Key(clientID)
 	sessionLock.Lock()
 	var retirements []*sessionRetirement
@@ -167,26 +178,31 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 			}
 			existing = nil
 
-		case b.stores.wills != nil:
+		default:
 			// Clean Start ends the previous session even when no session object
-			// survives to detach: it expired, its lease was lost, or a restart
-			// outlived only the Will record. Ending the session still makes a
-			// pending delayed Will due [MQTT-3.1.2-8], so it is claimed here.
-			// Without this, attachSession would cancel the record as if the
-			// session had resumed, and the Will would never be published.
-			storedWill, err := b.stores.wills.Get(ctx, clientID)
-			switch {
-			case err == nil:
-				if err := b.stores.wills.Delete(ctx, clientID); err != nil {
-					return nil, false, fmt.Errorf("failed to claim replaced session will: %w", err)
+			// survives to detach it — a restart outlives the session map while
+			// the records it wrote remain. Ending the session makes a pending
+			// delayed Will due [MQTT-3.1.2-8], and leaves nothing for the fresh
+			// session to inherit, so the Will is claimed and the rest purged.
+			// Without this the Will is never published (attachSession would
+			// cancel it as though the session had resumed) and the old
+			// subscriptions and queued messages survive to be restored into a
+			// later persistent reconnect, possibly under another identity.
+			storedWill, purge, err := b.orphanedSessionState(ctx, clientID)
+			if err != nil {
+				return nil, false, err
+			}
+			if purge {
+				if err := b.purgeSessionState(ctx, clientID); err != nil {
+					return nil, false, err
 				}
+			}
+			if storedWill != nil {
 				retirements = append(retirements, &sessionRetirement{
 					clientID:    clientID,
 					superseded:  &session.Superseded{Will: storedWill},
 					sessionEnds: true,
 				})
-			case !errors.Is(err, storage.ErrNotFound):
-				return nil, false, fmt.Errorf("failed to load replaced session will: %w", err)
 			}
 		}
 	}
@@ -221,8 +237,9 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 			}
 		}
 		ownershipAcquired = true
-		if expectedEpoch != nil {
-			*expectedEpoch = existing.Epoch()
+		if claim != nil {
+			// A live session is being reused, so this CONNECT continues it.
+			*claim = sessionClaim{epoch: existing.Epoch(), continuesSession: true}
 		}
 
 		return existing, false, nil
@@ -374,8 +391,13 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 
 		return nil, false, cluster.ErrSessionIdentityMismatch
 	}
-	if expectedEpoch != nil {
-		*expectedEpoch = s.Epoch()
+	if claim != nil {
+		// A takeover or a restored record carries the previous session forward.
+		// Anything else is a fresh logical session under a recycled client ID.
+		*claim = sessionClaim{
+			epoch:            s.Epoch(),
+			continuesSession: takeoverState != nil || restore.stored != nil,
+		}
 	}
 
 	return s, true, nil
@@ -390,7 +412,7 @@ var errSessionReplacedBeforeAttach = errors.New("session replaced before connect
 // happen under the same client-ID lock. A callback or Clean Start replacement can
 // therefore run either before this operation or after it, but cannot interleave
 // client-ID-scoped state with the new connection generation.
-func (b *Broker) attachSession(ctx context.Context, s *session.Session, expectedEpoch uint64, conn core.Connection, opts session.ConnectOptions, expiryInterval *uint32) (epoch uint64, err error) {
+func (b *Broker) attachSession(ctx context.Context, s *session.Session, claim sessionClaim, conn core.Connection, opts session.ConnectOptions, expiryInterval *uint32) (epoch uint64, err error) {
 	if s == nil {
 		return 0, errSessionReplacedBeforeAttach
 	}
@@ -405,14 +427,16 @@ func (b *Broker) attachSession(ctx context.Context, s *session.Session, expected
 		}
 	}()
 
-	if b.sessionsMap.Get(s.ID) != s || s.Epoch() != expectedEpoch {
+	if b.sessionsMap.Get(s.ID) != s || s.Epoch() != claim.epoch {
 		return 0, errSessionReplacedBeforeAttach
 	}
 
 	// Only delayed Wills are persisted. Reconnecting before their deadline
 	// cancels the previous generation's Will while the disconnect callback is
-	// fenced by this same lock and the epoch transition below.
-	if b.stores.wills != nil {
+	// fenced by this same lock and the epoch transition below. A CONNECT that
+	// starts a fresh session is not a reconnect to the session that armed the
+	// Will, so it leaves the record for the sweep to publish.
+	if claim.continuesSession && b.stores.wills != nil {
 		_, getErr := b.stores.wills.Get(ctx, s.ID)
 		switch {
 		case getErr == nil:
@@ -545,28 +569,41 @@ func (b *Broker) resolveSessionRestore(ctx context.Context, clientID string, opt
 	return sessionRestore{stored: stored, local: true}, nil
 }
 
+// orphanedSessionState reports what a client ID left behind in storage when no
+// session object holds it any more: the Will that a Clean Start makes due, and
+// whether anything at all is there to purge.
+//
+// The two reads keep the common cold connect cheap. Most Clean Start clients
+// have no persisted state, and answering that with two lookups is worth avoiding
+// four unconditional deletes on the CONNECT path.
+func (b *Broker) orphanedSessionState(ctx context.Context, clientID string) (will *storage.WillMessage, purge bool, err error) {
+	if b.stores.wills != nil {
+		storedWill, err := b.stores.wills.Get(ctx, clientID)
+		if err != nil && !errors.Is(err, storage.ErrNotFound) {
+			return nil, false, fmt.Errorf("failed to load replaced session will: %w", err)
+		}
+		will = storedWill
+	}
+	if will != nil {
+		return will, true, nil
+	}
+
+	if b.stores.sessions != nil {
+		stored, err := b.stores.sessions.Get(clientID)
+		if err != nil && !errors.Is(err, storage.ErrNotFound) {
+			return nil, false, fmt.Errorf("failed to load replaced session: %w", err)
+		}
+		purge = stored != nil
+	}
+
+	return nil, purge, nil
+}
+
 // purgeSessionState removes every trace of a persisted session that will not
 // be restored, so a session started fresh cannot resurrect it later.
 func (b *Broker) purgeSessionState(ctx context.Context, clientID string) error {
-	if b.stores.sessions != nil {
-		if err := b.stores.sessions.Delete(clientID); err != nil {
-			return fmt.Errorf("failed to delete session: %w", err)
-		}
-	}
-	if b.stores.subscriptions != nil {
-		if err := b.stores.subscriptions.RemoveAll(clientID); err != nil {
-			return fmt.Errorf("failed to remove subscriptions: %w", err)
-		}
-	}
-	if b.stores.messages != nil {
-		if err := b.stores.messages.DeleteByPrefix(clientID + "/"); err != nil {
-			return fmt.Errorf("failed to delete messages: %w", err)
-		}
-	}
-	if b.stores.wills != nil {
-		if err := b.stores.wills.Delete(ctx, clientID); err != nil {
-			return fmt.Errorf("failed to delete will: %w", err)
-		}
+	if err := b.deleteDurableSessionState(ctx, clientID); err != nil {
+		return err
 	}
 	if b.cluster != nil {
 		if err := b.cluster.RemoveAllSubscriptions(ctx, clientID); err != nil {
@@ -601,20 +638,27 @@ func (b *Broker) DestroySession(clientID string) error {
 	return b.destroySessionLocked(context.Background(), s)
 }
 
-// destroyIfCurrent removes s only while it is still the session installed for
-// its client ID. A CONNECT that fails after createSession installed the session
-// hands it back this way, together with its cluster ownership, without
-// disturbing a replacement that arrived in between.
-func (b *Broker) destroyIfCurrent(ctx context.Context, s *session.Session) error {
+// releaseUnattachedSession rolls back a session a CONNECT installed but never
+// attached, handing back the session map entry and the cluster ownership key.
+//
+// Persisted state is deliberately left alone. createSession reports a session
+// rebuilt from storage as newly created, so destroying durable state here would
+// let one failed CONNECT delete a client's subscriptions, queued messages, and
+// Will.
+//
+// The generation is checked alongside the identity because a persistent CONNECT
+// reuses the session pointer: only the epoch distinguishes a session nothing
+// ever attached to from one another connection has since claimed.
+func (b *Broker) releaseUnattachedSession(ctx context.Context, s *session.Session, expectedEpoch uint64) {
 	sessionLock := b.sessionLocks.Key(s.ID)
 	sessionLock.Lock()
 	defer sessionLock.Unlock()
 
-	if b.sessionsMap.Get(s.ID) != s {
-		return nil
+	if b.sessionsMap.Get(s.ID) != s || s.Epoch() != expectedEpoch {
+		return
 	}
 
-	return b.destroySessionLocked(ctx, s)
+	b.dropSessionLocked(ctx, s, true)
 }
 
 // destroySessionLocked destroys a session. Must be called with the session's key lock held.
@@ -634,27 +678,48 @@ func (b *Broker) destroySessionLockedWithOwnership(ctx context.Context, s *sessi
 		s.Disconnect(false, v5.DisconnectAdministrativeAction) //nolint:errcheck // disconnect during session destroy; connection is being removed
 	}
 
+	if err := b.deleteDurableSessionState(ctx, s.ID); err != nil {
+		return err
+	}
+	b.dropSessionLocked(ctx, s, releaseOwnership)
+
+	return nil
+}
+
+// deleteDurableSessionState removes everything a session persisted. It is the
+// half of a destroy that outlives this node, so it is kept separate from the
+// in-memory teardown: a CONNECT that fails before attaching has to undo its own
+// bookkeeping without discarding state that belongs to the client.
+func (b *Broker) deleteDurableSessionState(ctx context.Context, clientID string) error {
 	if b.stores.sessions != nil {
-		if err := b.stores.sessions.Delete(s.ID); err != nil {
+		if err := b.stores.sessions.Delete(clientID); err != nil {
 			return fmt.Errorf("failed to delete session: %w", err)
 		}
 	}
 	if b.stores.subscriptions != nil {
-		if err := b.stores.subscriptions.RemoveAll(s.ID); err != nil {
+		if err := b.stores.subscriptions.RemoveAll(clientID); err != nil {
 			return fmt.Errorf("failed to remove subscriptions: %w", err)
 		}
 	}
 	if b.stores.messages != nil {
-		if err := b.stores.messages.DeleteByPrefix(s.ID + "/"); err != nil {
+		if err := b.stores.messages.DeleteByPrefix(clientID + "/"); err != nil {
 			return fmt.Errorf("failed to delete messages: %w", err)
 		}
 	}
 	if b.stores.wills != nil {
-		if err := b.stores.wills.Delete(ctx, s.ID); err != nil {
+		if err := b.stores.wills.Delete(ctx, clientID); err != nil {
 			return fmt.Errorf("failed to delete will: %w", err)
 		}
 	}
 
+	return nil
+}
+
+// dropSessionLocked removes a session's presence on this node — the session map,
+// local routes, cluster routes, and optionally the ownership key — and releases
+// the messages it held in memory. Persisted state is untouched. Must be called
+// with the session's key lock held.
+func (b *Broker) dropSessionLocked(ctx context.Context, s *session.Session, releaseOwnership bool) {
 	b.sessionsMap.Delete(s.ID)
 
 	subs := s.GetSubscriptions()
@@ -683,8 +748,6 @@ func (b *Broker) destroySessionLockedWithOwnership(ctx context.Context, s *sessi
 		}
 	}
 	s.ClearMessages()
-
-	return nil
 }
 
 // HandleSessionLeaseLost fences connections that this node can no longer

--- a/mqtt/broker/session.go
+++ b/mqtt/broker/session.go
@@ -15,6 +15,7 @@ import (
 	"github.com/absmach/fluxmq/cluster"
 	"github.com/absmach/fluxmq/config"
 	"github.com/absmach/fluxmq/message"
+	core "github.com/absmach/fluxmq/mqtt"
 	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/mqtt/session"
 	clusterv1 "github.com/absmach/fluxmq/pkg/proto/cluster/v1"
@@ -27,7 +28,7 @@ import (
 // If opts.CleanStart is true and a session exists, it is destroyed first.
 // Returns the session and whether it was newly created.
 func (b *Broker) CreateSession(clientID string, version byte, opts session.Options) (sess *session.Session, created bool, err error) {
-	return b.createSession(clientID, version, opts, nil)
+	return b.createSession(clientID, version, opts, nil, nil)
 }
 
 // CreateSessionForIdentity creates or resumes an MQTT session while ensuring
@@ -39,17 +40,30 @@ func (b *Broker) CreateSessionForIdentity(clientID string, version byte, opts se
 		ExternalID:   opts.ExternalID,
 		RequireBound: requireBound,
 	}
-	return b.createSession(clientID, version, opts, identity)
+	return b.createSession(clientID, version, opts, identity, nil)
 }
 
-func (b *Broker) createSession(clientID string, version byte, opts session.Options, identity *cluster.SessionIdentityGuard) (sess *session.Session, created bool, err error) {
+// createSessionForConnection returns the session epoch observed while the
+// client-ID lock is still held. The protocol handler must present that epoch to
+// attachSession; a Clean Start replacement or another completed attachment in
+// between makes the claim stale and the connection is rejected.
+func (b *Broker) createSessionForConnection(clientID string, version byte, opts session.Options, requireBound bool) (sess *session.Session, created bool, expectedEpoch uint64, err error) {
+	identity := &cluster.SessionIdentityGuard{
+		ExternalID:   opts.ExternalID,
+		RequireBound: requireBound,
+	}
+	sess, created, err = b.createSession(clientID, version, opts, identity, &expectedEpoch)
+	return
+}
+
+func (b *Broker) createSession(clientID string, version byte, opts session.Options, identity *cluster.SessionIdentityGuard, expectedEpoch *uint64) (sess *session.Session, created bool, err error) {
 	sessionLock := b.sessionLocks.Key(clientID)
 	sessionLock.Lock()
-	var superseded []*session.Superseded
+	var retirements []*sessionRetirement
 	defer func() {
 		sessionLock.Unlock()
-		for _, retired := range superseded {
-			go b.drainSuperseded(context.Background(), retired)
+		for _, retired := range retirements {
+			go b.retireSession(context.Background(), retired)
 		}
 	}()
 
@@ -128,7 +142,7 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 
 	existing := b.sessionsMap.Get(clientID)
 	if opts.CleanStart && existing != nil {
-		retired := existing.DetachForTakeover(true)
+		retired := existing.DetachForTakeover()
 		// If the network callback already scheduled the Will, it consumed the
 		// in-memory copy. Ending the old session makes any stored delayed Will
 		// due now, while an already-published Will is absent from the store.
@@ -139,7 +153,11 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 			}
 			retired.Will = storedWill
 		}
-		superseded = append(superseded, retired)
+		retirements = append(retirements, &sessionRetirement{
+			clientID:    clientID,
+			superseded:  retired,
+			sessionEnds: true,
+		})
 		if err := b.destroySessionLocked(ctx, existing); err != nil {
 			return nil, false, err
 		}
@@ -176,6 +194,9 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 			}
 		}
 		ownershipAcquired = true
+		if expectedEpoch != nil {
+			*expectedEpoch = existing.Epoch()
+		}
 
 		return existing, false, nil
 	}
@@ -223,7 +244,10 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 			// already transferred and closed the session. Keep a delayed Will
 			// pending for the real owner; a zero-delay Will is due now.
 			if takeoverWill.Delay == 0 {
-				superseded = append(superseded, &session.Superseded{ClientID: clientID, Will: takeoverWill})
+				retirements = append(retirements, &sessionRetirement{
+					clientID:   clientID,
+					superseded: &session.Superseded{Will: takeoverWill},
+				})
 			} else if b.stores.wills != nil {
 				if err := b.stores.wills.Set(ctx, clientID, takeoverWill); err != nil {
 					return nil, false, fmt.Errorf("failed to preserve takeover will: %w", err)
@@ -233,10 +257,10 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 			// The old connection's Will belongs to that connection, not to the
 			// new CONNECT. A continued session cancels only a delayed Will; when
 			// the old session was discarded, every Will is due immediately.
-			superseded = append(superseded, &session.Superseded{
-				ClientID:    clientID,
-				Will:        takeoverWill,
-				SessionEnds: takeoverState == nil,
+			retirements = append(retirements, &sessionRetirement{
+				clientID:    clientID,
+				superseded:  &session.Superseded{Will: takeoverWill},
+				sessionEnds: takeoverState == nil,
 			})
 		}
 	}
@@ -294,8 +318,8 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 		}
 	}
 
-	s.SetOnDisconnect(func(s *session.Session, graceful bool) {
-		b.handleDisconnect(s, graceful)
+	s.SetOnDisconnectWithEpoch(func(s *session.Session, graceful bool, epoch uint64) {
+		b.handleDisconnect(s, graceful, epoch)
 	})
 
 	if b.cluster != nil {
@@ -323,8 +347,70 @@ func (b *Broker) createSession(clientID string, version byte, opts session.Optio
 
 		return nil, false, cluster.ErrSessionIdentityMismatch
 	}
+	if expectedEpoch != nil {
+		*expectedEpoch = s.Epoch()
+	}
 
 	return s, true, nil
+}
+
+var errSessionReplacedBeforeAttach = errors.New("session replaced before connection attachment")
+
+// attachSession commits a CONNECT to the session claim returned by
+// createSessionForConnection. Identity, epoch verification, stored delayed-Will
+// cancellation, connection attachment, auth binding, and persistence happen
+// under the same client-ID lock. A callback or Clean Start replacement can
+// therefore run either before this operation or after it, but cannot interleave
+// client-ID-scoped state with the new connection generation.
+func (b *Broker) attachSession(ctx context.Context, s *session.Session, expectedEpoch uint64, conn core.Connection, opts session.ConnectOptions, expiryInterval *uint32) (epoch uint64, err error) {
+	if s == nil {
+		return 0, errSessionReplacedBeforeAttach
+	}
+
+	sessionLock := b.sessionLocks.Key(s.ID)
+	sessionLock.Lock()
+	var retirement *sessionRetirement
+	defer func() {
+		sessionLock.Unlock()
+		if retirement != nil {
+			go b.retireSession(context.WithoutCancel(ctx), retirement)
+		}
+	}()
+
+	if b.sessionsMap.Get(s.ID) != s || s.Epoch() != expectedEpoch {
+		return 0, errSessionReplacedBeforeAttach
+	}
+
+	// Only delayed Wills are persisted. Reconnecting before their deadline
+	// cancels the previous generation's Will while the disconnect callback is
+	// fenced by this same lock and the epoch transition below.
+	if b.stores.wills != nil {
+		_, getErr := b.stores.wills.Get(ctx, s.ID)
+		switch {
+		case getErr == nil:
+			if err := b.stores.wills.Delete(ctx, s.ID); err != nil {
+				return 0, fmt.Errorf("failed to cancel previous session will: %w", err)
+			}
+		case !errors.Is(getErr, storage.ErrNotFound):
+			return 0, fmt.Errorf("failed to load previous session will: %w", getErr)
+		}
+	}
+
+	epoch, superseded := s.ConnectWithOptions(conn, opts)
+	if expiryInterval != nil {
+		s.SetExpiryInterval(*expiryInterval)
+	}
+	b.BindExternalID(s.ID, s.ExternalIdentity())
+	b.persistSessionInfo(s)
+
+	if superseded != nil {
+		retirement = &sessionRetirement{
+			clientID:   s.ID,
+			superseded: superseded,
+		}
+	}
+
+	return epoch, nil
 }
 
 // sessionRestore is the decision about which persisted or migrated state a
@@ -572,8 +658,11 @@ func (b *Broker) HandleSessionLeaseLost(_ context.Context, clientIDs []string) {
 	}
 }
 
-// handleDisconnect handles session disconnect.
-func (b *Broker) handleDisconnect(s *session.Session, graceful bool) {
+// handleDisconnect handles one physical connection disconnect. Notifications
+// describe the socket and are always emitted; client-ID-scoped cleanup is
+// allowed only while both the session identity and disconnected epoch remain
+// current.
+func (b *Broker) handleDisconnect(s *session.Session, graceful bool, disconnectEpoch uint64) {
 	sessionLock := b.sessionLocks.Key(s.ID)
 	sessionLock.Lock()
 	var publishWill *storage.WillMessage
@@ -600,10 +689,10 @@ func (b *Broker) handleDisconnect(s *session.Session, graceful bool) {
 	// a session that has already been replaced.
 	notifyDisconnect = true
 
-	// Disconnect callbacks run asynchronously. A clean reconnect can replace
-	// the session before the old callback starts; that stale callback must not
-	// delete or persist state belonging to the replacement session.
-	if b.sessionsMap.Get(s.ID) != s {
+	// Disconnect callbacks run asynchronously. A Clean Start may replace the
+	// session pointer, while a persistent reconnect reuses it with a new epoch.
+	// Neither stale generation may delete or persist replacement state.
+	if b.sessionsMap.Get(s.ID) != s || s.Epoch() != disconnectEpoch {
 		return
 	}
 
@@ -614,19 +703,19 @@ func (b *Broker) handleDisconnect(s *session.Session, graceful bool) {
 	b.persistSessionInfo(s)
 	sessionEnds := s.CleanStart && s.ExpiryInterval == 0
 	will := s.TakeWill()
-	if b.stores.wills != nil {
-		ctx := context.Background()
-		if !graceful && will != nil {
-			if sessionEnds {
-				publishWill = will
-			} else {
-				b.stores.wills.Set(ctx, s.ID, will) //nolint:errcheck // best-effort will persistence on disconnect
-			}
-		} else if graceful {
-			b.stores.wills.Delete(ctx, s.ID) //nolint:errcheck // best-effort will cleanup on graceful disconnect
+	if !graceful && will != nil {
+		switch {
+		case will.Delay == 0 || sessionEnds:
+			// A zero-delay Will is due at the physical disconnect. Clean Start
+			// also ends the session, so MQTT requires a delayed Will immediately.
+			publishWill = will
+		case b.stores.wills != nil:
+			// Only delayed Wills survive in storage. attachSession cancels this
+			// record atomically if the persistent session reconnects in time.
+			b.stores.wills.Set(context.Background(), s.ID, will) //nolint:errcheck // best-effort delayed-Will persistence
 		}
-	} else if !graceful && sessionEnds {
-		publishWill = will
+	} else if graceful && b.stores.wills != nil {
+		b.stores.wills.Delete(context.Background(), s.ID) //nolint:errcheck // best-effort Will cleanup on graceful disconnect
 	}
 	if b.stores.messages != nil {
 		msgs := s.OfflineQueue().Drain()
@@ -928,11 +1017,11 @@ func (b *Broker) restoreSubscriptionsFromTakeover(s *session.Session, state *clu
 func (b *Broker) GetSessionStateAndClose(ctx context.Context, clientID string, identity *cluster.SessionIdentityGuard) (*clusterv1.SessionState, error) {
 	sessionLock := b.sessionLocks.Key(clientID)
 	sessionLock.Lock()
-	var superseded *session.Superseded
+	var retirement *sessionRetirement
 	defer func() {
 		sessionLock.Unlock()
-		if superseded != nil {
-			go b.drainSuperseded(context.WithoutCancel(ctx), superseded)
+		if retirement != nil {
+			go b.retireSession(context.WithoutCancel(ctx), retirement)
 		}
 	}()
 
@@ -1023,8 +1112,9 @@ func (b *Broker) GetSessionStateAndClose(ctx context.Context, clientID string, i
 	// and close after unlocking. The Will travels in state so the new owner can
 	// decide whether Clean Start ends the session or a reconnect cancels its
 	// delay; the old owner must not publish it independently.
-	superseded = s.DetachForTakeover(false)
+	superseded := s.DetachForTakeover()
 	superseded.Will = nil
+	retirement = &sessionRetirement{clientID: clientID, superseded: superseded}
 	if err := b.destroySessionForTakeoverLocked(ctx, s); err != nil {
 		return nil, fmt.Errorf("failed to destroy session: %w", err)
 	}

--- a/mqtt/broker/session_identity_bench_test.go
+++ b/mqtt/broker/session_identity_bench_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/absmach/fluxmq/mqtt/session"
+	"github.com/absmach/fluxmq/storage/memory"
+)
+
+const benchIdentity = "bench-entity"
+
+// BenchmarkCreateSessionForIdentity covers the CONNECT path that resolves and
+// binds a session identity. The publish benchmarks do not reach it: they run
+// without an auth engine, so authorization short-circuits before any identity
+// is resolved.
+func BenchmarkCreateSessionForIdentity(b *testing.B) {
+	b.Run("new session", func(b *testing.B) {
+		br := NewBroker(memory.New(), nil)
+		b.Cleanup(func() { _ = br.Close() })
+
+		b.ReportAllocs()
+
+		// b.Loop decides the iteration count as it goes, so the client ID is
+		// built per iteration. That cost is identical on both sides of a
+		// comparison and does not hide the identity work being measured.
+		i := 0
+		for b.Loop() {
+			if _, _, err := br.CreateSessionForIdentity("bench-new-"+strconv.Itoa(i), 5, session.Options{
+				ExternalID:     benchIdentity,
+				ExpiryInterval: 300,
+			}, false); err != nil {
+				b.Fatal(err)
+			}
+			i++
+		}
+	})
+
+	b.Run("resume bound session", func(b *testing.B) {
+		br := NewBroker(memory.New(), nil)
+		b.Cleanup(func() { _ = br.Close() })
+
+		opts := session.Options{ExternalID: benchIdentity, ExpiryInterval: 300}
+		if _, _, err := br.CreateSessionForIdentity("bench-resume", 5, opts, false); err != nil {
+			b.Fatal(err)
+		}
+
+		b.ReportAllocs()
+
+		for b.Loop() {
+			if _, _, err := br.CreateSessionForIdentity("bench-resume", 5, opts, false); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("resume bound session over mtls", func(b *testing.B) {
+		br := NewBroker(memory.New(), nil)
+		b.Cleanup(func() { _ = br.Close() })
+
+		opts := session.Options{ExternalID: benchIdentity, ExpiryInterval: 300}
+		if _, _, err := br.CreateSessionForIdentity("bench-resume-mtls", 5, opts, true); err != nil {
+			b.Fatal(err)
+		}
+
+		b.ReportAllocs()
+
+		for b.Loop() {
+			if _, _, err := br.CreateSessionForIdentity("bench-resume-mtls", 5, opts, true); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/mqtt/broker/session_identity_takeover_test.go
+++ b/mqtt/broker/session_identity_takeover_test.go
@@ -10,6 +10,7 @@ import (
 
 	corebroker "github.com/absmach/fluxmq/broker"
 	"github.com/absmach/fluxmq/cluster"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/mqtt/session"
 	clusterv1 "github.com/absmach/fluxmq/pkg/proto/cluster/v1"
 	"github.com/absmach/fluxmq/storage/memory"
@@ -77,7 +78,8 @@ func TestSessionTakeoverMatchingIdentityTransfersState(t *testing.T) {
 		ExpiryInterval: 300,
 	})
 	require.NoError(t, err)
-	_, err = s.Connect(&mockConnection{})
+	conn := newSyncConn()
+	_, err = s.Connect(conn)
 	require.NoError(t, err)
 
 	state, err := b.GetSessionStateAndClose(context.Background(), s.ID, &cluster.SessionIdentityGuard{
@@ -89,6 +91,14 @@ func TestSessionTakeoverMatchingIdentityTransfersState(t *testing.T) {
 	require.Equal(t, mtlsEntityA, state.ExternalId)
 	require.Nil(t, b.Get(s.ID))
 	require.False(t, s.IsConnected())
+	waitFor(t, func() bool {
+		for _, p := range conn.writtenPackets() {
+			if d, ok := p.(*v5.Disconnect); ok && d.ReasonCode == v5.DisconnectSessionTakenOver {
+				return true
+			}
+		}
+		return false
+	}, "transferred v5 client receives DISCONNECT 0x8E")
 }
 
 func TestMQTTMTLSClusterTakeoverPropagatesIdentityGuard(t *testing.T) {

--- a/mqtt/broker/session_identity_takeover_test.go
+++ b/mqtt/broker/session_identity_takeover_test.go
@@ -71,6 +71,8 @@ func TestSessionTakeoverIdentityMismatchLeavesOwnerUntouched(t *testing.T) {
 func TestSessionTakeoverMatchingIdentityTransfersState(t *testing.T) {
 	b := NewBroker(memory.New(), nil)
 	t.Cleanup(func() { require.NoError(t, b.Close()) })
+	hook := &disconnectSpyHook{}
+	b.SetEventHook(hook)
 
 	s, _, err := b.CreateSession("bound-client", 5, session.Options{
 		ExternalID:     mtlsEntityA,
@@ -99,6 +101,8 @@ func TestSessionTakeoverMatchingIdentityTransfersState(t *testing.T) {
 		}
 		return false
 	}, "transferred v5 client receives DISCONNECT 0x8E")
+	waitFor(t, func() bool { return len(hook.snapshot()) == 1 }, "cross-node retirement emits its disconnect event")
+	require.Equal(t, []string{"takeover"}, hook.snapshot())
 }
 
 func TestMQTTMTLSClusterTakeoverPropagatesIdentityGuard(t *testing.T) {

--- a/mqtt/broker/session_identity_takeover_test.go
+++ b/mqtt/broker/session_identity_takeover_test.go
@@ -102,7 +102,7 @@ func TestSessionTakeoverMatchingIdentityTransfersState(t *testing.T) {
 		return false
 	}, "transferred v5 client receives DISCONNECT 0x8E")
 	waitFor(t, func() bool { return len(hook.snapshot()) == 1 }, "cross-node retirement emits its disconnect event")
-	require.Equal(t, []string{"takeover"}, hook.snapshot())
+	require.Equal(t, []string{reasonTakeover}, hook.snapshot())
 }
 
 func TestMQTTMTLSClusterTakeoverPropagatesIdentityGuard(t *testing.T) {

--- a/mqtt/broker/session_identity_test.go
+++ b/mqtt/broker/session_identity_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/absmach/fluxmq/cluster"
+	"github.com/absmach/fluxmq/message"
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/mqtt/session"
 	clusterv1 "github.com/absmach/fluxmq/pkg/proto/cluster/v1"
 	"github.com/absmach/fluxmq/storage"
@@ -28,13 +30,17 @@ const (
 type takeoverCluster struct {
 	cluster.Cluster
 	state     *clusterv1.SessionState
+	remoteID  string
 	takeovers int
 	released  int
 }
 
 func (c *takeoverCluster) NodeID() string { return "node-local" }
 
-func (c *takeoverCluster) GetSessionOwner(context.Context, string) (string, bool, error) {
+func (c *takeoverCluster) GetSessionOwner(_ context.Context, clientID string) (string, bool, error) {
+	if c.remoteID != "" && clientID != c.remoteID {
+		return "", false, nil
+	}
 	return "node-remote", true, nil
 }
 
@@ -58,6 +64,8 @@ func (c *takeoverCluster) AddSubscription(context.Context, string, string, byte,
 }
 
 func (c *takeoverCluster) RemoveAllSubscriptions(context.Context, string) error { return nil }
+
+func (c *takeoverCluster) RoutePublish(context.Context, *message.Envelope) error { return nil }
 
 func (c *takeoverCluster) GetSubscriptionsForClient(context.Context, string) ([]*storage.Subscription, error) {
 	return nil, nil
@@ -186,6 +194,55 @@ func TestCreateSessionTakeoverIdentity(t *testing.T) {
 		assert.Equal(t, identityA, s.ExternalIdentity())
 		assert.Empty(t, s.GetSubscriptions(), "state bound to no principal is not inherited")
 	})
+}
+
+func TestCreateSessionRemoteCleanStartRetiresTransferredWill(t *testing.T) {
+	const clientID = "remote-clean-start"
+	const oldWillTopic = "clients/remote-clean-start/old"
+	const newWillTopic = "clients/remote-clean-start/new"
+
+	cl := &takeoverCluster{
+		remoteID: clientID,
+		state: &clusterv1.SessionState{
+			ExpiryInterval: 300,
+			Will: &clusterv1.WillMessage{
+				Topic:   oldWillTopic,
+				Payload: []byte("old-offline"),
+				Delay:   60,
+			},
+		},
+	}
+	b := NewBroker(memory.New(), cl)
+	t.Cleanup(func() { _ = b.Close() })
+
+	sub, _, err := b.CreateSession("remote-clean-start-sub", 5, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	subConn := newSyncConn()
+	_, err = sub.Connect(subConn)
+	require.NoError(t, err)
+	require.NoError(t, b.subscribe(sub, oldWillTopic, 0, storage.SubscribeOptions{}))
+
+	incomingWill := &storage.WillMessage{
+		ClientID: clientID,
+		Topic:    newWillTopic,
+		Payload:  []byte("new-offline"),
+	}
+	s, created, err := b.CreateSession(clientID, 5, session.Options{
+		CleanStart: true,
+		Will:       incomingWill,
+	})
+	require.NoError(t, err)
+	require.True(t, created)
+	require.Equal(t, newWillTopic, s.GetWill().Topic, "the transferred Will must not replace the new CONNECT's Will")
+
+	waitFor(t, func() bool {
+		for _, p := range subConn.writtenPackets() {
+			if pub, ok := p.(*v5.Publish); ok && pub.TopicName == oldWillTopic {
+				return string(pub.Payload) == "old-offline"
+			}
+		}
+		return false
+	}, "Clean Start publishes the transferred delayed Will immediately")
 }
 
 func TestCreateSessionPersistedIdentity(t *testing.T) {

--- a/mqtt/broker/session_orphan_ownership_test.go
+++ b/mqtt/broker/session_orphan_ownership_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+
+	"github.com/absmach/fluxmq/cluster"
+	"github.com/absmach/fluxmq/mqtt/session"
+	"github.com/absmach/fluxmq/storage"
+	"github.com/absmach/fluxmq/storage/memory"
+	"github.com/stretchr/testify/require"
+)
+
+var errSessionOwnedElsewhere = errors.New("session owned by another node")
+
+// sharedClusterState is the one etcd both nodes in these tests talk to: a
+// session owner key and the routing entries keyed by client ID.
+type sharedClusterState struct {
+	mu    sync.Mutex
+	owner string
+	subs  map[string][]*storage.Subscription
+}
+
+func newSharedClusterState() *sharedClusterState {
+	return &sharedClusterState{subs: make(map[string][]*storage.Subscription)}
+}
+
+// raceCluster is one node's view of that state.
+//
+// GetSessionOwner always reports no owner. It stands in for the window between
+// a node reading ownership and another node acquiring it: both nodes see the
+// client ID as free, and only AcquireSession is authoritative about who got it.
+type raceCluster struct {
+	cluster.Cluster
+	state  *sharedClusterState
+	nodeID string
+}
+
+func (c *raceCluster) NodeID() string { return c.nodeID }
+
+func (c *raceCluster) GetSessionOwner(context.Context, string) (string, bool, error) {
+	return "", false, nil
+}
+
+func (c *raceCluster) AcquireSession(_ context.Context, _, nodeID string) error {
+	c.state.mu.Lock()
+	defer c.state.mu.Unlock()
+
+	if c.state.owner != "" && c.state.owner != nodeID {
+		return errSessionOwnedElsewhere
+	}
+	c.state.owner = nodeID
+
+	return nil
+}
+
+func (c *raceCluster) ReleaseSession(context.Context, string) error {
+	c.state.mu.Lock()
+	defer c.state.mu.Unlock()
+
+	if c.state.owner == c.nodeID {
+		c.state.owner = ""
+	}
+
+	return nil
+}
+
+func (c *raceCluster) GetSubscriptionsForClient(_ context.Context, clientID string) ([]*storage.Subscription, error) {
+	c.state.mu.Lock()
+	defer c.state.mu.Unlock()
+
+	return slices.Clone(c.state.subs[clientID]), nil
+}
+
+func (c *raceCluster) AddSubscription(_ context.Context, clientID, filter string, qos byte, opts storage.SubscribeOptions) error {
+	c.state.mu.Lock()
+	defer c.state.mu.Unlock()
+
+	c.state.subs[clientID] = append(c.state.subs[clientID], &storage.Subscription{
+		ClientID: clientID,
+		Filter:   filter,
+		QoS:      qos,
+		Options:  opts,
+	})
+
+	return nil
+}
+
+func (c *raceCluster) RemoveAllSubscriptions(_ context.Context, clientID string) error {
+	c.state.mu.Lock()
+	defer c.state.mu.Unlock()
+	delete(c.state.subs, clientID)
+
+	return nil
+}
+
+func (c *raceCluster) subscriptions(clientID string) []*storage.Subscription {
+	c.state.mu.Lock()
+	defer c.state.mu.Unlock()
+
+	return slices.Clone(c.state.subs[clientID])
+}
+
+// A CONNECT that loses the ownership race must leave the winner's routes alone.
+//
+// Both nodes read the client ID as unowned, so the loser reaches createSession
+// believing the session is its own to clean up. Cleaning up before acquiring
+// ownership deletes every cluster route under that client ID — including the
+// ones the winner has just subscribed — and the loser's own CONNECT then fails,
+// leaving nobody to put them back. Cross-node publishes miss a live subscriber.
+func TestOrphanCleanupDoesNotRemoveWinningNodesSubscriptions(t *testing.T) {
+	const clientID = "contended-client"
+	const filter = "sensors/+/temp"
+
+	state := newSharedClusterState()
+	// A route left behind by an earlier session under this client ID: without
+	// one there is nothing for the cleanup to find and nothing to delete.
+	state.subs[clientID] = []*storage.Subscription{{ClientID: clientID, Filter: "legacy/#", QoS: 0}}
+
+	winnerCluster := &raceCluster{state: state, nodeID: "node-winner"}
+	winner := NewBroker(memory.New(), winnerCluster)
+	defer winner.Close()
+
+	loserCluster := &raceCluster{state: state, nodeID: "node-loser"}
+	loser := NewBroker(memory.New(), loserCluster)
+	defer loser.Close()
+
+	// The winner takes the client ID and subscribes.
+	s, created, err := winner.CreateSession(clientID, 5, session.Options{ExpiryInterval: 300})
+	require.NoError(t, err)
+	require.True(t, created)
+	require.NoError(t, winner.subscribe(s, filter, 1, storage.SubscribeOptions{}))
+	require.Len(t, winnerCluster.subscriptions(clientID), 1, "the winner's route is in the cluster")
+
+	// The loser proceeds on its stale ownership read.
+	got, created, err := loser.CreateSession(clientID, 5, session.Options{ExpiryInterval: 300})
+	require.ErrorIs(t, err, errSessionOwnedElsewhere)
+	require.Nil(t, got)
+	require.False(t, created)
+
+	subs := loserCluster.subscriptions(clientID)
+	require.Len(t, subs, 1, "the loser must not remove the winner's cluster subscriptions")
+	require.Equal(t, filter, subs[0].Filter)
+	require.Contains(t, winner.sessionsMap.Get(clientID).GetSubscriptions(), filter, "the winner keeps its subscription")
+}
+
+// The winner's own cleanup is legitimate: it holds the client ID, so the routes
+// a previous session left there are its to clear.
+func TestOwningNodeClearsOrphanedClusterSubscriptions(t *testing.T) {
+	const clientID = "sole-owner"
+
+	state := newSharedClusterState()
+	state.subs[clientID] = []*storage.Subscription{{ClientID: clientID, Filter: "legacy/#", QoS: 0}}
+
+	cl := &raceCluster{state: state, nodeID: "node-winner"}
+	b := NewBroker(memory.New(), cl)
+	defer b.Close()
+
+	s, created, err := b.CreateSession(clientID, 5, session.Options{ExpiryInterval: 300})
+	require.NoError(t, err)
+	require.True(t, created)
+	require.Empty(t, s.GetSubscriptions(), "a fresh session must not inherit the orphaned route")
+	require.Empty(t, cl.subscriptions(clientID), "the orphaned route is cleared by the node that owns the client ID")
+}

--- a/mqtt/broker/session_orphan_ownership_test.go
+++ b/mqtt/broker/session_orphan_ownership_test.go
@@ -19,16 +19,27 @@ import (
 
 var errSessionOwnedElsewhere = errors.New("session owned by another node")
 
+// orphanFilter is the route a previous session left under a contended client ID.
+const orphanFilter = "legacy/#"
+
 // sharedClusterState is the one etcd both nodes in these tests talk to: a
 // session owner key and the routing entries keyed by client ID.
 type sharedClusterState struct {
 	mu    sync.Mutex
 	owner string
 	subs  map[string][]*storage.Subscription
+	// calls records the cluster operations in the order they were made, so a
+	// test can pin what a CONNECT announced and when.
+	calls []string
 }
 
 func newSharedClusterState() *sharedClusterState {
 	return &sharedClusterState{subs: make(map[string][]*storage.Subscription)}
+}
+
+// record must be called with the state lock held.
+func (s *sharedClusterState) record(nodeID, op string) {
+	s.calls = append(s.calls, nodeID+":"+op)
 }
 
 // raceCluster is one node's view of that state.
@@ -51,6 +62,7 @@ func (c *raceCluster) GetSessionOwner(context.Context, string) (string, bool, er
 func (c *raceCluster) AcquireSession(_ context.Context, _, nodeID string) error {
 	c.state.mu.Lock()
 	defer c.state.mu.Unlock()
+	c.state.record(c.nodeID, "acquire")
 
 	if c.state.owner != "" && c.state.owner != nodeID {
 		return errSessionOwnedElsewhere
@@ -95,9 +107,24 @@ func (c *raceCluster) AddSubscription(_ context.Context, clientID, filter string
 func (c *raceCluster) RemoveAllSubscriptions(_ context.Context, clientID string) error {
 	c.state.mu.Lock()
 	defer c.state.mu.Unlock()
+	c.state.record(c.nodeID, "remove_all_subscriptions")
 	delete(c.state.subs, clientID)
 
 	return nil
+}
+
+func (c *raceCluster) callLog() []string {
+	c.state.mu.Lock()
+	defer c.state.mu.Unlock()
+
+	return slices.Clone(c.state.calls)
+}
+
+func (c *raceCluster) currentOwner() string {
+	c.state.mu.Lock()
+	defer c.state.mu.Unlock()
+
+	return c.state.owner
 }
 
 func (c *raceCluster) subscriptions(clientID string) []*storage.Subscription {
@@ -121,7 +148,7 @@ func TestOrphanCleanupDoesNotRemoveWinningNodesSubscriptions(t *testing.T) {
 	state := newSharedClusterState()
 	// A route left behind by an earlier session under this client ID: without
 	// one there is nothing for the cleanup to find and nothing to delete.
-	state.subs[clientID] = []*storage.Subscription{{ClientID: clientID, Filter: "legacy/#", QoS: 0}}
+	state.subs[clientID] = []*storage.Subscription{{ClientID: clientID, Filter: orphanFilter, QoS: 0}}
 
 	winnerCluster := &raceCluster{state: state, nodeID: "node-winner"}
 	winner := NewBroker(memory.New(), winnerCluster)
@@ -156,7 +183,7 @@ func TestOwningNodeClearsOrphanedClusterSubscriptions(t *testing.T) {
 	const clientID = "sole-owner"
 
 	state := newSharedClusterState()
-	state.subs[clientID] = []*storage.Subscription{{ClientID: clientID, Filter: "legacy/#", QoS: 0}}
+	state.subs[clientID] = []*storage.Subscription{{ClientID: clientID, Filter: orphanFilter, QoS: 0}}
 
 	cl := &raceCluster{state: state, nodeID: "node-winner"}
 	b := NewBroker(memory.New(), cl)
@@ -167,4 +194,86 @@ func TestOwningNodeClearsOrphanedClusterSubscriptions(t *testing.T) {
 	require.True(t, created)
 	require.Empty(t, s.GetSubscriptions(), "a fresh session must not inherit the orphaned route")
 	require.Empty(t, cl.subscriptions(clientID), "the orphaned route is cleared by the node that owns the client ID")
+}
+
+// Announcing ownership is visible to the rest of the cluster, so a CONNECT that
+// is going to be rejected must never announce it. Taking the client ID before
+// the persisted identity is checked lets a mismatched client hold it briefly: a
+// legitimate node can begin a takeover against that announcement, block on this
+// node's client-ID lock, and find no session here once the rejected CONNECT has
+// released ownership. Its takeover then finalizes against an absent owner and
+// completes with no state, while the durable session stays behind on this node.
+func TestRejectedIdentityNeverAcquiresOwnership(t *testing.T) {
+	const clientID = "mismatched-identity"
+
+	store := memory.New()
+	cl := &raceCluster{state: newSharedClusterState(), nodeID: "node-a"}
+	b := NewBroker(store, cl)
+	defer b.Close()
+
+	require.NoError(t, store.Sessions().Save(&storage.Session{
+		ClientID:       clientID,
+		Version:        5,
+		ExternalID:     identityA,
+		ExpiryInterval: 300,
+	}))
+
+	got, created, err := b.CreateSessionForIdentity(clientID, 5, session.Options{
+		ExternalID:     identityB,
+		ExpiryInterval: 300,
+	}, false)
+	require.ErrorIs(t, err, cluster.ErrSessionIdentityMismatch)
+	require.Nil(t, got)
+	require.False(t, created)
+
+	require.NotContains(t, cl.callLog(), "node-a:acquire", "a rejected CONNECT must not announce ownership")
+	require.Empty(t, cl.currentOwner())
+
+	stored, err := store.Sessions().Get(clientID)
+	require.NoError(t, err)
+	require.Equal(t, identityA, stored.ExternalID, "the rejected CONNECT leaves the owner's session alone")
+}
+
+// The counterpart: state this CONNECT does discard is deleted, and only once
+// the client ID is owned here, so the deletion never reaches a session that is
+// live on another node.
+func TestDiscardedSessionIsPurgedAfterOwnership(t *testing.T) {
+	const clientID = "unbound-discarded"
+
+	store := memory.New()
+	cl := &raceCluster{state: newSharedClusterState(), nodeID: "node-a"}
+	b := NewBroker(store, cl)
+	defer b.Close()
+
+	// A session predating certificate binding: no principal on the record.
+	cl.state.subs[clientID] = []*storage.Subscription{{ClientID: clientID, Filter: orphanFilter, QoS: 0}}
+	require.NoError(t, store.Sessions().Save(&storage.Session{
+		ClientID:       clientID,
+		Version:        5,
+		ExpiryInterval: 300,
+	}))
+	require.NoError(t, store.Subscriptions().Add(&storage.Subscription{
+		ClientID: clientID,
+		Filter:   orphanFilter,
+		QoS:      1,
+	}))
+
+	s, created, err := b.CreateSessionForIdentity(clientID, 5, session.Options{
+		ExternalID:     identityA,
+		ExpiryInterval: 300,
+	}, true)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.Empty(t, s.GetSubscriptions(), "the discarded session's subscriptions are not inherited")
+
+	subs, err := store.Subscriptions().GetForClient(clientID)
+	require.NoError(t, err)
+	require.Empty(t, subs, "the discarded session is purged")
+
+	calls := cl.callLog()
+	acquired := slices.Index(calls, "node-a:acquire")
+	removed := slices.Index(calls, "node-a:remove_all_subscriptions")
+	require.NotEqual(t, -1, acquired, "the accepted CONNECT takes the client ID")
+	require.NotEqual(t, -1, removed, "the discarded session's cluster routes are cleared")
+	require.Less(t, acquired, removed, "the client ID is owned before its cluster routes are deleted")
 }

--- a/mqtt/broker/session_ownership_test.go
+++ b/mqtt/broker/session_ownership_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/absmach/fluxmq/cluster"
 	"github.com/absmach/fluxmq/mqtt/session"
+	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/storage/memory"
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +20,7 @@ type ownershipFailCluster struct {
 	err error
 }
 
-func (c *ownershipFailCluster) NodeID() string { return "node-a" }
+func (c *ownershipFailCluster) NodeID() string { return testNodeID }
 
 func (c *ownershipFailCluster) GetSessionOwner(context.Context, string) (string, bool, error) {
 	return "", false, nil
@@ -27,6 +28,10 @@ func (c *ownershipFailCluster) GetSessionOwner(context.Context, string) (string,
 
 func (c *ownershipFailCluster) AcquireSession(context.Context, string, string) error {
 	return c.err
+}
+
+func (c *ownershipFailCluster) GetSubscriptionsForClient(context.Context, string) ([]*storage.Subscription, error) {
+	return nil, nil
 }
 
 func TestCreateSessionRejectsFailedOwnershipClaim(t *testing.T) {

--- a/mqtt/broker/session_rollback_test.go
+++ b/mqtt/broker/session_rollback_test.go
@@ -6,14 +6,19 @@ package broker
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/absmach/fluxmq/cluster"
+	"github.com/absmach/fluxmq/message"
 	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
 	"github.com/absmach/fluxmq/mqtt/session"
 	"github.com/absmach/fluxmq/storage"
 	"github.com/absmach/fluxmq/storage/memory"
+	"github.com/absmach/fluxmq/storage/messages"
 	"github.com/stretchr/testify/require"
 )
 
@@ -99,6 +104,64 @@ func TestAttachFailureKeepsRestoredDurableSession(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, subs, 1, "persisted subscriptions must survive a failed CONNECT")
 	require.Equal(t, filter, subs[0].Filter)
+}
+
+// Restoring a session moves its queued and inflight messages out of storage and
+// into the session object, so a rollback that only hands back the object drops
+// them: nothing is left in storage and the release frees the envelopes.
+func TestAttachFailureKeepsRestoredMessages(t *testing.T) {
+	store := newFaultyStore()
+	b := NewBroker(store, nil)
+	defer b.Close()
+
+	const clientID = "restored-messages"
+	const packetID = 7
+
+	require.NoError(t, store.Sessions().Save(&storage.Session{
+		ClientID:       clientID,
+		Version:        5,
+		ExpiryInterval: 300,
+	}))
+
+	queued := message.New("sensors/1/temp", []byte("queued-payload"))
+	require.NoError(t, store.Messages().Store(clientID+queuePrefix+"0", queued))
+	message.Release(queued)
+
+	pending := message.New("sensors/1/humidity", []byte("inflight-payload"))
+	pending.BrokerMeta.Delivery.PacketID = packetID
+	pending.BrokerMeta.Delivery.InflightDirection = byte(messages.Outbound)
+	pending.BrokerMeta.Delivery.InflightState = byte(messages.StatePublishSent)
+	inflightKey := fmt.Sprintf("%s%s%d/%d", clientID, inflightPrefix, messages.Outbound, packetID)
+	require.NoError(t, store.Messages().Store(inflightKey, pending))
+	message.Release(pending)
+
+	store.wills.failGet.Store(true)
+
+	s, _, claim, err := b.createSessionForConnection(clientID, 5, session.Options{
+		ExpiryInterval: 300,
+	}, false)
+	require.NoError(t, err)
+	require.Equal(t, 1, s.OfflineQueue().Len(), "the restore moved the queued message into the session")
+	require.Len(t, s.Inflight().GetAll(), 1, "the restore moved the inflight message into the session")
+
+	_, err = b.attachSession(context.Background(), s, claim, newSyncConn(), session.ConnectOptions{
+		Version:        5,
+		KeepAlive:      time.Minute,
+		ReceiveMaximum: 16,
+	}, nil)
+	require.ErrorIs(t, err, errWillStoreUnavailable)
+
+	b.releaseUnattachedSession(context.Background(), s, claim.epoch)
+
+	restoredQueue, err := store.Messages().List(clientID + queuePrefix)
+	require.NoError(t, err)
+	require.Len(t, restoredQueue, 1, "queued messages must survive a failed CONNECT")
+	require.Equal(t, []byte("queued-payload"), restoredQueue[0].PayloadBytes())
+
+	restoredInflight, err := store.Messages().List(clientID + inflightPrefix)
+	require.NoError(t, err)
+	require.Len(t, restoredInflight, 1, "inflight messages must survive a failed CONNECT")
+	require.Equal(t, uint16(packetID), restoredInflight[0].BrokerMeta.Delivery.PacketID)
 }
 
 // A persistent CONNECT reuses the session pointer, so identity alone cannot tell
@@ -206,7 +269,9 @@ func TestExpireSessionPublishesDueWill(t *testing.T) {
 		return err == nil
 	}, "disconnect callback stores the delayed Will")
 
-	b.expireSession(context.Background(), clientID)
+	// A deadline in the future stands in for the wait, so the sweep's own expiry
+	// check runs for real without the test sleeping through it.
+	b.expireSession(context.Background(), s, time.Now().Add(time.Hour))
 
 	require.Nil(t, b.sessionsMap.Get(clientID))
 	waitFor(t, func() bool {
@@ -219,22 +284,166 @@ func TestExpireSessionPublishesDueWill(t *testing.T) {
 	}, "an expiring session publishes its delayed Will")
 }
 
+// A session a CONNECT has installed but not attached to has never held a
+// connection, so it has no disconnect timestamp. Read as one, it looks overdue
+// by the whole span since the zero time, and the sweep destroys the session
+// together with the durable state it just restored.
+func TestExpireSessionsSkipsUnattachedSession(t *testing.T) {
+	store := memory.New()
+	b := NewBroker(store, nil)
+	defer b.Close()
+
+	const clientID = "unattached-session"
+	const filter = "sensors/+/temp"
+
+	require.NoError(t, store.Sessions().Save(&storage.Session{
+		ClientID:       clientID,
+		Version:        5,
+		ExpiryInterval: 300,
+	}))
+	require.NoError(t, store.Subscriptions().Add(&storage.Subscription{
+		ClientID: clientID,
+		Filter:   filter,
+		QoS:      1,
+	}))
+
+	s, _, claim, err := b.createSessionForConnection(clientID, 5, session.Options{
+		ExpiryInterval: 300,
+	}, false)
+	require.NoError(t, err)
+	require.False(t, s.IsConnected(), "the CONNECT has not attached yet")
+
+	// The sweep runs between creation and attachment.
+	b.expireSessions()
+
+	require.Same(t, s, b.sessionsMap.Get(clientID), "an unattached session has not expired")
+	stored, err := store.Sessions().Get(clientID)
+	require.NoError(t, err)
+	require.NotNil(t, stored, "the restored durable session must survive the sweep")
+	subs, err := store.Subscriptions().GetForClient(clientID)
+	require.NoError(t, err)
+	require.Len(t, subs, 1)
+
+	_, err = b.attachSession(context.Background(), s, claim, newSyncConn(), session.ConnectOptions{
+		Version:        5,
+		KeepAlive:      time.Minute,
+		ReceiveMaximum: 16,
+	}, nil)
+	require.NoError(t, err)
+}
+
+// The sweep reads the expiry interval while the CONNECT it belongs to is still
+// setting it, so the read has to share the session's lock.
+func TestExpireSessionsRacesAttachingSession(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+
+	const clientID = "expiry-race"
+	s, _, claim, err := b.createSessionForConnection(clientID, 5, session.Options{
+		ExpiryInterval: 300,
+	}, false)
+	require.NoError(t, err)
+
+	var sweeps sync.WaitGroup
+	sweeps.Add(1)
+	go func() {
+		defer sweeps.Done()
+		for range 100 {
+			b.expireSessions()
+		}
+	}()
+
+	interval := uint32(600)
+	_, err = b.attachSession(context.Background(), s, claim, newSyncConn(), session.ConnectOptions{
+		Version:        5,
+		KeepAlive:      time.Minute,
+		ReceiveMaximum: 16,
+	}, &interval)
+	require.NoError(t, err)
+	sweeps.Wait()
+
+	require.Same(t, s, b.sessionsMap.Get(clientID))
+	require.True(t, s.IsConnected())
+}
+
+// The sweep picks candidates without the client-ID lock, so a reconnect can land
+// between the scan and the retirement. Destroying whatever answers to the client
+// ID by then takes out a live connection.
+func TestExpireSessionSkipsReconnectedSession(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+
+	const clientID = "reconnecting-client"
+	s, _, err := b.CreateSession(clientID, 5, session.Options{ExpiryInterval: 1})
+	require.NoError(t, err)
+	_, err = s.Connect(newSyncConn())
+	require.NoError(t, err)
+	require.NoError(t, s.Disconnect(false, v5.DisconnectUnspecifiedError))
+
+	// The scan observed an expired disconnected session; the client reconnects
+	// before the sweep takes the lock.
+	conn := newSyncConn()
+	_, err = s.Connect(conn)
+	require.NoError(t, err)
+
+	b.expireSession(context.Background(), s, time.Now().Add(time.Hour))
+
+	require.Same(t, s, b.sessionsMap.Get(clientID), "a reconnected session must survive the sweep")
+	require.True(t, s.IsConnected())
+}
+
+// The same race with a Clean Start replacement: the client ID now names a
+// different session, and the sweep must not destroy it on the old one's behalf.
+func TestExpireSessionSkipsReplacedSession(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+
+	const clientID = "replaced-client"
+	retired, _, err := b.CreateSession(clientID, 5, session.Options{ExpiryInterval: 1})
+	require.NoError(t, err)
+	_, err = retired.Connect(newSyncConn())
+	require.NoError(t, err)
+	require.NoError(t, retired.Disconnect(false, v5.DisconnectUnspecifiedError))
+
+	replacement, _, err := b.CreateSession(clientID, 5, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	require.NotSame(t, retired, replacement)
+	_, err = replacement.Connect(newSyncConn())
+	require.NoError(t, err)
+
+	b.expireSession(context.Background(), retired, time.Now().Add(time.Hour))
+
+	require.Same(t, replacement, b.sessionsMap.Get(clientID), "the replacement must survive the sweep")
+	require.True(t, replacement.IsConnected())
+}
+
 // Cancelling a delayed Will is reserved for "a new Network Connection to this
 // Session" [MQTT-3.1.3-9]. A CleanStart=false CONNECT that finds no persisted
-// session starts a fresh one, so the orphaned Will stays due.
-func TestFreshSessionDoesNotCancelOrphanedWill(t *testing.T) {
+// session starts a fresh one, so the session that armed the Will has ended and
+// the Will is due now [MQTT-3.1.2-8]. Merely declining to cancel it is not
+// enough: the delay sweep drops a pending Will once a session is connected
+// under that client ID, so it is never published.
+func TestFreshSessionPublishesOrphanedWill(t *testing.T) {
 	store := memory.New()
 	b := NewBroker(store, nil)
 	defer b.Close()
 
 	const clientID = "fresh-session-orphan"
-	orphan := &storage.WillMessage{
+	const willTopic = "clients/fresh-session-orphan/status"
+
+	sub, _, err := b.CreateSession("fresh-session-orphan-sub", 5, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	subConn := newSyncConn()
+	_, err = sub.Connect(subConn)
+	require.NoError(t, err)
+	require.NoError(t, b.subscribe(sub, willTopic, 0, storage.SubscribeOptions{}))
+
+	require.NoError(t, store.Wills().Set(context.Background(), clientID, &storage.WillMessage{
 		ClientID: clientID,
-		Topic:    "clients/fresh-session-orphan/status",
+		Topic:    willTopic,
 		Payload:  []byte(willPayloadOffline),
 		Delay:    3600,
-	}
-	require.NoError(t, store.Wills().Set(context.Background(), clientID, orphan))
+	}))
 
 	s, created, claim, err := b.createSessionForConnection(clientID, 5, session.Options{
 		ExpiryInterval: 300,
@@ -250,10 +459,140 @@ func TestFreshSessionDoesNotCancelOrphanedWill(t *testing.T) {
 	}, nil)
 	require.NoError(t, err)
 
-	kept, err := store.Wills().Get(context.Background(), clientID)
+	waitFor(t, func() bool {
+		for _, p := range subConn.writtenPackets() {
+			if pub, ok := p.(*v5.Publish); ok && pub.TopicName == willTopic {
+				return string(pub.Payload) == willPayloadOffline
+			}
+		}
+		return false
+	}, "a fresh session publishes the previous session's orphaned Will")
+
+	_, err = store.Wills().Get(context.Background(), clientID)
+	require.ErrorIs(t, err, storage.ErrNotFound, "the claimed Will must not be publishable twice")
+}
+
+// orphanSubscriptionCluster holds cluster routing entries for a client ID whose
+// session is gone from this node, and counts the writes made to clear them.
+type orphanSubscriptionCluster struct {
+	cluster.Cluster
+	mu       sync.Mutex
+	subs     []*storage.Subscription
+	removals int
+}
+
+func (c *orphanSubscriptionCluster) NodeID() string { return testNodeID }
+
+func (c *orphanSubscriptionCluster) GetSessionOwner(context.Context, string) (string, bool, error) {
+	return "", false, nil
+}
+
+func (c *orphanSubscriptionCluster) AcquireSession(context.Context, string, string) error {
+	return nil
+}
+
+func (c *orphanSubscriptionCluster) ReleaseSession(context.Context, string) error { return nil }
+
+func (c *orphanSubscriptionCluster) GetSubscriptionsForClient(context.Context, string) ([]*storage.Subscription, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.subs, nil
+}
+
+func (c *orphanSubscriptionCluster) RemoveAllSubscriptions(context.Context, string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.subs = nil
+	c.removals++
+
+	return nil
+}
+
+func (c *orphanSubscriptionCluster) snapshot() (subs []*storage.Subscription, removals int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.subs, c.removals
+}
+
+// Cluster routing entries outlive the local records written beside them, and a
+// persistent restore reads subscriptions from the cluster in preference to local
+// storage. An entry left behind is inherited by the next session under that
+// client ID, whoever it now belongs to.
+func TestFreshSessionPurgesOrphanedClusterSubscriptions(t *testing.T) {
+	const clientID = "orphan-cluster-subs"
+	const filter = "legacy/#"
+
+	cl := &orphanSubscriptionCluster{
+		subs: []*storage.Subscription{{ClientID: clientID, Filter: filter, QoS: 1}},
+	}
+	b := NewBroker(memory.New(), cl)
+	defer b.Close()
+
+	s, created, err := b.CreateSession(clientID, 5, session.Options{ExpiryInterval: 300})
 	require.NoError(t, err)
-	require.NotNil(t, kept, "a fresh session must not cancel the previous session's Will")
-	require.Equal(t, orphan.Topic, kept.Topic)
+	require.True(t, created)
+	require.Empty(t, s.GetSubscriptions(), "a fresh session must not inherit the orphaned cluster subscriptions")
+
+	subs, removals := cl.snapshot()
+	require.Empty(t, subs, "the orphaned cluster subscriptions must be removed")
+	require.Equal(t, 1, removals)
+}
+
+// The counterpart: nothing to detect means no write. An unconditional removal
+// would put an etcd round trip on every cold CONNECT.
+func TestFreshSessionSkipsClusterRemovalWithoutOrphans(t *testing.T) {
+	cl := &orphanSubscriptionCluster{}
+	b := NewBroker(memory.New(), cl)
+	defer b.Close()
+
+	_, created, err := b.CreateSession("cold-connect", 5, session.Options{ExpiryInterval: 300})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	_, removals := cl.snapshot()
+	require.Zero(t, removals, "a cold CONNECT must not write to the cluster routing table")
+}
+
+// A client ID's key spaces expire independently — badger gives the session
+// record a TTL of its own expiry interval while the subscriptions and messages
+// keyed by the same client ID stay — so a missing session record says nothing
+// about what else is left. A fresh session must inherit none of it.
+func TestFreshSessionPurgesOrphanedStateWithoutSessionRecord(t *testing.T) {
+	store := memory.New()
+	b := NewBroker(store, nil)
+	defer b.Close()
+
+	const clientID = "orphan-no-record"
+	const filter = "legacy/#"
+
+	require.NoError(t, store.Subscriptions().Add(&storage.Subscription{
+		ClientID: clientID,
+		Filter:   filter,
+		QoS:      1,
+	}))
+	queued := message.New("legacy/reading", []byte("stale"))
+	require.NoError(t, store.Messages().Store(clientID+queuePrefix+"0", queued))
+	message.Release(queued)
+
+	stored, err := store.Sessions().Get(clientID)
+	require.ErrorIs(t, err, storage.ErrNotFound)
+	require.Nil(t, stored, "the case under test has no session record")
+
+	s, created, err := b.CreateSession(clientID, 5, session.Options{ExpiryInterval: 300})
+	require.NoError(t, err)
+	require.True(t, created)
+	require.Empty(t, s.GetSubscriptions(), "a fresh session must not inherit the old subscriptions")
+	require.Equal(t, 0, s.OfflineQueue().Len(), "a fresh session must not inherit the old queued messages")
+
+	subs, err := store.Subscriptions().GetForClient(clientID)
+	require.NoError(t, err)
+	require.Empty(t, subs, "the orphaned subscriptions must be purged")
+
+	msgs, err := store.Messages().List(clientID + queuePrefix)
+	require.NoError(t, err)
+	require.Empty(t, msgs, "the orphaned queued messages must be purged")
 }
 
 // The counterpart: a reconnect that genuinely resumes a persisted session is

--- a/mqtt/broker/session_rollback_test.go
+++ b/mqtt/broker/session_rollback_test.go
@@ -476,9 +476,11 @@ func TestFreshSessionPublishesOrphanedWill(t *testing.T) {
 // session is gone from this node, and counts the writes made to clear them.
 type orphanSubscriptionCluster struct {
 	cluster.Cluster
-	mu       sync.Mutex
-	subs     []*storage.Subscription
-	removals int
+	mu        sync.Mutex
+	subs      []*storage.Subscription
+	removals  int
+	getErr    error
+	removeErr error
 }
 
 func (c *orphanSubscriptionCluster) NodeID() string { return testNodeID }
@@ -496,6 +498,9 @@ func (c *orphanSubscriptionCluster) ReleaseSession(context.Context, string) erro
 func (c *orphanSubscriptionCluster) GetSubscriptionsForClient(context.Context, string) ([]*storage.Subscription, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.getErr != nil {
+		return nil, c.getErr
+	}
 
 	return c.subs, nil
 }
@@ -503,8 +508,11 @@ func (c *orphanSubscriptionCluster) GetSubscriptionsForClient(context.Context, s
 func (c *orphanSubscriptionCluster) RemoveAllSubscriptions(context.Context, string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.subs = nil
 	c.removals++
+	if c.removeErr != nil {
+		return c.removeErr
+	}
+	c.subs = nil
 
 	return nil
 }
@@ -538,6 +546,68 @@ func TestFreshSessionPurgesOrphanedClusterSubscriptions(t *testing.T) {
 	subs, removals := cl.snapshot()
 	require.Empty(t, subs, "the orphaned cluster subscriptions must be removed")
 	require.Equal(t, 1, removals)
+}
+
+var errClusterUnreachable = errors.New("cluster unreachable")
+
+// Claiming the orphaned state is one operation with a remote half that can fail
+// on its own. Purging the local records first would mean a claim that then
+// failed had already dropped the Will it never returned, with nothing left to
+// publish it from, so the local state must still be there for the next CONNECT
+// to claim.
+func TestOrphanClaimKeepsLocalStateWhenClusterFails(t *testing.T) {
+	const clientID = "orphan-cluster-failure"
+	const filter = "legacy/#"
+
+	for _, tc := range []struct {
+		name    string
+		cluster *orphanSubscriptionCluster
+	}{
+		{
+			name:    "read fails",
+			cluster: &orphanSubscriptionCluster{getErr: errClusterUnreachable},
+		},
+		{
+			name: "removal fails",
+			cluster: &orphanSubscriptionCluster{
+				subs:      []*storage.Subscription{{ClientID: clientID, Filter: filter, QoS: 1}},
+				removeErr: errClusterUnreachable,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			store := memory.New()
+			b := NewBroker(store, tc.cluster)
+			defer b.Close()
+
+			orphan := &storage.WillMessage{
+				ClientID: clientID,
+				Topic:    "clients/orphan-cluster-failure/status",
+				Payload:  []byte(willPayloadOffline),
+				Delay:    3600,
+			}
+			require.NoError(t, store.Wills().Set(context.Background(), clientID, orphan))
+			require.NoError(t, store.Subscriptions().Add(&storage.Subscription{
+				ClientID: clientID,
+				Filter:   filter,
+				QoS:      1,
+			}))
+
+			s, created, err := b.CreateSession(clientID, 5, session.Options{ExpiryInterval: 300})
+			require.ErrorIs(t, err, errClusterUnreachable)
+			require.Nil(t, s)
+			require.False(t, created)
+			require.Nil(t, b.sessionsMap.Get(clientID), "the failed CONNECT installs no session")
+
+			kept, err := store.Wills().Get(context.Background(), clientID)
+			require.NoError(t, err, "the Will must survive for the next CONNECT to claim")
+			require.Equal(t, orphan.Topic, kept.Topic)
+
+			subs, err := store.Subscriptions().GetForClient(clientID)
+			require.NoError(t, err)
+			require.Len(t, subs, 1, "the local state must survive a claim that failed")
+		})
+	}
 }
 
 // The counterpart: nothing to detect means no write. An unconditional removal

--- a/mqtt/broker/session_rollback_test.go
+++ b/mqtt/broker/session_rollback_test.go
@@ -1,0 +1,294 @@
+// Copyright (c) Abstract Machines
+// SPDX-License-Identifier: Apache-2.0
+
+package broker
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	v5 "github.com/absmach/fluxmq/mqtt/packets/v5"
+	"github.com/absmach/fluxmq/mqtt/session"
+	"github.com/absmach/fluxmq/storage"
+	"github.com/absmach/fluxmq/storage/memory"
+	"github.com/stretchr/testify/require"
+)
+
+var errWillStoreUnavailable = errors.New("will store unavailable")
+
+// faultyWillStore fails Get on demand, modelling a storage backend that becomes
+// briefly unreachable while a CONNECT is in flight.
+type faultyWillStore struct {
+	storage.WillStore
+	failGet atomic.Bool
+}
+
+func (w *faultyWillStore) Get(ctx context.Context, clientID string) (*storage.WillMessage, error) {
+	if w.failGet.Load() {
+		return nil, errWillStoreUnavailable
+	}
+
+	return w.WillStore.Get(ctx, clientID)
+}
+
+// faultyStore serves a faultyWillStore in place of the backend's own.
+type faultyStore struct {
+	storage.Store
+	wills *faultyWillStore
+}
+
+func (s *faultyStore) Wills() storage.WillStore { return s.wills }
+
+func newFaultyStore() *faultyStore {
+	inner := memory.New()
+
+	return &faultyStore{Store: inner, wills: &faultyWillStore{WillStore: inner.Wills()}}
+}
+
+// A CONNECT that fails before attaching must not delete durable state.
+// createSession reports a session rebuilt from storage as newly created, so a
+// rollback that destroyed the session would let one failed CONNECT take a
+// client's subscriptions and queued messages with it.
+func TestAttachFailureKeepsRestoredDurableSession(t *testing.T) {
+	store := newFaultyStore()
+	b := NewBroker(store, nil)
+	defer b.Close()
+
+	const clientID = "restored-durable"
+	const filter = "sensors/+/temp"
+
+	// Seed the persisted session the reconnect will restore.
+	require.NoError(t, store.Sessions().Save(&storage.Session{
+		ClientID:       clientID,
+		Version:        5,
+		ExpiryInterval: 300,
+	}))
+	require.NoError(t, store.Subscriptions().Add(&storage.Subscription{
+		ClientID: clientID,
+		Filter:   filter,
+		QoS:      1,
+	}))
+
+	store.wills.failGet.Store(true)
+
+	s, created, claim, err := b.createSessionForConnection(clientID, 5, session.Options{
+		ExpiryInterval: 300,
+	}, false)
+	require.NoError(t, err)
+	require.True(t, created, "a restored session is still reported as created")
+
+	_, err = b.attachSession(context.Background(), s, claim, newSyncConn(), session.ConnectOptions{
+		Version:        5,
+		KeepAlive:      time.Minute,
+		ReceiveMaximum: 16,
+	}, nil)
+	require.ErrorIs(t, err, errWillStoreUnavailable)
+
+	b.releaseUnattachedSession(context.Background(), s, claim.epoch)
+
+	require.Nil(t, b.sessionsMap.Get(clientID), "the unattached session is handed back")
+
+	stored, err := store.Sessions().Get(clientID)
+	require.NoError(t, err)
+	require.NotNil(t, stored, "the persisted session must survive a failed CONNECT")
+
+	subs, err := store.Subscriptions().GetForClient(clientID)
+	require.NoError(t, err)
+	require.Len(t, subs, 1, "persisted subscriptions must survive a failed CONNECT")
+	require.Equal(t, filter, subs[0].Filter)
+}
+
+// A persistent CONNECT reuses the session pointer, so identity alone cannot tell
+// a session nothing attached to from one another connection has since claimed.
+// Rollback keyed on the stale generation must leave the live session alone.
+func TestReleaseUnattachedSessionIgnoresNewerGeneration(t *testing.T) {
+	b := NewBroker(memory.New(), nil)
+	defer b.Close()
+
+	const clientID = "generation-guard"
+	s, _, claim, err := b.createSessionForConnection(clientID, 5, session.Options{
+		ExpiryInterval: 300,
+	}, false)
+	require.NoError(t, err)
+
+	// A second CONNECT wins the race and attaches to the same session pointer.
+	winner, _, winnerClaim, err := b.createSessionForConnection(clientID, 5, session.Options{
+		ExpiryInterval: 300,
+	}, false)
+	require.NoError(t, err)
+	require.Same(t, s, winner)
+
+	conn := newSyncConn()
+	epoch, err := b.attachSession(context.Background(), winner, winnerClaim, conn, session.ConnectOptions{
+		Version:        5,
+		KeepAlive:      time.Minute,
+		ReceiveMaximum: 16,
+	}, nil)
+	require.NoError(t, err)
+	require.Greater(t, epoch, claim.epoch)
+
+	// The loser rolls back against the generation it observed.
+	b.releaseUnattachedSession(context.Background(), s, claim.epoch)
+
+	require.Same(t, s, b.sessionsMap.Get(clientID), "the attached replacement must survive")
+	require.True(t, s.IsConnected())
+	require.Equal(t, conn, s.Conn())
+}
+
+// Clean Start ends the previous session, so nothing it persisted may be
+// inherited — not just its Will. Otherwise a later persistent reconnect restores
+// subscriptions the client asked to be rid of.
+func TestCleanStartPurgesOrphanedDurableState(t *testing.T) {
+	store := memory.New()
+	b := NewBroker(store, nil)
+	defer b.Close()
+
+	const clientID = "orphaned-durable"
+	const filter = "legacy/#"
+
+	require.NoError(t, store.Sessions().Save(&storage.Session{
+		ClientID:       clientID,
+		Version:        5,
+		ExpiryInterval: 300,
+	}))
+	require.NoError(t, store.Subscriptions().Add(&storage.Subscription{
+		ClientID: clientID,
+		Filter:   filter,
+		QoS:      1,
+	}))
+	require.Nil(t, b.sessionsMap.Get(clientID))
+
+	_, created, err := b.CreateSession(clientID, 5, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	require.True(t, created)
+
+	subs, err := store.Subscriptions().GetForClient(clientID)
+	require.NoError(t, err)
+	require.Empty(t, subs, "Clean Start must not leave the old subscriptions behind")
+}
+
+// Expiry ends the session, and a Will waiting on its delay is due when the
+// session ends or the delay passes, whichever comes first. The sweep used to
+// delete the record without ever publishing it.
+func TestExpireSessionPublishesDueWill(t *testing.T) {
+	store := memory.New()
+	b := NewBroker(store, nil)
+	defer b.Close()
+
+	const clientID = "expiring-will"
+	const willTopic = "clients/expiring-will/status"
+
+	sub, _, err := b.CreateSession("expiring-will-sub", 5, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	subConn := newSyncConn()
+	_, err = sub.Connect(subConn)
+	require.NoError(t, err)
+	require.NoError(t, b.subscribe(sub, willTopic, 0, storage.SubscribeOptions{}))
+
+	s, _, err := b.CreateSession(clientID, 5, session.Options{
+		ExpiryInterval: 1,
+		Will: &storage.WillMessage{
+			ClientID: clientID,
+			Topic:    willTopic,
+			Payload:  []byte(willPayloadOffline),
+			Delay:    3600,
+		},
+	})
+	require.NoError(t, err)
+	_, err = s.Connect(newSyncConn())
+	require.NoError(t, err)
+	require.NoError(t, s.Disconnect(false, v5.DisconnectUnspecifiedError))
+	waitFor(t, func() bool {
+		_, err := store.Wills().Get(context.Background(), clientID)
+		return err == nil
+	}, "disconnect callback stores the delayed Will")
+
+	b.expireSession(context.Background(), clientID)
+
+	require.Nil(t, b.sessionsMap.Get(clientID))
+	waitFor(t, func() bool {
+		for _, p := range subConn.writtenPackets() {
+			if pub, ok := p.(*v5.Publish); ok && pub.TopicName == willTopic {
+				return string(pub.Payload) == willPayloadOffline
+			}
+		}
+		return false
+	}, "an expiring session publishes its delayed Will")
+}
+
+// Cancelling a delayed Will is reserved for "a new Network Connection to this
+// Session" [MQTT-3.1.3-9]. A CleanStart=false CONNECT that finds no persisted
+// session starts a fresh one, so the orphaned Will stays due.
+func TestFreshSessionDoesNotCancelOrphanedWill(t *testing.T) {
+	store := memory.New()
+	b := NewBroker(store, nil)
+	defer b.Close()
+
+	const clientID = "fresh-session-orphan"
+	orphan := &storage.WillMessage{
+		ClientID: clientID,
+		Topic:    "clients/fresh-session-orphan/status",
+		Payload:  []byte(willPayloadOffline),
+		Delay:    3600,
+	}
+	require.NoError(t, store.Wills().Set(context.Background(), clientID, orphan))
+
+	s, created, claim, err := b.createSessionForConnection(clientID, 5, session.Options{
+		ExpiryInterval: 300,
+	}, false)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.False(t, claim.continuesSession, "no persisted session means a fresh one")
+
+	_, err = b.attachSession(context.Background(), s, claim, newSyncConn(), session.ConnectOptions{
+		Version:        5,
+		KeepAlive:      time.Minute,
+		ReceiveMaximum: 16,
+	}, nil)
+	require.NoError(t, err)
+
+	kept, err := store.Wills().Get(context.Background(), clientID)
+	require.NoError(t, err)
+	require.NotNil(t, kept, "a fresh session must not cancel the previous session's Will")
+	require.Equal(t, orphan.Topic, kept.Topic)
+}
+
+// The counterpart: a reconnect that genuinely resumes a persisted session is
+// "this Session", so it does cancel the pending Will.
+func TestResumedSessionCancelsPendingWill(t *testing.T) {
+	store := memory.New()
+	b := NewBroker(store, nil)
+	defer b.Close()
+
+	const clientID = "resumed-session"
+	require.NoError(t, store.Sessions().Save(&storage.Session{
+		ClientID:       clientID,
+		Version:        5,
+		ExpiryInterval: 300,
+	}))
+	require.NoError(t, store.Wills().Set(context.Background(), clientID, &storage.WillMessage{
+		ClientID: clientID,
+		Topic:    "clients/resumed-session/status",
+		Payload:  []byte(willPayloadOffline),
+		Delay:    3600,
+	}))
+
+	s, _, claim, err := b.createSessionForConnection(clientID, 5, session.Options{
+		ExpiryInterval: 300,
+	}, false)
+	require.NoError(t, err)
+	require.True(t, claim.continuesSession, "a persisted record continues the session")
+
+	_, err = b.attachSession(context.Background(), s, claim, newSyncConn(), session.ConnectOptions{
+		Version:        5,
+		KeepAlive:      time.Minute,
+		ReceiveMaximum: 16,
+	}, nil)
+	require.NoError(t, err)
+
+	_, err = store.Wills().Get(context.Background(), clientID)
+	require.ErrorIs(t, err, storage.ErrNotFound)
+}

--- a/mqtt/broker/session_rollback_test.go
+++ b/mqtt/broker/session_rollback_test.go
@@ -701,3 +701,57 @@ func TestResumedSessionCancelsPendingWill(t *testing.T) {
 	_, err = store.Wills().Get(context.Background(), clientID)
 	require.ErrorIs(t, err, storage.ErrNotFound)
 }
+
+// A session discarded for being bound to no principal has ended, so its delayed
+// Will is due [MQTT-3.1.2-8]. Deleting the discarded state as part of resolving
+// what may be inherited would drop the Will before the claim could read it, and
+// the Will would never be published.
+func TestDiscardedUnboundSessionPublishesDueWill(t *testing.T) {
+	store := memory.New()
+	b := NewBroker(store, nil)
+	defer b.Close()
+
+	const clientID = "unbound-discarded-will"
+	const willTopic = "clients/unbound-discarded-will/status"
+
+	sub, _, err := b.CreateSession("unbound-discarded-will-sub", 5, session.Options{CleanStart: true})
+	require.NoError(t, err)
+	subConn := newSyncConn()
+	_, err = sub.Connect(subConn)
+	require.NoError(t, err)
+	require.NoError(t, b.subscribe(sub, willTopic, 0, storage.SubscribeOptions{}))
+
+	// A session written before identities were resolved, with a Will still
+	// waiting on its delay.
+	require.NoError(t, store.Sessions().Save(&storage.Session{
+		ClientID:       clientID,
+		Version:        5,
+		ExpiryInterval: 300,
+	}))
+	require.NoError(t, store.Wills().Set(context.Background(), clientID, &storage.WillMessage{
+		ClientID: clientID,
+		Topic:    willTopic,
+		Payload:  []byte(willPayloadOffline),
+		Delay:    3600,
+	}))
+
+	s, created, err := b.CreateSessionForIdentity(clientID, 5, session.Options{
+		ExternalID:     identityA,
+		ExpiryInterval: 300,
+	}, true)
+	require.NoError(t, err)
+	require.True(t, created)
+	require.Equal(t, identityA, s.ExternalIdentity(), "the bound client gets its own session")
+
+	waitFor(t, func() bool {
+		for _, p := range subConn.writtenPackets() {
+			if pub, ok := p.(*v5.Publish); ok && pub.TopicName == willTopic {
+				return string(pub.Payload) == willPayloadOffline
+			}
+		}
+		return false
+	}, "discarding an unbound session publishes its due Will")
+
+	_, err = store.Wills().Get(context.Background(), clientID)
+	require.ErrorIs(t, err, storage.ErrNotFound)
+}

--- a/mqtt/broker/takeover.go
+++ b/mqtt/broker/takeover.go
@@ -6,6 +6,7 @@ package broker
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"time"
 
 	core "github.com/absmach/fluxmq/mqtt"
@@ -19,17 +20,27 @@ import (
 // client cannot delay the close.
 const supersededNotifyGrace = time.Second
 
-// drainSuperseded retires a connection displaced by a local takeover: it
-// notifies an MQTT 5 client with a DISCONNECT (DisconnectSessionTakenOver), closes the socket, and
-// publishes the displaced connection's Will when required. It is safe to run in
-// its own goroutine and must not block the replacement connection's setup.
+// sessionRetirement combines protocol-neutral connection data captured by the
+// session package with broker-owned lifecycle policy.
+type sessionRetirement struct {
+	clientID    string
+	superseded  *session.Superseded
+	sessionEnds bool
+}
+
+// retireSession retires a connection displaced by a takeover: it notifies an
+// MQTT 5 client with a DISCONNECT (DisconnectSessionTakenOver), closes the
+// socket, publishes the displaced connection's Will when required, and emits
+// exactly one physical-connection disconnect event. It is safe to run in its
+// own goroutine and must not block the replacement connection's setup.
 //
 // References: OASIS MQTT 5.0, sections 3.1.4 (session takeover) and 3.1.2.5
 // (Will lifecycle).
-func (b *Broker) drainSuperseded(ctx context.Context, sc *session.Superseded) {
-	if sc == nil {
+func (b *Broker) retireSession(ctx context.Context, retired *sessionRetirement) {
+	if retired == nil || retired.superseded == nil {
 		return
 	}
+	sc := retired.superseded
 
 	if sc.Conn != nil {
 		// Notify a displaced MQTT 5 client before closing the connection. Wait for
@@ -43,14 +54,38 @@ func (b *Broker) drainSuperseded(ctx context.Context, sc *session.Superseded) {
 				ReasonCode:  v5.DisconnectSessionTakenOver,
 			}
 			sent := make(chan struct{})
+			writeDone := make(chan error, 1)
+			var sentOnce sync.Once
 			go func() {
 				// WriteControlPacket may block enqueueing on a stalled client.
-				sc.Conn.WriteControlPacket(d, func() { close(sent) }) //nolint:errcheck // best-effort takeover notification
+				writeDone <- sc.Conn.WriteControlPacket(d, func() {
+					sentOnce.Do(func() { close(sent) })
+				})
 			}()
+			timer := time.NewTimer(supersededNotifyGrace)
+			waitForSent := true
 			// Bounded: a stalled client must not delay the close indefinitely.
-			select {
-			case <-sent:
-			case <-time.After(supersededNotifyGrace):
+			for waitForSent {
+				select {
+				case <-sent:
+					waitForSent = false
+				case err := <-writeDone:
+					if err != nil {
+						waitForSent = false
+						continue
+					}
+					// A successful enqueue is not a successful write. Keep waiting
+					// for onSent, but do not select the completed result again.
+					writeDone = nil
+				case <-timer.C:
+					waitForSent = false
+				}
+			}
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
 			}
 		}
 
@@ -62,17 +97,16 @@ func (b *Broker) drainSuperseded(ctx context.Context, sc *session.Superseded) {
 	// A zero-delay Will is always published when the old connection closes. A
 	// delayed Will is cancelled only when the same session continues; Clean Start
 	// ends the old session, so its delayed Will is due immediately.
-	if sc.Will != nil && (sc.SessionEnds || sc.Will.Delay == 0) {
+	if sc.Will != nil && (retired.sessionEnds || sc.Will.Delay == 0) {
 		if err := b.publishWillMessage(ctx, sc.Will); err != nil {
 			b.logError("publish_superseded_will", err, slog.String("client_id", sc.Will.ClientID))
 		}
 	}
 
-	// Ending the old session retires its connection for good, so the disconnect
-	// is owed to hooks and webhooks. A takeover that continues the same session
-	// owes nothing: the client ID stays connected under the replacement socket,
-	// and the handler reports the new connection through NotifyConnect.
-	if sc.SessionEnds && sc.Conn != nil {
-		b.emitClientDisconnected(ctx, sc.ClientID, "takeover")
+	// Disconnect events describe physical connections. Every socket retired by
+	// this path emits one event, whether the MQTT session ends or continues on a
+	// replacement connection on this node or another one.
+	if sc.Conn != nil {
+		b.emitClientDisconnected(ctx, retired.clientID, "takeover")
 	}
 }

--- a/mqtt/broker/takeover.go
+++ b/mqtt/broker/takeover.go
@@ -27,42 +27,52 @@ const supersededNotifyGrace = time.Second
 // References: OASIS MQTT 5.0, sections 3.1.4 (session takeover) and 3.1.2.5
 // (Will lifecycle).
 func (b *Broker) drainSuperseded(ctx context.Context, sc *session.Superseded) {
-	if sc == nil || sc.Conn == nil {
+	if sc == nil {
 		return
 	}
 
-	// Notify a displaced MQTT 5 client before closing the connection. Wait for
-	// the packet to actually be transmitted (the onSent callback fires after
-	// the send loop writes it to the socket), not merely enqueued, so an
-	// asynchronous send queue does not observe the close before flushing the
-	// DISCONNECT.
-	if sc.Version == core.ProtocolV5 {
-		d := &v5.Disconnect{
-			FixedHeader: packets.FixedHeader{PacketType: packets.DisconnectType},
-			ReasonCode:  v5.DisconnectSessionTakenOver,
+	if sc.Conn != nil {
+		// Notify a displaced MQTT 5 client before closing the connection. Wait for
+		// the packet to actually be transmitted (the onSent callback fires after
+		// the send loop writes it to the socket), not merely enqueued, so an
+		// asynchronous send queue does not observe the close before flushing the
+		// DISCONNECT.
+		if sc.Version == core.ProtocolV5 {
+			d := &v5.Disconnect{
+				FixedHeader: packets.FixedHeader{PacketType: packets.DisconnectType},
+				ReasonCode:  v5.DisconnectSessionTakenOver,
+			}
+			sent := make(chan struct{})
+			go func() {
+				// WriteControlPacket may block enqueueing on a stalled client.
+				sc.Conn.WriteControlPacket(d, func() { close(sent) }) //nolint:errcheck // best-effort takeover notification
+			}()
+			// Bounded: a stalled client must not delay the close indefinitely.
+			select {
+			case <-sent:
+			case <-time.After(supersededNotifyGrace):
+			}
 		}
-		sent := make(chan struct{})
-		go func() {
-			// WriteControlPacket may block enqueueing on a stalled client.
-			sc.Conn.WriteControlPacket(d, func() { close(sent) }) //nolint:errcheck // best-effort takeover notification
-		}()
-		// Bounded: a stalled client must not delay the close indefinitely.
-		select {
-		case <-sent:
-		case <-time.After(supersededNotifyGrace):
-		}
+
+		// Closing unblocks any pending notify write and lets the displaced
+		// connection's runSession goroutine observe the closed socket and exit.
+		sc.Conn.Close() //nolint:errcheck // idempotent close of superseded connection
 	}
 
-	// Closing unblocks any pending notify write and lets the displaced
-	// connection's runSession goroutine observe the closed socket and exit.
-	sc.Conn.Close() //nolint:errcheck // idempotent close of superseded connection
-
-	// Publish the displaced connection's Will if it has no delay. A Will with a
-	// delay is cancelled because the session continues under the new
-	// connection (a takeover is a reconnect of the same session).
-	if sc.Will != nil && sc.Will.Delay == 0 {
+	// A zero-delay Will is always published when the old connection closes. A
+	// delayed Will is cancelled only when the same session continues; Clean Start
+	// ends the old session, so its delayed Will is due immediately.
+	if sc.Will != nil && (sc.SessionEnds || sc.Will.Delay == 0) {
 		if err := b.publishWillMessage(ctx, sc.Will); err != nil {
 			b.logError("publish_superseded_will", err, slog.String("client_id", sc.Will.ClientID))
 		}
+	}
+
+	// Ending the old session retires its connection for good, so the disconnect
+	// is owed to hooks and webhooks. A takeover that continues the same session
+	// owes nothing: the client ID stays connected under the replacement socket,
+	// and the handler reports the new connection through NotifyConnect.
+	if sc.SessionEnds && sc.Conn != nil {
+		b.emitClientDisconnected(ctx, sc.ClientID, "takeover")
 	}
 }

--- a/mqtt/broker/takeover_test.go
+++ b/mqtt/broker/takeover_test.go
@@ -171,6 +171,19 @@ type syncConn struct {
 	readOnce  sync.Once
 }
 
+type failingNotifyConn struct {
+	*blockingConn
+}
+
+func newFailingNotifyConn() *failingNotifyConn {
+	return &failingNotifyConn{blockingConn: newBlockingConn()}
+}
+
+func (c *failingNotifyConn) WriteControlPacket(pkt packets.ControlPacket, _ func()) error {
+	pkt.Release()
+	return io.ErrClosedPipe
+}
+
 func newSyncConn() *syncConn {
 	return &syncConn{closeCh: make(chan struct{}), reading: make(chan struct{})}
 }
@@ -272,6 +285,25 @@ func waitFor(t *testing.T, cond func() bool, msg string) {
 		time.Sleep(time.Millisecond)
 	}
 	t.Fatalf("timed out waiting for: %s", msg)
+}
+
+func TestRetireSession_WriteFailureClosesWithoutGraceDelay(t *testing.T) {
+	b := NewBroker(nil, nil)
+	defer b.Close()
+	conn := newFailingNotifyConn()
+
+	start := time.Now()
+	b.retireSession(context.Background(), &sessionRetirement{
+		clientID: "notify-write-failure",
+		superseded: &session.Superseded{
+			Conn:    conn,
+			Version: 5,
+		},
+	})
+
+	require.True(t, conn.closed.Load())
+	require.Less(t, time.Since(start), supersededNotifyGrace/2,
+		"an immediate notification write failure must not wait for the grace timeout")
 }
 
 // TestHandleConnect_LocalTakeoverHighLatencyReconnect reproduces propeller#241:
@@ -718,7 +750,7 @@ func TestHandleConnect_V5TakeoverDelayedWillNotPublished(t *testing.T) {
 	// must not be published.
 	waitFor(t, func() bool { return oldConn.closed.Load() }, "old connection closed by takeover")
 
-	// The Will is published (if at all) by the asynchronous drainSuperseded
+	// The Will is published (if at all) by the asynchronous retirement
 	// goroutine, which the test cannot join. require.Never polls the subscriber
 	// throughout a settle window, asserting the delayed Will never arrives —
 	// deterministic where a single sleep+check would only sample one instant.

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -127,7 +127,7 @@ func (h *v3Handler) HandleConnect(ctx context.Context, conn core.Connection, pkt
 		Will:           will,
 	}
 
-	s, isNew, err := h.broker.CreateSessionForIdentity(clientID, p.ProtocolVersion, opts, boundMTLS) //nolint:contextcheck // CreateSession has no context parameter yet; 73 call sites, tracked separately
+	s, isNew, expectedEpoch, err := h.broker.createSessionForConnection(clientID, p.ProtocolVersion, opts, boundMTLS)
 	if err != nil {
 		if errors.Is(err, cluster.ErrSessionIdentityMismatch) {
 			h.broker.telemetry.stats.IncrementAuthErrors()
@@ -148,18 +148,21 @@ func (h *v3Handler) HandleConnect(ctx context.Context, conn core.Connection, pkt
 	// connection enforcing a different limit than it was admitted under. MQTT
 	// 3.1.1 cannot advertise the value, so a client has no way to learn about a
 	// later change.
-	epoch, superseded := s.ConnectWithOptions(conn, session.ConnectOptions{
+	epoch, err := h.broker.attachSession(ctx, s, expectedEpoch, conn, session.ConnectOptions{
 		Version:        p.ProtocolVersion,
 		KeepAlive:      time.Duration(p.KeepAlive) * time.Second,
 		Will:           will,
 		ReceiveMaximum: maxReceived,
 		MaxQoS:         h.broker.MaxQoS(),
-	})
-	if superseded != nil {
-		go h.broker.drainSuperseded(context.WithoutCancel(ctx), superseded)
+	}, nil)
+	if err != nil {
+		if !errors.Is(err, errSessionReplacedBeforeAttach) {
+			h.broker.telemetry.stats.IncrementProtocolErrors()
+		}
+		sendV3ConnAck(conn, false, v3.ConnAckServerUnavailable) //nolint:errcheck // best-effort rejection reply before closing
+		conn.Close()
+		return err
 	}
-	h.broker.BindExternalID(clientID, externalID)
-	h.broker.persistSessionInfo(s)
 
 	sessionPresent := !isNew && !cleanStart
 	if err := sendV3ConnAck(conn, sessionPresent, v3.ConnAckAccepted); err != nil {

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -127,7 +127,7 @@ func (h *v3Handler) HandleConnect(ctx context.Context, conn core.Connection, pkt
 		Will:           will,
 	}
 
-	s, isNew, expectedEpoch, err := h.broker.createSessionForConnection(clientID, p.ProtocolVersion, opts, boundMTLS)
+	s, isNew, expectedEpoch, err := h.broker.createSessionForConnection(clientID, p.ProtocolVersion, opts, boundMTLS) //nolint:contextcheck // createSession has no context parameter yet; 73 call sites, tracked separately
 	if err != nil {
 		if errors.Is(err, cluster.ErrSessionIdentityMismatch) {
 			h.broker.telemetry.stats.IncrementAuthErrors()
@@ -156,8 +156,16 @@ func (h *v3Handler) HandleConnect(ctx context.Context, conn core.Connection, pkt
 		MaxQoS:         h.broker.MaxQoS(),
 	}, nil)
 	if err != nil {
+		// A lost epoch race is not a fault: the CONNECT that won owns the
+		// session, which may be the very one this call created. Any other
+		// failure leaves a session nothing will ever attach to, so hand it back
+		// along with its cluster ownership. MQTT 3.1.1 has no code that
+		// distinguishes the two cases.
 		if !errors.Is(err, errSessionReplacedBeforeAttach) {
 			h.broker.telemetry.stats.IncrementProtocolErrors()
+			if isNew {
+				h.broker.destroyIfCurrent(context.WithoutCancel(ctx), s) //nolint:errcheck // best-effort cleanup of a session that never attached
+			}
 		}
 		sendV3ConnAck(conn, false, v3.ConnAckServerUnavailable) //nolint:errcheck // best-effort rejection reply before closing
 		conn.Close()

--- a/mqtt/broker/v3_handler.go
+++ b/mqtt/broker/v3_handler.go
@@ -127,7 +127,7 @@ func (h *v3Handler) HandleConnect(ctx context.Context, conn core.Connection, pkt
 		Will:           will,
 	}
 
-	s, isNew, expectedEpoch, err := h.broker.createSessionForConnection(clientID, p.ProtocolVersion, opts, boundMTLS) //nolint:contextcheck // createSession has no context parameter yet; 73 call sites, tracked separately
+	s, isNew, claim, err := h.broker.createSessionForConnection(clientID, p.ProtocolVersion, opts, boundMTLS) //nolint:contextcheck // createSession has no context parameter yet; 73 call sites, tracked separately
 	if err != nil {
 		if errors.Is(err, cluster.ErrSessionIdentityMismatch) {
 			h.broker.telemetry.stats.IncrementAuthErrors()
@@ -148,7 +148,7 @@ func (h *v3Handler) HandleConnect(ctx context.Context, conn core.Connection, pkt
 	// connection enforcing a different limit than it was admitted under. MQTT
 	// 3.1.1 cannot advertise the value, so a client has no way to learn about a
 	// later change.
-	epoch, err := h.broker.attachSession(ctx, s, expectedEpoch, conn, session.ConnectOptions{
+	epoch, err := h.broker.attachSession(ctx, s, claim, conn, session.ConnectOptions{
 		Version:        p.ProtocolVersion,
 		KeepAlive:      time.Duration(p.KeepAlive) * time.Second,
 		Will:           will,
@@ -164,7 +164,7 @@ func (h *v3Handler) HandleConnect(ctx context.Context, conn core.Connection, pkt
 		if !errors.Is(err, errSessionReplacedBeforeAttach) {
 			h.broker.telemetry.stats.IncrementProtocolErrors()
 			if isNew {
-				h.broker.destroyIfCurrent(context.WithoutCancel(ctx), s) //nolint:errcheck // best-effort cleanup of a session that never attached
+				h.broker.releaseUnattachedSession(context.WithoutCancel(ctx), s, claim.epoch)
 			}
 		}
 		sendV3ConnAck(conn, false, v3.ConnAckServerUnavailable) //nolint:errcheck // best-effort rejection reply before closing

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -148,7 +148,7 @@ func (h *v5Handler) HandleConnect(ctx context.Context, conn core.Connection, pkt
 		Will:           will,
 	}
 
-	s, isNew, err := h.broker.CreateSessionForIdentity(clientID, p.ProtocolVersion, opts, boundMTLS) //nolint:contextcheck // CreateSession has no context parameter yet; 73 call sites, tracked separately
+	s, isNew, expectedEpoch, err := h.broker.createSessionForConnection(clientID, p.ProtocolVersion, opts, boundMTLS)
 	if err != nil {
 		if errors.Is(err, cluster.ErrSessionIdentityMismatch) {
 			h.broker.telemetry.stats.IncrementAuthErrors()
@@ -173,26 +173,30 @@ func (h *v5Handler) HandleConnect(ctx context.Context, conn core.Connection, pkt
 	// a configuration reload cannot leave the connection enforcing a limit other
 	// than the one its CONNACK announced.
 	sessionMaxQoS := h.broker.MaxQoS()
-	epoch, superseded := s.ConnectWithOptions(conn, session.ConnectOptions{
+	var expiryInterval *uint32
+	if !isNew {
+		expiryInterval = &sessionExpiry
+	}
+	epoch, err := h.broker.attachSession(ctx, s, expectedEpoch, conn, session.ConnectOptions{
 		Version:        p.ProtocolVersion,
 		KeepAlive:      time.Duration(p.KeepAlive) * time.Second,
 		Will:           will,
 		ReceiveMaximum: receiveMax,
 		TopicAliasMax:  topicAliasMax,
 		MaxQoS:         sessionMaxQoS,
-	})
+	}, expiryInterval)
+	if err != nil {
+		if !errors.Is(err, errSessionReplacedBeforeAttach) {
+			h.broker.telemetry.stats.IncrementProtocolErrors()
+		}
+		sendV5ConnAck(conn, false, v5.ConnAckUnspecifiedError, nil) //nolint:errcheck // best-effort rejection reply before closing
+		conn.Close()
+		return err
+	}
 	// Session expiry is applied verbatim on reconnect so a new value of 0
 	// (expire on disconnect) replaces a previous positive one. A new session's
 	// expiry, including the server default policy, was already set in
 	// CreateSession.
-	if !isNew {
-		s.SetExpiryInterval(sessionExpiry)
-	}
-	if superseded != nil {
-		go h.broker.drainSuperseded(context.WithoutCancel(ctx), superseded)
-	}
-	h.broker.BindExternalID(clientID, externalID)
-	h.broker.persistSessionInfo(s)
 
 	sessionPresent := !isNew && !cleanStart
 	if err := sendV5ConnAckWithProperties(conn, s, sessionPresent, v5.ConnAckSuccess, sessionMaxQoS); err != nil {

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -148,7 +148,7 @@ func (h *v5Handler) HandleConnect(ctx context.Context, conn core.Connection, pkt
 		Will:           will,
 	}
 
-	s, isNew, expectedEpoch, err := h.broker.createSessionForConnection(clientID, p.ProtocolVersion, opts, boundMTLS) //nolint:contextcheck // createSession has no context parameter yet; 73 call sites, tracked separately
+	s, isNew, claim, err := h.broker.createSessionForConnection(clientID, p.ProtocolVersion, opts, boundMTLS) //nolint:contextcheck // createSession has no context parameter yet; 73 call sites, tracked separately
 	if err != nil {
 		if errors.Is(err, cluster.ErrSessionIdentityMismatch) {
 			h.broker.telemetry.stats.IncrementAuthErrors()
@@ -177,7 +177,7 @@ func (h *v5Handler) HandleConnect(ctx context.Context, conn core.Connection, pkt
 	if !isNew {
 		expiryInterval = &sessionExpiry
 	}
-	epoch, err := h.broker.attachSession(ctx, s, expectedEpoch, conn, session.ConnectOptions{
+	epoch, err := h.broker.attachSession(ctx, s, claim, conn, session.ConnectOptions{
 		Version:        p.ProtocolVersion,
 		KeepAlive:      time.Duration(p.KeepAlive) * time.Second,
 		Will:           will,
@@ -196,7 +196,7 @@ func (h *v5Handler) HandleConnect(ctx context.Context, conn core.Connection, pkt
 			connAckCode = v5.ConnAckUnspecifiedError
 			h.broker.telemetry.stats.IncrementProtocolErrors()
 			if isNew {
-				h.broker.destroyIfCurrent(context.WithoutCancel(ctx), s) //nolint:errcheck // best-effort cleanup of a session that never attached
+				h.broker.releaseUnattachedSession(context.WithoutCancel(ctx), s, claim.epoch)
 			}
 		}
 		sendV5ConnAck(conn, false, connAckCode, nil) //nolint:errcheck // best-effort rejection reply before closing

--- a/mqtt/broker/v5_handler.go
+++ b/mqtt/broker/v5_handler.go
@@ -148,7 +148,7 @@ func (h *v5Handler) HandleConnect(ctx context.Context, conn core.Connection, pkt
 		Will:           will,
 	}
 
-	s, isNew, expectedEpoch, err := h.broker.createSessionForConnection(clientID, p.ProtocolVersion, opts, boundMTLS)
+	s, isNew, expectedEpoch, err := h.broker.createSessionForConnection(clientID, p.ProtocolVersion, opts, boundMTLS) //nolint:contextcheck // createSession has no context parameter yet; 73 call sites, tracked separately
 	if err != nil {
 		if errors.Is(err, cluster.ErrSessionIdentityMismatch) {
 			h.broker.telemetry.stats.IncrementAuthErrors()
@@ -186,10 +186,20 @@ func (h *v5Handler) HandleConnect(ctx context.Context, conn core.Connection, pkt
 		MaxQoS:         sessionMaxQoS,
 	}, expiryInterval)
 	if err != nil {
+		// A lost epoch race is not a fault: the CONNECT that won owns the
+		// session, which may be the very one this call created. Server busy
+		// tells the client to retry, and separates the race from a real fault.
+		// Any other failure leaves a session nothing will ever attach to, so
+		// hand it back along with its cluster ownership.
+		connAckCode := byte(v5.ConnAckServerBusy)
 		if !errors.Is(err, errSessionReplacedBeforeAttach) {
+			connAckCode = v5.ConnAckUnspecifiedError
 			h.broker.telemetry.stats.IncrementProtocolErrors()
+			if isNew {
+				h.broker.destroyIfCurrent(context.WithoutCancel(ctx), s) //nolint:errcheck // best-effort cleanup of a session that never attached
+			}
 		}
-		sendV5ConnAck(conn, false, v5.ConnAckUnspecifiedError, nil) //nolint:errcheck // best-effort rejection reply before closing
+		sendV5ConnAck(conn, false, connAckCode, nil) //nolint:errcheck // best-effort rejection reply before closing
 		conn.Close()
 		return err
 	}

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -308,9 +308,61 @@ type ConnectOptions struct {
 // drain it outside the session lock: notify the displaced MQTT 5 client with a
 // DISCONNECT (DisconnectSessionTakenOver), close the socket, and publish its Will if required.
 type Superseded struct {
-	Conn    core.Connection
-	Version byte
-	Will    *storage.WillMessage
+	ClientID    string
+	Conn        core.Connection
+	Version     byte
+	Will        *storage.WillMessage
+	SessionEnds bool
+}
+
+// DetachForTakeover ends this session's current network connection without
+// closing the socket or invoking the asynchronous disconnect callback. The
+// caller must retire the returned connection after releasing any broker-level
+// session lock. sessionEnds distinguishes a Clean Start replacement, where a
+// delayed Will is published immediately, from a reconnect that continues the
+// same session and cancels a delayed Will.
+func (s *Session) DetachForTakeover(sessionEnds bool) *Superseded {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	superseded := &Superseded{
+		ClientID:    s.ID,
+		Version:     s.Version,
+		SessionEnds: sessionEnds,
+	}
+
+	// A session installed in the broker map but not yet attached to a network
+	// connection has not completed CONNECT, so its proposed Will is not active.
+	if s.state == StateNew || s.state == StateConnecting {
+		s.Will = nil
+		return superseded
+	}
+
+	// Transfer ownership of the old connection's Will to the retirement path.
+	// Clearing it here prevents a previously queued callback from scheduling the
+	// same Will if session destruction later fails.
+	superseded.Will = s.Will
+	s.Will = nil
+
+	if s.state != StateConnected {
+		return superseded
+	}
+
+	s.state = StateDisconnecting
+	select {
+	case <-s.deliverStop:
+	default:
+		close(s.deliverStop)
+	}
+
+	s.disconnectedAt = time.Now()
+	superseded.Conn = s.conn
+	s.conn = nil
+	s.state = StateDisconnected
+	s.drainPendingToOffline()
+	s.msgHandler.ClearAliases()
+
+	return superseded
 }
 
 // Connect attaches a connection using the session's existing options. The
@@ -344,7 +396,7 @@ func (s *Session) attach(c core.Connection, opts ConnectOptions, applyOpts bool)
 
 	var superseded *Superseded
 	if s.conn != nil {
-		superseded = &Superseded{Conn: s.conn, Version: s.Version, Will: s.Will}
+		superseded = &Superseded{ClientID: s.ID, Conn: s.conn, Version: s.Version, Will: s.Will}
 	}
 
 	if applyOpts {
@@ -972,6 +1024,18 @@ func (s *Session) GetWill() *storage.WillMessage {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.Will
+}
+
+// TakeWill transfers ownership of the current Will to the caller. Consuming it
+// prevents a later clean replacement or stale disconnect callback from
+// publishing the same Will a second time.
+func (s *Session) TakeWill() *storage.WillMessage {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	will := s.Will
+	s.Will = nil
+	return will
 }
 
 // Info returns session info for persistence.

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -760,6 +760,27 @@ func (s *Session) IsConnected() bool {
 	return s.state == StateConnected && s.conn != nil
 }
 
+// HasExpired reports whether the session has been disconnected for longer than
+// its expiry interval as of now. Connection state, expiry interval, and
+// disconnect timestamp are read together under one lock: read separately they
+// can come from either side of a reconnect or a SetExpiryInterval.
+//
+// A session that has never held a connection has no disconnect timestamp, and a
+// zero one is not an expiry that elapsed in 1970. That is the state a CONNECT
+// leaves behind between installing the session and attaching to it, so treating
+// it as overdue would let the expiry sweep destroy a session — and the durable
+// state it restored — out from under a connection still being set up.
+func (s *Session) HasExpired(now time.Time) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if (s.state == StateConnected && s.conn != nil) || s.ExpiryInterval == 0 || s.disconnectedAt.IsZero() {
+		return false
+	}
+
+	return now.After(s.disconnectedAt.Add(time.Duration(s.ExpiryInterval) * time.Second))
+}
+
 // GetDisconnectedAt returns when the session was disconnected.
 // Cheaper than Info() when only the disconnect timestamp is needed.
 func (s *Session) GetDisconnectedAt() time.Time {

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -401,6 +401,10 @@ func (s *Session) attach(c core.Connection, opts ConnectOptions, applyOpts bool)
 			// before applying the new connection's options.
 			s.Will = nil
 		}
+		// Without applyOpts the session keeps its Will, so the returned value
+		// aliases it rather than owning it. Connect is the only such caller and
+		// retires nothing but the socket; a caller that publishes this Will
+		// would publish the live session's Will twice.
 	} else if s.state == StateDisconnected && s.Will != nil {
 		// A disconnect callback may still be queued. Transfer its generation's
 		// outstanding Will before installing the replacement so that callback

--- a/mqtt/session/session.go
+++ b/mqtt/session/session.go
@@ -68,13 +68,13 @@ type Session struct {
 	subscriptions       map[string]storage.SubscribeOptions
 	subscriptionAliases map[string]string
 	subscriptionIDs     map[string][]uint32
-	onDisconnect        func(s *Session, graceful bool)
+	onDisconnect        func(s *Session, graceful bool, epoch uint64)
 	KeepAlive           time.Duration
 	state               State
-	// epoch is bumped on every Connect. It identifies the current connection
-	// generation so a stale runSession goroutine (from a superseded connection)
-	// can detect that the session has moved on and avoid tearing down the new
-	// connection. Guarded by mu.
+	// epoch is bumped on every attach and explicit detachment. It identifies the
+	// current connection generation so a stale runSession goroutine (from a
+	// superseded connection) can detect that the session has moved on and avoid
+	// tearing down the new connection. Guarded by mu.
 	epoch                uint64
 	ExpiryInterval       uint32
 	MaxPacketSize        uint32
@@ -304,32 +304,31 @@ type ConnectOptions struct {
 	MaxQoS byte
 }
 
-// Superseded describes a connection displaced by a takeover, so the broker can
-// drain it outside the session lock: notify the displaced MQTT 5 client with a
-// DISCONNECT (DisconnectSessionTakenOver), close the socket, and publish its Will if required.
+// Superseded describes connection-scoped state displaced by a takeover. The
+// caller owns the returned connection and Will and decides how to retire them.
 type Superseded struct {
-	ClientID    string
-	Conn        core.Connection
-	Version     byte
-	Will        *storage.WillMessage
-	SessionEnds bool
+	Conn    core.Connection
+	Version byte
+	Will    *storage.WillMessage
 }
 
 // DetachForTakeover ends this session's current network connection without
 // closing the socket or invoking the asynchronous disconnect callback. The
 // caller must retire the returned connection after releasing any broker-level
-// session lock. sessionEnds distinguishes a Clean Start replacement, where a
-// delayed Will is published immediately, from a reconnect that continues the
-// same session and cancels a delayed Will.
-func (s *Session) DetachForTakeover(sessionEnds bool) *Superseded {
+// session lock. Detaching advances the epoch immediately, fencing packet
+// processing and callbacks from the detached connection.
+func (s *Session) DetachForTakeover() *Superseded {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	superseded := &Superseded{
-		ClientID:    s.ID,
-		Version:     s.Version,
-		SessionEnds: sessionEnds,
+		Version: s.Version,
 	}
+
+	// Detachment is a generation transition even when the connection already
+	// disappeared. A runSession or disconnect callback holding the previous
+	// epoch must become stale before broker-owned cleanup starts.
+	s.epoch++
 
 	// A session installed in the broker map but not yet attached to a network
 	// connection has not completed CONNECT, so its proposed Will is not active.
@@ -396,7 +395,18 @@ func (s *Session) attach(c core.Connection, opts ConnectOptions, applyOpts bool)
 
 	var superseded *Superseded
 	if s.conn != nil {
-		superseded = &Superseded{ClientID: s.ID, Conn: s.conn, Version: s.Version, Will: s.Will}
+		superseded = &Superseded{Conn: s.conn, Version: s.Version, Will: s.Will}
+		if applyOpts {
+			// The Will belongs to the generation being replaced. Transfer it
+			// before applying the new connection's options.
+			s.Will = nil
+		}
+	} else if s.state == StateDisconnected && s.Will != nil {
+		// A disconnect callback may still be queued. Transfer its generation's
+		// outstanding Will before installing the replacement so that callback
+		// cannot consume or overwrite the replacement Will.
+		superseded = &Superseded{Version: s.Version, Will: s.Will}
+		s.Will = nil
 	}
 
 	if applyOpts {
@@ -724,8 +734,9 @@ func (s *Session) disconnectLocked(graceful bool, reasonCode byte) error {
 	s.msgHandler.ClearAliases()
 
 	callback := s.onDisconnect
+	epoch := s.epoch
 	if callback != nil {
-		go callback(s, graceful)
+		go callback(s, graceful, epoch)
 	}
 
 	return nil
@@ -894,8 +905,22 @@ func (s *Session) Touch() {
 	}
 }
 
-// SetOnDisconnect sets the disconnect callback.
+// SetOnDisconnect sets a disconnect callback without exposing the connection
+// epoch. It is retained for callers that do not need generation-aware cleanup.
 func (s *Session) SetOnDisconnect(fn func(*Session, bool)) {
+	if fn == nil {
+		s.SetOnDisconnectWithEpoch(nil)
+		return
+	}
+	s.SetOnDisconnectWithEpoch(func(s *Session, graceful bool, _ uint64) {
+		fn(s, graceful)
+	})
+}
+
+// SetOnDisconnectWithEpoch sets a disconnect callback that receives the epoch
+// of the physical connection that disconnected. Broker cleanup uses the epoch
+// together with session identity to fence callbacks delayed past a reconnect.
+func (s *Session) SetOnDisconnectWithEpoch(fn func(*Session, bool, uint64)) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.onDisconnect = fn

--- a/mqtt/session/takeover_test.go
+++ b/mqtt/session/takeover_test.go
@@ -135,6 +135,45 @@ func TestConnect_OnDisconnectCallbackScopedToEpoch(t *testing.T) {
 	require.False(t, newConn.closed.Load())
 }
 
+func TestDetachForTakeoverAdvancesEpochBeforeClosingConnection(t *testing.T) {
+	s := newTakeoverSession(t)
+
+	callbackEpoch := make(chan uint64, 1)
+	s.SetOnDisconnectWithEpoch(func(_ *Session, _ bool, epoch uint64) {
+		callbackEpoch <- epoch
+	})
+	oldConn := &wsLikeConn{}
+	oldEpoch, err := s.Connect(oldConn)
+	require.NoError(t, err)
+
+	superseded := s.DetachForTakeover()
+	require.Same(t, oldConn, superseded.Conn)
+	require.Greater(t, s.Epoch(), oldEpoch, "detachment must fence the old runSession immediately")
+
+	require.NoError(t, superseded.Conn.Close())
+	require.Never(t, func() bool {
+		select {
+		case <-callbackEpoch:
+			return true
+		default:
+			return false
+		}
+	}, 50*time.Millisecond, time.Millisecond, "detached connection callback must be stale")
+}
+
+func TestDisconnectCallbackReportsDisconnectedEpoch(t *testing.T) {
+	s := newTakeoverSession(t)
+	epochCh := make(chan uint64, 1)
+	s.SetOnDisconnectWithEpoch(func(_ *Session, _ bool, epoch uint64) {
+		epochCh <- epoch
+	})
+
+	epoch, err := s.Connect(&recordingConn{})
+	require.NoError(t, err)
+	require.NoError(t, s.Disconnect(false, v5.DisconnectUnspecifiedError))
+	require.Equal(t, epoch, <-epochCh)
+}
+
 // TestConnect_WebSocketStyleSyncOnDisconnectNoDeadlock verifies that a takeover
 // of a connection whose Close() synchronously calls onDisconnect (WebSocket)
 // does not deadlock by re-entering the session lock.
@@ -192,6 +231,29 @@ func TestConnectWithOptions_AppliesNewOptionsOnReconnect(t *testing.T) {
 	require.Equal(t, uint16(8), s.ReceiveMaximum, "reconnect must adopt the new Receive Maximum")
 	require.NotNil(t, superseded)
 	require.Equal(t, byte(4), superseded.Version, "superseded carries the old version")
+}
+
+func TestConnectWithOptions_TransfersDisconnectedGenerationWill(t *testing.T) {
+	s := newTakeoverSession(t)
+	oldWill := &storage.WillMessage{Topic: "will/old", Payload: []byte("old")}
+	s.UpdateConnectionOptions(4, time.Minute, oldWill)
+
+	_, err := s.Connect(&recordingConn{})
+	require.NoError(t, err)
+	require.NoError(t, s.Disconnect(false, v5.DisconnectUnspecifiedError))
+
+	newWill := &storage.WillMessage{Topic: "will/new", Payload: []byte("new")}
+	_, superseded := s.ConnectWithOptions(&recordingConn{}, ConnectOptions{
+		Version:        5,
+		KeepAlive:      time.Minute,
+		Will:           newWill,
+		ReceiveMaximum: 16,
+	})
+
+	require.NotNil(t, superseded)
+	require.Nil(t, superseded.Conn, "the old physical connection already disconnected")
+	require.Same(t, oldWill, superseded.Will)
+	require.Same(t, newWill, s.GetWill())
 }
 
 // TestSetExpiryInterval_ZeroReplacesPositive guards finding #3: a reconnect

--- a/storage/badger/will.go
+++ b/storage/badger/will.go
@@ -137,3 +137,35 @@ func (w *WillStore) GetPending(ctx context.Context, before time.Time) ([]*storag
 
 	return pending, err
 }
+
+// GetPendingForClient returns the client's current Will only when its delay has
+// elapsed by before. It is an optional fast path used by the MQTT broker to
+// revalidate a pending snapshot without scanning every stored Will.
+func (w *WillStore) GetPendingForClient(ctx context.Context, clientID string, before time.Time) (*storage.WillMessage, error) {
+	key := []byte("will:" + clientID)
+	var entry willEntry
+
+	err := w.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get(key)
+		if err != nil {
+			if errors.Is(err, badger.ErrKeyNotFound) {
+				return storage.ErrNotFound
+			}
+			return err
+		}
+		return item.Value(func(val []byte) error {
+			return json.Unmarshal(val, &entry)
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+	if entry.DisconnectedAt.IsZero() {
+		return nil, storage.ErrNotFound
+	}
+	triggerTime := entry.DisconnectedAt.Add(time.Duration(entry.Will.Delay) * time.Second)
+	if triggerTime.After(before) {
+		return nil, storage.ErrNotFound
+	}
+	return entry.Will, nil
+}

--- a/storage/memory/will.go
+++ b/storage/memory/will.go
@@ -99,6 +99,24 @@ func (s *WillStore) GetPending(ctx context.Context, before time.Time) ([]*storag
 	return result, nil
 }
 
+// GetPendingForClient returns the client's current Will only when its delay has
+// elapsed by before. It is an optional fast path used by the MQTT broker to
+// revalidate a pending snapshot without scanning every stored Will.
+func (s *WillStore) GetPendingForClient(ctx context.Context, clientID string, before time.Time) (*storage.WillMessage, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entry, ok := s.data[clientID]
+	if !ok || entry.disconnedAt.IsZero() {
+		return nil, storage.ErrNotFound
+	}
+	triggerTime := entry.disconnedAt.Add(time.Duration(entry.will.Delay) * time.Second)
+	if triggerTime.After(before) {
+		return nil, storage.ErrNotFound
+	}
+	return copyWill(entry.will), nil
+}
+
 // copyWill creates a deep copy of a will message.
 func copyWill(will *storage.WillMessage) *storage.WillMessage {
 	if will == nil {


### PR DESCRIPTION
<!--
Copyright (c) Abstract Machines
SPDX-License-Identifier: Apache-2.0
-->
# What type of PR is this?
This is a bugfix and enhancement,

## What does this do?
This fixes session takeover lifecycle.

 This fixes session replacement when a client reconnects with the same Client ID.

  - Detaches the displaced connection while holding the client-ID lock.
  - Sends MQTT 5 DISCONNECT with reason 0x8E (Session Taken Over).
  - Closes and drains the old connection after releasing the lock.
  - Publishes the displaced connection’s Will exactly once.
  - Publishes delayed Wills immediately when Clean Start ends the old session.
  - Cancels delayed Wills when the same persistent session continues.
  - Keeps the old and incoming connection Wills separate during cross-node takeover.
  - Prevents stale disconnect callbacks from deleting or persisting replacement
    state.

  - Handles already-persisted delayed Wills when Clean Start discards a disconnected
    session.

  - Runs webhook and event-hook notifications outside the client-ID shard lock.

  Regression tests cover MQTT 3, MQTT 5, local replacement, cross-node takeover,
  both callback lock orderings, delayed Wills, and the 0x8E reason code.

## Which issue(s) does this PR fix/relate to?
<!--
- Related Issue #
- Resolves #
-->
There is no such issue.
## Have you included tests for your changes?
Yes.

## Did you document any new/modified features?
N/A

### Notes
N/A
